### PR TITLE
fix: risk prediction data is always up to date

### DIFF
--- a/packages/FreiFahren_BE-NLP/main.py
+++ b/packages/FreiFahren_BE-NLP/main.py
@@ -102,11 +102,8 @@ if __name__ == '__main__':
     @bot.message_handler(func=lambda message: message)
     def get_info(message):
         timestamp = datetime.fromtimestamp(message.date, utc)
-        # timestamps are rounded to the nearest minute to avoid saving personal data
-        if timestamp.second or timestamp.microsecond:
-            timestamp = timestamp.replace(second=0, microsecond=0) + timedelta(minutes=1)
-        else:
-            timestamp = timestamp.replace(second=0, microsecond=0)
+        # Round the timestamp to the last minute
+        timestamp = timestamp.replace(second=0, microsecond=0)
             
         process_new_message(timestamp, message)
 

--- a/packages/FreiFahren_BE-NLP/main.py
+++ b/packages/FreiFahren_BE-NLP/main.py
@@ -1,7 +1,7 @@
 import os
 import telebot
 import pytz
-from datetime import datetime, timedelta
+from datetime import datetime
 from dotenv import load_dotenv
 from verify_info import verify_direction, verify_line
 from process_message import (

--- a/packages/backend/api/getAllStationsAndLines.go
+++ b/packages/backend/api/getAllStationsAndLines.go
@@ -9,15 +9,21 @@ import (
 )
 
 // @Summary Retrieves stations and lines information
+//
 // @Description This endpoint returns a comprehensive list of all train stations and lines.
 // @Description Optionally, it can return only a list of lines or stations based on the provided query parameters.
+//
 // @Tags data
+//
 // @Accept  json
 // @Produce  json
+//
 // @Param   lines      query     string  false  "Set to 'true' to retrieve only the list of lines."
 // @Param   stations   query     string  false  "Set to 'true' to retrieve only the list of stations."
+//
 // @Success 200 {object} utils.AllStationsAndLinesList
 // @Failure 500 {string} string "Internal Server Error: Unable to process the request."
+//
 // @Router /data/list [get]
 func GetAllStationsAndLines(c echo.Context) error {
 	var StationsAndLinesList = data.GetStationsAndLinesList()

--- a/packages/backend/api/getId.go
+++ b/packages/backend/api/getId.go
@@ -24,15 +24,21 @@ func FindStationId(name string, stationsMap map[string]utils.StationListEntry) (
 }
 
 // @Summary      Retrieve Station ID by Name
+//
 // @Description  Fetches the unique identifier for a station by its name from the StationsMap. This endpoint performs a case-insensitive search and ignores spaces in the station name.
 // @Description  The Ids have format Line prefix that has the format "SU" followed by an abbreviation of the station name. For example "SU-A" for the station "Alexanderplatz".
+//
 // @Tags         data
+//
 // @Accept       json
 // @Produce      json
+//
 // @Param		 name query string true "Station name", case and whitespace insensitive
+//
 // @Success      200 {string} string "The station id"
 // @Failure      404 {string} string "Station not found"
-// @Router       /data//id [get]
+//
+// @Router       /data/id [get]
 func GetStationId(c echo.Context) error {
 	name := c.QueryParam("name")
 	fmt.Printf("receiving name: %s\n", name)

--- a/packages/backend/api/getRecentTicketInspectorInfo.go
+++ b/packages/backend/api/getRecentTicketInspectorInfo.go
@@ -14,17 +14,22 @@ import (
 )
 
 // @Summary Retrieve information about recent ticket inspector reports
+//
 // @Description Fetches the most recent ticket inspector reports from the database and returns them as a JSON array.
 // @Description If there are not enough recent reports, the endpoint will fetch additional historic reports to meet the required amount.
 // @Description The required amount is determined by the current time of the day and the day of the week, ensuring the most relevant and timely information is provided to the user.
 //
 // @Tags basics
+//
 // @Accept json
 // @Produce json
+//
 // @Param If-Modified-Since header string false "Standard HTTP header used to make conditional requests; the response will include the requested data only if it has changed since this date and time."
+//
 // @Success 200 {object} []utils.TicketInspectorResponse "A JSON array of ticket inspector information, each entry includes details such as timestamp, station, direction, line, and historic flag."
 // @Failure 304 {object} nil "Returns an empty response indicating that the requested data has not changed since the time provided in the 'If-Modified-Since' header."
 // @Failure 500 {string} string "Internal Server Error: An error occurred while processing the request."
+//
 // @Router /basics/recent [get]
 func GetRecentTicketInspectorInfo(c echo.Context) error {
 	databaseLastModified, err := database.GetLatestUpdateTime()

--- a/packages/backend/api/getSegmentColors.go
+++ b/packages/backend/api/getSegmentColors.go
@@ -16,16 +16,21 @@ import (
 )
 
 // @Summary Get risk colors for segments
+//
 // @Description Fetches the latest risk assessments for transit segments, returned as color codes representing the risk level. You can find out more about the risk level calculation in the documentation.
 // @Description The response includes the last modified timestamp of the risk model data to support conditional GET requests.
 //
 // @Tags Risk Prediction
+//
 // @Accept json
 // @Produce json
+//
 // @Param If-Modified-Since header string false "Standard HTTP header used to make conditional requests; the response will include the risk colors only if they have changed since this date and time."
+//
 // @Success 200 {object} utils.RiskModelResponse "Successfully retrieved the color-coded risk levels for each segment."
 // @Success 304 {none} nil "No changes: The data has not been modified since the last request date provided in the 'If-Modified-Since' header."
 // @Failure 500 "Internal Server Error: Error during the processing of the request."
+//
 // @Router /risk-prediction/getSegmentColors [get]
 func GetSegmentColors(c echo.Context) error {
 	segmentsFiles, err := getSegmentFiles()

--- a/packages/backend/api/getStationDistance.go
+++ b/packages/backend/api/getStationDistance.go
@@ -25,18 +25,22 @@ var stationIDs []string
 var linesList map[string][]string
 
 // @Summary Calculate shortest distance to a station
-// @Description Returns the shortest number of stations between an inspector's station and a given user's latitude and longitude coordinates.
 //
+// @Description Returns the shortest number of stations between an inspector's station and a given user's latitude and longitude coordinates.
 // @Description The distance calculation employs Dijkstra's algorithm to determine the minimal stops required to reach the nearest station from the given coordinates.
 //
 // @Tags transit
+//
 // @Accept  json
 // @Produce  json
+//
 // @Param   inspectorStationId   query   string  true   "The station ID of the inspector's current location."
 // @Param   userLat              query   string  true   "The latitude of the user's location."
 // @Param   userLon              query   string  true   "The longitude of the user's location."
+//
 // @Success 200 {int} int "The shortest distance in terms of the number of station stops between the inspector's station and the user's location."
 // @Failure 500 "An error occurred in processing the request."
+//
 // @Router /transit/distance [get]
 func GetStationDistance(c echo.Context) error {
 	var err error

--- a/packages/backend/api/getStationName.go
+++ b/packages/backend/api/getStationName.go
@@ -22,14 +22,20 @@ func IdToStationName(id string) (string, error) {
 }
 
 // @Summary      Retrieve Name by Station ID
+//
 // @Description  Fetches the name of a station by its unique identifier from the StationsMap.
 // @Description  The Ids have format Line prefix that has the format "SU" followed by an abbreviation of the station name. For example "SU-A" for the station "Alexanderplatz".
+//
 // @Tags         data
+//
 // @Accept       json
 // @Produce      json
+//
 // @Param		 id query string true "Station Id"
+//
 // @Success      200 {string} string "The station id"
 // @Failure      404 {string} string "Error getting station name"
+//
 // @Router       /station [get]
 func GetStationName(c echo.Context) error {
 	id := c.QueryParam("id")

--- a/packages/backend/api/getStats.go
+++ b/packages/backend/api/getStats.go
@@ -10,12 +10,17 @@ import (
 )
 
 // @Summary Get statistics on recent submissions
+//
 // @Description Fetches the total number of submissions recorded in the database over the past 24 hours.
+//
 // @Tags Statistics
+//
 // @Accept json
 // @Produce json
+//
 // @Success 200 {integer} integer "Number of submissions in the last 24 hours"
 // @Failure 500 "Internal Server Error: Unable to fetch statistics from the database."
+//
 // @Router /statistics/stats [get]
 func GetStats(c echo.Context) error {
 	stats, err := database.GetNumberOfSubmissionsInLast24Hours()

--- a/packages/backend/api/postInspector.go
+++ b/packages/backend/api/postInspector.go
@@ -65,16 +65,16 @@ func PostInspector(c echo.Context) error {
 func processRequestData(req structs.InspectorRequest) (*structs.ResponseData, *structs.InsertPointers, error) {
 	var stations = data.GetStationsList()
 
+	// Using pointers to allow for nil values
 	response := &structs.ResponseData{}
 	pointers := &structs.InsertPointers{}
 
-	// Assign pointers for values to be potentially inserted as NULL
-
-	if req.Timestamp != (time.Time{}) {
+	// Check if the timestamp is provided, otherwise use the current time
+	if req.Timestamp != (time.Time{}) { // time.time{} is the zero value for time.Time
 		pointers.TimestampPtr = &req.Timestamp
 		response.Timestamp = req.Timestamp
 	} else {
-		timestamp := time.Now().UTC().Truncate(time.Minute).Add(time.Minute)
+		timestamp := time.Now().UTC().Truncate(time.Minute)
 		pointers.TimestampPtr = &timestamp
 		response.Timestamp = *pointers.TimestampPtr
 	}

--- a/packages/backend/api/postInspector.go
+++ b/packages/backend/api/postInspector.go
@@ -16,18 +16,22 @@ import (
 )
 
 // @Summary Submit ticket inspector data
+//
 // @Description Accepts a JSON payload with details about a ticket inspector's current location.
 // @Description This endpoint validates the provided data, processes necessary computations for linking stations and lines,
 // @Description inserts the data into the database, and triggers an update to the risk model used in operational analysis.
 //
 // @Tags basics
+//
 // @Accept json
 // @Produce json
 //
 // @Param inspectorData body structs.InspectorRequest true "Data about the inspector's location and activity"
+//
 // @Success 200 {object} structs.ResponseData "Successfully processed and inserted the inspector data with computed linkages and risk model updates."
 // @Failure 400 "Bad Request: Missing or incorrect parameters provided."
 // @Failure 500 "Internal Server Error: Error during data processing or database insertion."
+//
 // @Router /basics/newInspector [post]
 func PostInspector(c echo.Context) error {
 	var req structs.InspectorRequest

--- a/packages/backend/docs/docs.go
+++ b/packages/backend/docs/docs.go
@@ -98,7 +98,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/data//id": {
+        "/data/id": {
             "get": {
                 "description": "Fetches the unique identifier for a station by its name from the StationsMap. This endpoint performs a case-insensitive search and ignores spaces in the station name.\nThe Ids have format Line prefix that has the format \"SU\" followed by an abbreviation of the station name. For example \"SU-A\" for the station \"Alexanderplatz\".",
                 "consumes": [

--- a/packages/backend/docs/swagger.json
+++ b/packages/backend/docs/swagger.json
@@ -92,7 +92,7 @@
                 }
             }
         },
-        "/data//id": {
+        "/data/id": {
             "get": {
                 "description": "Fetches the unique identifier for a station by its name from the StationsMap. This endpoint performs a case-insensitive search and ignores spaces in the station name.\nThe Ids have format Line prefix that has the format \"SU\" followed by an abbreviation of the station name. For example \"SU-A\" for the station \"Alexanderplatz\".",
                 "consumes": [

--- a/packages/backend/docs/swagger.yaml
+++ b/packages/backend/docs/swagger.yaml
@@ -183,7 +183,7 @@ paths:
       summary: Retrieve information about recent ticket inspector reports
       tags:
       - basics
-  /data//id:
+  /data/id:
     get:
       consumes:
       - application/json

--- a/packages/frontend/src/components/Map/MapLayers/LineLayer/RiskLineLayer.tsx
+++ b/packages/frontend/src/components/Map/MapLayers/LineLayer/RiskLineLayer.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useState } from 'react';
 import { Source, Layer } from 'react-map-gl/maplibre';
 
-import { getRecentDataWithIfModifiedSince } from '../../../../utils/dbUtils';
 import { RiskData } from 'src/utils/types';
 
 interface RiskLineLayerProps {
@@ -25,31 +24,8 @@ const RiskLineLayer: React.FC<RiskLineLayerProps> = ({ linesGeoJSON, textColor, 
         };
     };
 
-    const [updatedGeoJSON, setUpdatedGeoJSON] = useState<GeoJSON.FeatureCollection<GeoJSON.LineString>>(
-        initializeWithColor(linesGeoJSON, preloadedRiskData?.segment_colors)
-    );
-
-    const lastUpdateTimestamp = useRef<string | null>(null);
-
-    useEffect(() => {
-        const fetchSegmentHighlightColors = async () => {
-            try {
-                const response = await getRecentDataWithIfModifiedSince(`${process.env.REACT_APP_API_URL}/risk-prediction/getSegmentColors`, lastUpdateTimestamp.current);
-                if (response) {
-                    const { last_modified, segment_colors } = response;
-                    lastUpdateTimestamp.current = last_modified;
-
-                    const newGeoJSON = initializeWithColor(linesGeoJSON, segment_colors);
-                    setUpdatedGeoJSON(newGeoJSON);
-                }
-            } catch (error) {
-                console.error('Error fetching segment colors:', error);
-            }
-        };
-
-        const interval = setInterval(fetchSegmentHighlightColors, 5*1000);
-        return () => clearInterval(interval);
-    }, [linesGeoJSON]);
+    const updatedGeoJSON = initializeWithColor(linesGeoJSON, preloadedRiskData?.segment_colors);
+    useState<GeoJSON.FeatureCollection<GeoJSON.LineString>>(updatedGeoJSON);
 
     return (
         <>

--- a/packages/frontend/src/components/Map/MapLayers/LineLayer/RiskLineLayer.tsx
+++ b/packages/frontend/src/components/Map/MapLayers/LineLayer/RiskLineLayer.tsx
@@ -48,8 +48,7 @@ const RiskLineLayer: React.FC<RiskLineLayerProps> = ({ linesGeoJSON, textColor, 
     useEffect(() => {
         const interval = setInterval(() => {
             refreshRiskData();
-            console.log('Called every 5 seconds');
-        }, 5 * 1000);
+        }, 30 * 1000);
         return () => clearInterval(interval);
     }, [refreshRiskData]);
 

--- a/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
+++ b/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
@@ -5,6 +5,7 @@ import { OpacityMarker } from './Classes/OpacityMarker/OpacityMarker';
 import MarkerModal from '../../Modals/MarkerModal/MarkerModal';
 import { CloseButton } from '../../Buttons/CloseButton/CloseButton';
 import { useModalAnimation } from '../../../utils/uiUtils';
+import { useRiskData } from '../../../contexts/RiskDataContext';
 
 export interface MarkersProps {
 	formSubmitted: boolean;
@@ -39,6 +40,7 @@ const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted, isFirstOpen, u
 	const [ticketInspectorList, setTicketInspectorList] = useState<MarkerData[]>([]);
 	const lastReceivedInspectorTimestamp = useRef<string | null>(null);
 	const [selectedMarker, setSelectedMarker] = useState<MarkerData | null>(null);
+	const riskData = useRiskData();
 
 	useEffect(() => {
 		const fetchData = async () => {
@@ -51,6 +53,7 @@ const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted, isFirstOpen, u
 
 					if (filteredNewInspectors.length > 0) {
 						lastReceivedInspectorTimestamp.current = newTicketInspectorList[0].timestamp;
+						riskData.refreshRiskData(); // refresh risk data when new inspectors are fetched
 						return [...currentList, ...filteredNewInspectors];
 					}
 
@@ -63,7 +66,7 @@ const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted, isFirstOpen, u
 		const interval = setInterval(fetchData, 5*1000);
 
 		return () => clearInterval(interval);
-	}, [formSubmitted]);
+	}, [formSubmitted, riskData]);
 
 	const {
 		isOpen: isMarkerModalOpen,

--- a/packages/frontend/src/contexts/RiskDataContext.tsx
+++ b/packages/frontend/src/contexts/RiskDataContext.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useState, useContext } from 'react';
+import { getRecentDataWithIfModifiedSince } from '../utils/dbUtils';
+import { RiskData } from 'src/utils/types';
+
+const RiskDataContext = createContext<{ segmentRiskData: RiskData | null, refreshRiskData: () => void }>({ segmentRiskData: null, refreshRiskData: () => {} });
+
+export const useRiskData = () => useContext(RiskDataContext);
+
+export const RiskDataProvider = ({ children }: { children: React.ReactNode }) => {
+    const [segmentRiskData, setSegmentRiskData] = useState<RiskData | null>(null);
+
+    const refreshRiskData = async () => {
+        const results: RiskData = await getRecentDataWithIfModifiedSince(`${process.env.REACT_APP_API_URL}/risk-prediction/getSegmentColors`, null);
+        setSegmentRiskData(results);
+        console.log('Risk data refreshed');
+    };
+
+    return (
+        <RiskDataContext.Provider value={{ segmentRiskData, refreshRiskData }}>
+            {children}
+        </RiskDataContext.Provider>
+    );
+};

--- a/packages/frontend/src/contexts/RiskDataContext.tsx
+++ b/packages/frontend/src/contexts/RiskDataContext.tsx
@@ -1,22 +1,33 @@
-import React, { createContext, useState, useContext } from 'react';
+import React, { createContext, useState, useContext, useCallback } from 'react';
 import { getRecentDataWithIfModifiedSince } from '../utils/dbUtils';
 import { RiskData } from 'src/utils/types';
 
-const RiskDataContext = createContext<{ segmentRiskData: RiskData | null, refreshRiskData: () => void }>({ segmentRiskData: null, refreshRiskData: () => {} });
+const RiskDataContext = createContext({
+    segmentRiskData: null as RiskData | null,
+    refreshRiskData: async () => {},
+    lastModified: null as string | null
+});
 
 export const useRiskData = () => useContext(RiskDataContext);
 
 export const RiskDataProvider = ({ children }: { children: React.ReactNode }) => {
     const [segmentRiskData, setSegmentRiskData] = useState<RiskData | null>(null);
+    const [lastModified, setLastModified] = useState<string | null>(null);
 
-    const refreshRiskData = async () => {
-        const results: RiskData = await getRecentDataWithIfModifiedSince(`${process.env.REACT_APP_API_URL}/risk-prediction/getSegmentColors`, null);
-        setSegmentRiskData(results);
-        console.log('Risk data refreshed');
-    };
+    const refreshRiskData = useCallback(async () => {
+        const results: RiskData = await getRecentDataWithIfModifiedSince(
+            `${process.env.REACT_APP_API_URL}/risk-prediction/getSegmentColors`,
+            lastModified
+        );
+        console.log('Risk data fetched', results);
+        if (results) {
+            setSegmentRiskData(results);
+            setLastModified(results.last_modified);
+        }
+    }, [lastModified]);
 
     return (
-        <RiskDataContext.Provider value={{ segmentRiskData, refreshRiskData }}>
+        <RiskDataContext.Provider value={{ segmentRiskData, refreshRiskData, lastModified }}>
             {children}
         </RiskDataContext.Provider>
     );

--- a/packages/frontend/src/contexts/RiskDataContext.tsx
+++ b/packages/frontend/src/contexts/RiskDataContext.tsx
@@ -19,7 +19,6 @@ export const RiskDataProvider = ({ children }: { children: React.ReactNode }) =>
             `${process.env.REACT_APP_API_URL}/risk-prediction/getSegmentColors`,
             lastModified
         );
-        console.log('Risk data fetched', results);
         if (results) {
             setSegmentRiskData(results);
             setLastModified(results.last_modified);

--- a/packages/frontend/src/contexts/RiskDataContext.tsx
+++ b/packages/frontend/src/contexts/RiskDataContext.tsx
@@ -2,9 +2,13 @@ import React, { createContext, useState, useContext, useCallback } from 'react';
 import { getRecentDataWithIfModifiedSince } from '../utils/dbUtils';
 import { RiskData } from 'src/utils/types';
 
+const defaultRefreshRiskData = async (): Promise<void> => {
+    throw new Error('refreshRiskData is not implemented');
+};
+
 const RiskDataContext = createContext({
     segmentRiskData: null as RiskData | null,
-    refreshRiskData: async () => {},
+    refreshRiskData: defaultRefreshRiskData,
     lastModified: null as string | null
 });
 
@@ -15,13 +19,17 @@ export const RiskDataProvider = ({ children }: { children: React.ReactNode }) =>
     const [lastModified, setLastModified] = useState<string | null>(null);
 
     const refreshRiskData = useCallback(async () => {
-        const results: RiskData = await getRecentDataWithIfModifiedSince(
-            `${process.env.REACT_APP_API_URL}/risk-prediction/getSegmentColors`,
-            lastModified
-        );
-        if (results) {
-            setSegmentRiskData(results);
-            setLastModified(results.last_modified);
+        try {
+            const results = await getRecentDataWithIfModifiedSince(
+                `${process.env.REACT_APP_API_URL}/risk-prediction/getSegmentColors`,
+                lastModified
+            );
+            if (results) {
+                setSegmentRiskData(results);
+                setLastModified(results.last_modified);
+            }
+        } catch (error) {
+            console.error('Failed to fetch risk data:', error);
         }
     }, [lastModified]);
 

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -13,6 +13,7 @@ import { CloseButton } from '../../components/Buttons/CloseButton/CloseButton';
 import { highlightElement, useModalAnimation, currentColorTheme, setColorThemeInLocalStorage } from '../../utils/uiUtils';
 import Backdrop from '../../../src/components/Miscellaneous/Backdrop/Backdrop';
 import { getNumberOfReportsInLast24Hours } from '../../utils/dbUtils';
+import { RiskDataProvider } from '../../contexts/RiskDataContext';
 import './App.css';
 
 type AppUIState = {
@@ -155,15 +156,17 @@ function App() {
       )}
 
       <div id='portal-root'></div>
-      <Map
-        isFirstOpen={appUIState.isFirstOpen}
-        formSubmitted={appUIState.formSubmitted}
-        userPosition={userPosition}
-        setUserPosition={setUserPosition}
-        currentColorTheme={appUIState.currentColorTheme}
-        openAskForLocation={openAskForLocation}
-        isRiskLayerOpen={appUIState.isRiskLayerOpen}
-      />
+      <RiskDataProvider>
+        <Map
+          isFirstOpen={appUIState.isFirstOpen}
+          formSubmitted={appUIState.formSubmitted}
+          userPosition={userPosition}
+          setUserPosition={setUserPosition}
+          currentColorTheme={appUIState.currentColorTheme}
+          openAskForLocation={openAskForLocation}
+          isRiskLayerOpen={appUIState.isRiskLayerOpen}
+        />
+      </RiskDataProvider>
       <LayerSwitcher
         changeLayer={changeLayer}
         isRiskLayerOpen={appUIState.isRiskLayerOpen}


### PR DESCRIPTION
## Describe the issue:
1. The preloaded risk data was not refreshed when a new inspector was added causing a shift after the newest risk data was requested
2. the risk data was always one minute behind the real time

## Explain how you solved the issue:
1. I used React Context to create a global risk data state as it is being updated in multiple places. The context is updated when we are loading the app for the first time, when a new inspector is added, every 30 seconds that the risk line layer is loaded
2. For some reason one minute was added to the timestamps of the bot and in the backend when reporting a new station this caused the database data to be in the future and the risk model which is getting the current data, always had to wait for a minute until it used to data from json.

## Additional notes or considerations: