### PR TITLE
Johan/fre 222 avoid instantly asking for users location

### DIFF
--- a/packages/frontend/src/utils/mapUtils.tsx
+++ b/packages/frontend/src/utils/mapUtils.tsx
@@ -55,7 +55,12 @@ export const watchPosition = async (
         (error) => {
             console.error('Error obtaining position:', error.message);
             onPositionChanged(null);
-            openAskForLocation();
+
+            // if after a couple of seconds the user hasn't given permission, ask for it
+            // this way we can be sure it is not being caused by a short timeout
+            setTimeout(() => {
+                openAskForLocation();
+            }, 5 * 1000);
         },
         options
     );

--- a/packages/frontend/src/utils/mapUtils.tsx
+++ b/packages/frontend/src/utils/mapUtils.tsx
@@ -28,7 +28,12 @@ function deg2rad(deg: number) {
  * Subscribes to user's geolocation changes and executes callback functions based on the result.
  * @param {Function} onPositionChanged Callback that handles position data.
  * @param {Function} openAskForLocation Callback that handles failures in obtaining geolocation.
- * @param {Object} options Configuration options for geolocation.
+ * @param {Object} options Configuration options for geolocation. Default values are:
+ * {
+ *    enableHighAccuracy: true,
+ *    timeout: 15 seconds,
+ *    maximumAge: 15 seconds
+ * }
  * @returns {Function} Unsubscribe function to stop watching position.
  */
 export const watchPosition = async (


### PR DESCRIPTION
## Describe the issue:
- When I was in subway it often happend that I was asked for my location even when I have shared it, due to a small outage in the network.
- I have noticed that users who dont share their location always click the modal down because it is being opened instantly which does not give them time to first process the new info on the map. 

## Explain how you solved the issue:
I think this will increase the number of people submitting their location using the form as we avoid overwhelming the user with an instant request.

## Additional notes or considerations: