### PR TITLE
Johan/fre 223 replace old data when getting a new report

### DIFF
--- a/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
+++ b/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
@@ -66,7 +66,7 @@ const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted, isFirstOpen, u
 
 					// Set the latest timestamp from the fetched data
 					lastReceivedInspectorTimestamp.current = newTicketInspectorList[0].timestamp;
-					riskData.refreshRiskData(); // Refresh risk data when new inspectors are fetched
+					riskData.refreshRiskData();
 
 					// Convert the map back to an array for the state
 					return Array.from(updatedList.values());


### PR DESCRIPTION
## Describe the issue:
Issue was described by @jfsalzmann in the chat with a person reporting Potsdamer Platz

## Explain how you solved the issue:
Compare the timestamps of the inspectors when filtering and only let the newest one pass.

## Additional notes or considerations: