### PR TITLE
refactor: compare timestamps and isHistoric flag when updating inspectors

### DIFF
--- a/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
+++ b/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
@@ -54,8 +54,8 @@ const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted, isFirstOpen, u
 					newTicketInspectorList.forEach((newInspector: MarkerData) => {
 						const existingInspector = updatedList.get(newInspector.station.id);
 						if (existingInspector) {
-							// Compare timestamps to decide if we need to update
-							if (new Date(newInspector.timestamp) > new Date(existingInspector.timestamp)) {
+							// Compare timestamps and wether it is historic to decide if we need to update
+							if (new Date(newInspector.timestamp) > new Date(existingInspector.timestamp) && newInspector.isHistoric === false) {
 								updatedList.set(newInspector.station.id, newInspector);
 							}
 						} else {

--- a/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
+++ b/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
@@ -55,7 +55,7 @@ const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted, isFirstOpen, u
 						const existingInspector = updatedList.get(newInspector.station.id);
 						if (existingInspector) {
 							// Compare timestamps and wether it is historic to decide if we need to update
-							if (new Date(newInspector.timestamp) > new Date(existingInspector.timestamp) && newInspector.isHistoric === false) {
+							if (new Date(newInspector.timestamp) >= new Date(existingInspector.timestamp) && newInspector.isHistoric === false) {
 								updatedList.set(newInspector.station.id, newInspector);
 							}
 						} else {


### PR DESCRIPTION
## Describe the issue:
The inspectors timestamp is being set to the last non historic timestamp it can find in the last hour. This caused an effect where when there are only historic stations and the first user to report a station is reporting it on a station that is already a historic station the timestamps would be the same. Thus it would not pass the filter.

## Explain how you solved the issue:
In order to be updated when there are two of the same stations the updated is selected if it has a newer timestamp or is a non historic station.

## Additional notes or considerations: