### PR TITLE
refactor: pulse animation should only be applied in the first 30 min

### DIFF
--- a/packages/frontend/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.css
+++ b/packages/frontend/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.css
@@ -12,6 +12,9 @@
   display: block;
   border-radius: 50%;
   background-color: var(--color-red);
+}
+
+.pulse {
   animation:pulse 3500ms infinite;
 }
 

--- a/packages/frontend/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
+++ b/packages/frontend/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
@@ -26,6 +26,8 @@ export const OpacityMarker: React.FC<OpacityMarkerProps> = ({ markerData, index,
 
     const markerRef = useRef<maplibregl.Marker>(null);
 
+    const [isWithin30Mins, setIsWithin30Mins] = useState(false);
+
     useEffect(() => {
         let intervalId: NodeJS.Timeout;
         if (!isFirstOpen) {
@@ -41,6 +43,9 @@ export const OpacityMarker: React.FC<OpacityMarkerProps> = ({ markerData, index,
                         newOpacity = 0.20;
                     }
                     setOpacity(newOpacity);
+
+                    // indicate that the marker should not pulse anymore
+                    setIsWithin30Mins(elapsedTime <= 30 * 60 * 1000);
 
                     if (elapsedTime >= timeToFade) {
                         setOpacity(0);
@@ -74,7 +79,7 @@ export const OpacityMarker: React.FC<OpacityMarkerProps> = ({ markerData, index,
             style={{ opacity: opacity.toString()}}
             onClick={()=> onMarkerClick(markerData)}
         >
-            <span className='live' />
+            <span className={`live ${isWithin30Mins ? 'pulse' : ''}`} />
         </Marker>
     );
 };


### PR DESCRIPTION
## Describe the issue:
The live animation should indicate the a marker is live meaning that is is very fresh, but it was being applied to all markers. It also slowed down performance.

## Explain how you solved the issue:
I refactored the .live class to extract the pusling animation into a seperate class. This class is only getting applied to the opacity marker if it is newer than 30 minutes.

## Additional notes or considerations: