### PR TITLE
Fix header date format

### DIFF
--- a/packages/backend/utils/cachingUtils.go
+++ b/packages/backend/utils/cachingUtils.go
@@ -26,8 +26,8 @@ func CheckIfModifiedSince(ifModifiedSince string, lastModified time.Time) (bool,
 		return true, nil
 	}
 
-	// Use time.RFC3339 to parse ISO 8601 format
-	requestedModificationTime, err := time.Parse(time.RFC3339, ifModifiedSince)
+	// Use time.RFC1123 to parse HTTP date format
+	requestedModificationTime, err := time.Parse(time.RFC1123, ifModifiedSince)
 	if err != nil {
 		logger.Log.Error().Msg("Error parsing If-Modified-Since header")
 		return true, err

--- a/packages/backend/utils_test/CheckIfModifiedSince_test.go
+++ b/packages/backend/utils_test/CheckIfModifiedSince_test.go
@@ -26,14 +26,14 @@ func TestCheckIfModifiedSince(t *testing.T) {
 		},
 		{
 			name:             "Correct header, not modified",
-			ifModifiedSince:  "2024-01-01T12:00:00Z",
+			ifModifiedSince:  "Mon, 01 Jan 2024 12:00:00 GMT",
 			lastModified:     lastModifiedTime,
 			expectedModified: false,
 			expectError:      false,
 		},
 		{
 			name:             "Correct header, modified",
-			ifModifiedSince:  "2023-12-31T11:00:00Z",
+			ifModifiedSince:  "Sun, 31 Dec 2023 11:00:00 GMT",
 			lastModified:     lastModifiedTime,
 			expectedModified: true,
 			expectError:      false,

--- a/packages/backend/utils_test/CheckIfModifiedSince_test.go
+++ b/packages/backend/utils_test/CheckIfModifiedSince_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestCheckIfModifiedSince(t *testing.T) {
-	// Define a fixed time for "lastModified"
-	lastModifiedTime, _ := time.Parse(time.RFC3339, "2024-01-01T12:00:00Z")
+	lastModifiedTime, _ := time.Parse(time.RFC1123, "Mon, 01 Jan 2024 12:00:00 GMT")
 
 	tests := []struct {
 		name             string

--- a/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
+++ b/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
@@ -36,6 +36,8 @@ export type MarkerData = {
 	message?: string;
 };
 
+const toRFC1123 = (timestamp: string): string => new Date(timestamp).toUTCString();
+
 const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted, isFirstOpen, userPosition }) => {
 	const [ticketInspectorList, setTicketInspectorList] = useState<MarkerData[]>([]);
 	const lastReceivedInspectorTimestamp = useRef<string | null>(null);
@@ -44,7 +46,10 @@ const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted, isFirstOpen, u
 
 	useEffect(() => {
 		const fetchData = async () => {
-			const newTicketInspectorList = await getRecentDataWithIfModifiedSince(`${process.env.REACT_APP_API_URL}/basics/recent`, lastReceivedInspectorTimestamp.current) || [];
+			const newTicketInspectorList = await getRecentDataWithIfModifiedSince(
+				`${process.env.REACT_APP_API_URL}/basics/recent`,
+				lastReceivedInspectorTimestamp.current === null ? null : toRFC1123(lastReceivedInspectorTimestamp.current)
+			) || [];
 
 			if (newTicketInspectorList.length > 0) {
 				setTicketInspectorList(currentList => {


### PR DESCRIPTION
The date format we use for the `If-Modified-Since` header is non-standard. This leads to issues on android because the network stack can add it's own caching headers with the specced format, which will result in a code 500 with current parsing logic.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since