### PR TITLE
Fix header date format for risk

### DIFF
--- a/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
+++ b/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
@@ -36,11 +36,9 @@ export type MarkerData = {
 	message?: string;
 };
 
-const toRFC1123 = (timestamp: string): string => new Date(timestamp).toUTCString();
-
 const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted, isFirstOpen, userPosition }) => {
 	const [ticketInspectorList, setTicketInspectorList] = useState<MarkerData[]>([]);
-	const lastReceivedInspectorTimestamp = useRef<string | null>(null);
+	const lastReceivedInspectorTime = useRef<Date | null>(null);
 	const [selectedMarker, setSelectedMarker] = useState<MarkerData | null>(null);
 	const riskData = useRiskData();
 
@@ -48,7 +46,7 @@ const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted, isFirstOpen, u
 		const fetchData = async () => {
 			const newTicketInspectorList = await getRecentDataWithIfModifiedSince(
 				`${process.env.REACT_APP_API_URL}/basics/recent`,
-				lastReceivedInspectorTimestamp.current === null ? null : toRFC1123(lastReceivedInspectorTimestamp.current)
+				lastReceivedInspectorTime.current,
 			) || [];
 
 			if (newTicketInspectorList.length > 0) {
@@ -70,7 +68,7 @@ const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted, isFirstOpen, u
 					});
 
 					// Set the latest timestamp from the fetched data
-					lastReceivedInspectorTimestamp.current = newTicketInspectorList[0].timestamp;
+					lastReceivedInspectorTime.current = new Date(newTicketInspectorList[0].timestamp);
 					riskData.refreshRiskData();
 
 					// Convert the map back to an array for the state

--- a/packages/frontend/src/contexts/RiskDataContext.tsx
+++ b/packages/frontend/src/contexts/RiskDataContext.tsx
@@ -9,14 +9,14 @@ const defaultRefreshRiskData = async (): Promise<void> => {
 const RiskDataContext = createContext({
     segmentRiskData: null as RiskData | null,
     refreshRiskData: defaultRefreshRiskData,
-    lastModified: null as string | null
+    lastModified: null as Date | null
 });
 
 export const useRiskData = () => useContext(RiskDataContext);
 
 export const RiskDataProvider = ({ children }: { children: React.ReactNode }) => {
     const [segmentRiskData, setSegmentRiskData] = useState<RiskData | null>(null);
-    const [lastModified, setLastModified] = useState<string | null>(null);
+    const [lastModified, setLastModified] = useState<Date | null>(null);
 
     const refreshRiskData = useCallback(async () => {
         try {
@@ -26,7 +26,7 @@ export const RiskDataProvider = ({ children }: { children: React.ReactNode }) =>
             );
             if (results) {
                 setSegmentRiskData(results);
-                setLastModified(results.last_modified);
+                setLastModified(new Date(results.last_modified));
             }
         } catch (error) {
             console.error('Failed to fetch risk data:', error);

--- a/packages/frontend/src/utils/dbUtils.tsx
+++ b/packages/frontend/src/utils/dbUtils.tsx
@@ -25,12 +25,12 @@ export type LinesList = Record<string, string[]>;
  * @returns {Promise<any | null>} A promise that resolves to the fetched data if successful, or null if there is no new data or an error occurs.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function getRecentDataWithIfModifiedSince(endpointUrl: string, lastUpdateTimestamp: string | null): Promise<any | null> {
+export async function getRecentDataWithIfModifiedSince(endpointUrl: string, lastUpdate: Date | null): Promise<any | null> {
     try {
         const headers = new Headers();
         // Include the If-Modified-Since header only if lastUpdateTimestamp is available
-        if (lastUpdateTimestamp) {
-            headers.append('If-Modified-Since', lastUpdateTimestamp);
+        if (lastUpdate) {
+            headers.append('If-Modified-Since', lastUpdate.toUTCString())
         }
 
         // Make the request with optional If-Modified-Since header


### PR DESCRIPTION
Risk model header format was still the old one, so this change is needed. changed it so that we use dates for the timestamps so that the request helper can decide the format.