### PR TITLE
Johan/fre 249 fix analytics

### DIFF
--- a/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
+++ b/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
@@ -12,11 +12,17 @@ interface LayerSwitcherProps {
 const LayerSwitcher: React.FC<LayerSwitcherProps> = ({ changeLayer, isRiskLayerOpen }) => {
   const [areLayerOptionsVisible, setAreLayerOptionsVisible] = useState(false);
 
-  const closeModalAndHighlightSelectedLayer = useCallback((layer: string) => {
+  const closeModalAndHighlightSelectedLayer = useCallback(async (layer: string) => {
     changeLayer(layer);
     setAreLayerOptionsVisible(false);
 
-    if (layer === 'risk' && !isRiskLayerOpen) sendAnalyticsEvent('Risk Layer Opened');
+    if (layer === 'risk' && !isRiskLayerOpen) {
+      try {
+        await sendAnalyticsEvent('Risk Layer Opened');
+      } catch (error) {
+        console.error('Failed to send analytics event:', error);
+      }
+    }
 
   }, [changeLayer, isRiskLayerOpen]);
 

--- a/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
+++ b/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
@@ -2,7 +2,7 @@ import React, {useState, useCallback} from 'react';
 
 import './LayerSwitcher.css';
 import Backdrop from '../../../../src/components/Miscellaneous/Backdrop/Backdrop';
-import { sendAnalyticsEvent } from '../../../../src/utils/dbUtils';
+import { sendAnalyticsEvent } from '../../../../src/utils/analytics';
 
 interface LayerSwitcherProps {
    changeLayer: (layer: string) => void;

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -119,6 +119,12 @@ const ReportForm: React.FC<ReportFormProps> = ({
         const endTime = new Date();
         const durationInSeconds = startTime ? Math.round((endTime.getTime() - startTime.getTime()) / 1000) : 0;
 
+        async function finalizeSubmission() {
+            localStorage.setItem('lastReportTime', new Date().toISOString()); // Save the timestamp of the report to prevent spamming
+            closeModal();
+            onFormSubmit(); // Notify App component about the submission
+        }
+
         try {
             await sendAnalyticsEvent('Report Submitted', {
               duration: durationInSeconds,
@@ -128,15 +134,12 @@ const ReportForm: React.FC<ReportFormProps> = ({
                 Direction: directionInput?.label
               }
             });
+
+            finalizeSubmission();
           } catch (error) {
             console.error('Failed to send analytics event:', error);
+            finalizeSubmission();
           }
-
-        // Save the timestamp of the report to prevent spamming
-        localStorage.setItem('lastReportTime', new Date().toISOString());
-
-        closeModal();
-        onFormSubmit(); // Notify App component about the submission
     };
 
     async function verifyUserLocation(

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -119,14 +119,18 @@ const ReportForm: React.FC<ReportFormProps> = ({
         const endTime = new Date();
         const durationInSeconds = startTime ? Math.round((endTime.getTime() - startTime.getTime()) / 1000) : 0;
 
-        sendAnalyticsEvent('Report Submitted', {
-            duration: durationInSeconds,
-            meta: {
+        try {
+            await sendAnalyticsEvent('Report Submitted', {
+              duration: durationInSeconds,
+              meta: {
                 Station: stationInput!.label,
                 Line: lineInput?.label,
                 Direction: directionInput?.label
-            }
-        });
+              }
+            });
+          } catch (error) {
+            console.error('Failed to send analytics event:', error);
+          }
 
         // Save the timestamp of the report to prevent spamming
         localStorage.setItem('lastReportTime', new Date().toISOString());

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { ActionMeta } from 'react-select/';
 import AutocompleteInputForm, { selectOption } from '../AutocompleteInputForm/AutocompleteInputForm';
 
-import { LinesList, StationList, getAllLinesList, reportInspector, sendAnalyticsEvent } from '../../../utils/dbUtils';
+import { LinesList, StationList, getAllLinesList, reportInspector } from '../../../utils/dbUtils';
+import { sendAnalyticsEvent } from '../../../utils/analytics';
 import {
     highlightElement,
     redefineDirectionOptions,

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -14,6 +14,7 @@ import { highlightElement, useModalAnimation, currentColorTheme, setColorThemeIn
 import Backdrop from '../../../src/components/Miscellaneous/Backdrop/Backdrop';
 import { getNumberOfReportsInLast24Hours } from '../../utils/dbUtils';
 import { RiskDataProvider } from '../../contexts/RiskDataContext';
+import { sendSavedEvents } from '../../utils/analytics';
 import './App.css';
 
 type AppUIState = {
@@ -121,6 +122,10 @@ function App() {
   function changeLayer(clickedLayer: string) {
     setAppUIState({ ...appUIState, isRiskLayerOpen: clickedLayer === 'risk' });
   }
+
+  useEffect(() => {
+    sendSavedEvents();
+}, []);
 
   return (
     <div className='App'>

--- a/packages/frontend/src/utils/analytics.tsx
+++ b/packages/frontend/src/utils/analytics.tsx
@@ -1,0 +1,71 @@
+import { AnalyticsOptions, SavedEvent } from './types';
+
+/**
+ * Sends an analytics event to the Pirsch SDK.
+ * If the SDK is not loaded or an error occurs, the event is saved locally for later retry.
+ *
+ * @param {string} eventName - The name of the event to send.
+ * @param {AnalyticsOptions} [options] - Optional parameters for the event.
+ * @returns {Promise<void>} A promise that resolves if the event is sent successfully, or rejects with an error.
+ */
+export function sendAnalyticsEvent(eventName: string, options?: AnalyticsOptions): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (window.pirsch) {
+        try {
+          window.pirsch(eventName, options || {});
+          resolve();
+        } catch (error) {
+          console.error(`Failed to send event: ${eventName}`, error);
+          saveUnsuccessfulEvent(eventName, options || {});
+          reject(error);
+        }
+      } else {
+        console.warn('Pirsch SDK not loaded');
+        saveUnsuccessfulEvent(eventName, options || {});
+        reject(new Error('Pirsch SDK not loaded'));
+      }
+    });
+}
+
+/**
+ * Saves an unsuccessful analytics event to local storage for later retry.
+ *
+ * @param {string} eventName - The name of the event to save.
+ * @param {AnalyticsOptions} options - The parameters for the event.
+ */
+export function saveUnsuccessfulEvent(eventName: string, options: AnalyticsOptions): void {
+    const savedEvents: SavedEvent[] = JSON.parse(localStorage.getItem('unsent_analytics_events') || '[]');
+    savedEvents.push({
+        eventName,
+        options,
+        timestamp: Date.now()
+    });
+    localStorage.setItem('unsent_analytics_events', JSON.stringify(savedEvents));
+}
+
+/**
+ * Attempts to resend all previously saved unsuccessful analytics events.
+ * Events older than 24 hours are discarded.
+ *
+ * @returns {Promise<void>} A promise that resolves when all events have been processed.
+ */
+export async function sendSavedEvents(): Promise<void> {
+    const savedEvents: SavedEvent[] = JSON.parse(localStorage.getItem('unsent_analytics_events') || '[]');
+    const remainingEvents: SavedEvent[] = [];
+
+    for (const event of savedEvents) {
+        try {
+            await sendAnalyticsEvent(event.eventName, event.options);
+            // If successful, the event will not be added to remainingEvents
+        } catch (error) {
+            console.error(`Failed to send saved event: ${event.eventName}`, error);
+            // If the event is less than 24 hours old, keep it for retry
+            if (Date.now() - event.timestamp < 24 * 60 * 60 * 1000) {
+                remainingEvents.push(event);
+            }
+        }
+    }
+
+    localStorage.setItem('unsent_analytics_events', JSON.stringify(remainingEvents));
+}
+

--- a/packages/frontend/src/utils/dbUtils.tsx
+++ b/packages/frontend/src/utils/dbUtils.tsx
@@ -1,5 +1,4 @@
 import { selectOption } from '../components/Form/AutocompleteInputForm/AutocompleteInputForm';
-import { AnalyticsOptions } from './types';
 
 export interface StationProperty {
 	name: string;
@@ -172,25 +171,4 @@ export async function getNumberOfReportsInLast24Hours(): Promise<number> {
         console.error('Error:', error);
         return 0;
     }
-}
-
-export function getDataFromLocalStorage(key: string) {
-    return localStorage.getItem(key);
-}
-
-export function sendAnalyticsEvent(eventName: string, options?: AnalyticsOptions): Promise<void> {
-    return new Promise((resolve, reject) => {
-      if (window.pirsch) {
-        try {
-          window.pirsch(eventName, options || {});
-          resolve();
-        } catch (error) {
-          console.error(`Failed to send event: ${eventName}`, error);
-          reject(error);
-        }
-      } else {
-        console.warn('Pirsch SDK not loaded');
-        reject(new Error('Pirsch SDK not loaded'));
-      }
-    });
 }

--- a/packages/frontend/src/utils/dbUtils.tsx
+++ b/packages/frontend/src/utils/dbUtils.tsx
@@ -193,4 +193,4 @@ export function sendAnalyticsEvent(eventName: string, options?: AnalyticsOptions
         reject(new Error('Pirsch SDK not loaded'));
       }
     });
-  }
+}

--- a/packages/frontend/src/utils/dbUtils.tsx
+++ b/packages/frontend/src/utils/dbUtils.tsx
@@ -178,10 +178,19 @@ export function getDataFromLocalStorage(key: string) {
     return localStorage.getItem(key);
 }
 
-export function sendAnalyticsEvent(eventName: string, options?: AnalyticsOptions): void {
-    if (window.pirsch) {
-      window.pirsch(eventName, options || {});
-    } else {
-      console.warn('Pirsch SDK not loaded');
-    }
+export function sendAnalyticsEvent(eventName: string, options?: AnalyticsOptions): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (window.pirsch) {
+        try {
+          window.pirsch(eventName, options || {});
+          resolve();
+        } catch (error) {
+          console.error(`Failed to send event: ${eventName}`, error);
+          reject(error);
+        }
+      } else {
+        console.warn('Pirsch SDK not loaded');
+        reject(new Error('Pirsch SDK not loaded'));
+      }
+    });
   }

--- a/packages/frontend/src/utils/types.tsx
+++ b/packages/frontend/src/utils/types.tsx
@@ -17,6 +17,12 @@ export interface AnalyticsOptions {
     meta?: AnalyticsMeta;
 }
 
+export type SavedEvent = {
+    eventName: string;
+    options: AnalyticsOptions;
+    timestamp: number;
+};
+
 export interface StationGeoJSON {
     type: string;
     features: {


### PR DESCRIPTION
## Describe the issue:
@brandesdavid noticed that some of the report submitted analytic events were lost, this is obviously a huge deal as our analytics need to be accurate. 

## Explain how you solved the issue:
- I implemented Promises in the sendAnalyticsEvent function and made sure that the modal will only close once the Promises resolves or is rejected (The CTO of Pirsch said that this was likely the issue that the component was unmounted before the promise could resolve)
- Any unsuccessful will be saved in localstorage and resent when the app component is being mounted, that way we can make sure that we dont lose any events that were rejected.

## Additional notes or considerations: