### PR TITLE
refactor: lower the heading of the story

### DIFF
--- a/packages/instagram_bot/src/image.ts
+++ b/packages/instagram_bot/src/image.ts
@@ -76,7 +76,7 @@ function createSvgContent(width: number, height: number, inspectorSvgs: string):
     return `
         <svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
             <rect width="100%" height="100%" fill="#232323"/>
-            <text x="70" y="120" font-family="Arial, sans-serif" font-size="80" font-weight="bold" fill="white">Aktuelle Meldungen</text>
+            <text x="70" y="175" font-family="Arial, sans-serif" font-size="80" font-weight="bold" fill="white">Aktuelle Meldungen</text>
             ${inspectorSvgs}
             <text x="70" y="${
                 height - 60


### PR DESCRIPTION
The heading was blocked by the instagram app components. So I moved it down a bit so that it is easier to read.
