### PR TITLE
refactor: move useModalAnimation hook to own file

### DIFF
--- a/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
+++ b/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 import { OpacityMarker } from './Classes/OpacityMarker/OpacityMarker'
 import MarkerModal from '../../Modals/MarkerModal/MarkerModal'
 import { CloseButton } from '../../Buttons/CloseButton/CloseButton'
-import { useModalAnimation } from '../../../utils/uiUtils'
+import { useModalAnimation } from '../../../hooks/useModalAnimation'
 import { useTicketInspectors } from '../../../contexts/TicketInspectorsContext'
 import { MarkerData } from '../../../utils/types'
 export interface MarkersProps {

--- a/packages/frontend/src/hooks/useModalAnimation.tsx
+++ b/packages/frontend/src/hooks/useModalAnimation.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react'
+
+export function useModalAnimation(timeout = 250) {
+    const [isOpen, setIsOpen] = useState(false)
+    const [isAnimatingOut, setIsAnimatingOut] = useState(false)
+
+    const openModal = () => setIsOpen(true)
+
+    const closeModal = () => {
+        setIsAnimatingOut(true)
+        setTimeout(() => {
+            setIsOpen(false)
+            setIsAnimatingOut(false)
+        }, timeout)
+    }
+
+    return { isOpen, isAnimatingOut, openModal, closeModal }
+}

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -16,7 +16,8 @@ import { TicketInspectorsProvider } from '../../contexts/TicketInspectorsContext
 
 import { getNumberOfReportsInLast24Hours } from '../../utils/dbUtils';
 import { CloseButton } from '../../components/Buttons/CloseButton/CloseButton';
-import { highlightElement, useModalAnimation, currentColorTheme, setColorThemeInLocalStorage } from '../../utils/uiUtils';
+import { highlightElement, currentColorTheme, setColorThemeInLocalStorage } from '../../utils/uiUtils';
+import { useModalAnimation } from '../../hooks/useModalAnimation';
 import { RiskDataProvider } from '../../contexts/RiskDataContext';
 import { sendSavedEvents } from '../../utils/analytics';
 import './App.css';
@@ -167,7 +168,7 @@ function App() {
         </>
       )}
       <div id='portal-root'></div>
-      <RiskDataProvider>
+      <RiskDataProvider>s
         <TicketInspectorsProvider>
             <Map
             isFirstOpen={appUIState.isFirstOpen}

--- a/packages/frontend/src/utils/uiUtils.tsx
+++ b/packages/frontend/src/utils/uiUtils.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react'
-
 export function highlightElement(id: string) {
     const element = document.getElementById(id)
 
@@ -31,23 +29,6 @@ export function createWarningSpan(elementId: string, message: string) {
         warningSpan.textContent = message
         document.getElementById(elementId)?.appendChild(warningSpan)
     }
-}
-
-export function useModalAnimation(timeout = 250) {
-    const [isOpen, setIsOpen] = useState(false)
-    const [isAnimatingOut, setIsAnimatingOut] = useState(false)
-
-    const openModal = () => setIsOpen(true)
-
-    const closeModal = () => {
-        setIsAnimatingOut(true)
-        setTimeout(() => {
-            setIsOpen(false)
-            setIsAnimatingOut(false)
-        }, timeout)
-    }
-
-    return { isOpen, isAnimatingOut, openModal, closeModal }
 }
 
 export const currentColorTheme = () => {


### PR DESCRIPTION
it is a react best practice to keep hooks in their own file in a /hooks folder

## Describe the issue:

## Explain how you solved the issue:

## Additional notes or considerations:
