### PR TITLE
fix: ring should not have a direction

### DIFF
--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -265,7 +265,7 @@ const ReportForm: React.FC<ReportFormProps> = ({ closeModal, notifyParentAboutSu
                         required={true}
                         setSearchUsed={setSearchUsed}
                     />
-                    {currentLine && (
+                    {currentLine && currentLine !== 'S41' && currentLine !== 'S42' &&(
                         <section>
                             <h3>Richtung</h3>
                             <SelectField


### PR DESCRIPTION
I added a flag that will avoid showing the direction selectField if the currentLine is S41 or S42

## Describe the issue:

## Explain how you solved the issue:

## Additional notes or considerations:
