### PR TITLE
fix: legal disclaimer event did not send

### DIFF
--- a/packages/frontend/src/components/Modals/LegalDisclaimer/LegalDisclaimer.tsx
+++ b/packages/frontend/src/components/Modals/LegalDisclaimer/LegalDisclaimer.tsx
@@ -15,8 +15,8 @@ const LegalDisclaimer: React.FC<LegalDisclaimerProps> = ({ closeModal, openAnima
 
     const handleClose = () => {
         const endTime = Date.now()
-        const durationInSeconds = (endTime - startTimeRef.current) / 1000
-        sendAnalyticsEvent('Legal disclaimer has been closed', { duration: durationInSeconds })
+        const durationInSeconds = Math.floor((endTime - startTimeRef.current) / 1000)
+        sendAnalyticsEvent('Legal disclaimer has been closed', { duration: durationInSeconds, meta: {} })
         closeModal()
     }
     return (

--- a/packages/frontend/src/pages/Datenschutz/Datenschutz.tsx
+++ b/packages/frontend/src/pages/Datenschutz/Datenschutz.tsx
@@ -4,7 +4,7 @@ const Datenschutz = () => {
             <div className="legal-text">
                 <h1>Datenschutzerklärung für die App "Freifahren"</h1>
                 <br />
-                <p>Letze aktualisierung: 12.09.2024</p>
+                <p>Letze aktualisierung: 14.09.2024</p>
                 <h2>Rechtsgrundlagen der Datenverarbeitung</h2>
                 <p>
                     Die Verarbeitung personenbezogener Daten in unserer App erfolgt auf Basis der folgenden
@@ -123,6 +123,7 @@ const Datenschutz = () => {
                     <li>Ob die Liste der Ticketkontrolleure betrachtet wurde.</li>
                     <li>Welcher Marker (roter Punkt) auf der Karte angeklickt wurde.</li>
                     <li>Ob der Standort des Nutzers geteilt wurde und durch welche Methode.</li>
+                    <li>Wie lange benötigt wurde um das erste Fenster zu schließen.</li>
                 </ul>
                 <p>
                     Diese Daten sind nicht personenbezogen; es werden keine Informationen gesammelt, die eine


### PR DESCRIPTION
I think that the issue was related to the meta object not being present but being required by the API.

