### PR TITLE
fix: add areLayerOptionsVisible to draggable attribute and onClick at…

### DIFF
--- a/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
+++ b/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
@@ -46,19 +46,21 @@ const LayerSwitcher: React.FC<LayerSwitcherProps> = ({ changeLayer, isRiskLayerO
             <div
                 className={`layer-options small-button align-child-on-line ${areLayerOptionsVisible ? 'visible' : ''}`}
             >
-                <div onClick={() => closeModalAndHighlightSelectedLayer('risk')}>
+                <div onClick={areLayerOptionsVisible ? () => closeModalAndHighlightSelectedLayer('risk') : undefined}>
                     <img
                         src={process.env.PUBLIC_URL + '/icons/risk.png'}
                         alt="Showing how the risk layer looks like"
                         className={isRiskLayerOpen ? 'active' : ''}
+                        draggable={areLayerOptionsVisible}
                     />
                     <p>Risiko</p>
                 </div>
-                <div onClick={() => closeModalAndHighlightSelectedLayer('line')}>
+                <div onClick={areLayerOptionsVisible ? () => closeModalAndHighlightSelectedLayer('line') : undefined}>
                     <img
                         src={process.env.PUBLIC_URL + '/icons/lines.png'}
                         alt="Showing how the line layer looks like"
                         className={isRiskLayerOpen ? '' : 'active'}
+                        draggable={areLayerOptionsVisible}
                     />
                     <p>Linien</p>
                 </div>

--- a/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
+++ b/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
@@ -46,7 +46,7 @@ const LayerSwitcher: React.FC<LayerSwitcherProps> = ({ changeLayer, isRiskLayerO
             <div
                 className={`layer-options small-button align-child-on-line ${areLayerOptionsVisible ? 'visible' : ''}`}
             >
-                <div onClick={areLayerOptionsVisible ? () => closeModalAndHighlightSelectedLayer('risk') : undefined}>
+                <div {...(areLayerOptionsVisible ? { onClick: () => closeModalAndHighlightSelectedLayer('risk') } : {})}>
                     <img
                         src={process.env.PUBLIC_URL + '/icons/risk.png'}
                         alt="Showing how the risk layer looks like"
@@ -55,7 +55,7 @@ const LayerSwitcher: React.FC<LayerSwitcherProps> = ({ changeLayer, isRiskLayerO
                     />
                     <p>Risiko</p>
                 </div>
-                <div onClick={areLayerOptionsVisible ? () => closeModalAndHighlightSelectedLayer('line') : undefined}>
+                <div {...(areLayerOptionsVisible ? { onClick: () => closeModalAndHighlightSelectedLayer('line') } : {})}>
                     <img
                         src={process.env.PUBLIC_URL + '/icons/lines.png'}
                         alt="Showing how the line layer looks like"


### PR DESCRIPTION
## Describe the issue:

layer can still be switched after the modal for the layer switcher (hidden button)
also, when dragging the hidden image from the button, it still pops up

## Explain how you solved the issue:

added a check for areLayerOptionsVisible in the onclick and divs

## Additional notes or considerations:
```
 ____
< helo >
  ----
         \   ^__^ 
          \  (oo)\_______
             (__)\       )\/\\
                 ||----w |
                 ||     ||
```
    