### PR TITLE
Johan/fre 307 add more spacing in reportform

### DIFF
--- a/packages/frontend/src/components/Form/AutocompleteInputForm/AutocompleteInputForm.css
+++ b/packages/frontend/src/components/Form/AutocompleteInputForm/AutocompleteInputForm.css
@@ -16,10 +16,7 @@ section img {
 
 .search-input {
     position: absolute;
-    transition:
-        width var(--transition-default),
-        opacity var(--transition-default),
-        visibility var(--transition-default);
+    transition: width var(--transition-default), opacity var(--transition-default), visibility var(--transition-default);
     opacity: 0;
     height: 1.5rem;
     right: 45px;

--- a/packages/frontend/src/components/Form/AutocompleteInputForm/AutocompleteInputForm.css
+++ b/packages/frontend/src/components/Form/AutocompleteInputForm/AutocompleteInputForm.css
@@ -34,3 +34,9 @@ section img {
     visibility: visible;
     pointer-events: auto;
 }
+
+.station-list-container {
+    overflow-y: auto;
+    transition: ease-in-out var(--transition-default);
+    max-height: calc(100vh - 475px);
+}

--- a/packages/frontend/src/components/Form/AutocompleteInputForm/AutocompleteInputForm.tsx
+++ b/packages/frontend/src/components/Form/AutocompleteInputForm/AutocompleteInputForm.tsx
@@ -97,7 +97,10 @@ function AutocompleteInputForm<T>({
                 />
                 <img src={search_icon} onClick={toggleSearchBox} alt="Search icon" />
             </div>
-            <div className="station-list-container" style={listHeight ? { height: `${listHeight}px` } : undefined}>
+            <div
+                className="station-list-container"
+                style={listHeight ? { height: `${listHeight}px`, maxHeight: '100%' } : undefined}
+            >
                 <SelectField
                     onSelect={handleSelect}
                     value={value ? getDisplayValue(items[value]) : ''}

--- a/packages/frontend/src/components/Form/AutocompleteInputForm/AutocompleteInputForm.tsx
+++ b/packages/frontend/src/components/Form/AutocompleteInputForm/AutocompleteInputForm.tsx
@@ -13,6 +13,7 @@ interface AutocompleteInputFormProps<T> {
     label: string
     required?: boolean
     setSearchUsed?: (searchUsed: boolean) => void
+    listHeight?: number | null
 }
 
 const search_icon = `${process.env.PUBLIC_URL}/icons/search.svg`
@@ -46,6 +47,7 @@ function AutocompleteInputForm<T>({
     label,
     required = false,
     setSearchUsed,
+    listHeight,
 }: AutocompleteInputFormProps<T>) {
     const [showSearchBox, setShowSearchBox] = useState(false)
     const [search, setSearch] = useState('')
@@ -95,17 +97,19 @@ function AutocompleteInputForm<T>({
                 />
                 <img src={search_icon} onClick={toggleSearchBox} alt="Search icon" />
             </div>
-            <SelectField
-                onSelect={handleSelect}
-                value={value ? getDisplayValue(items[value]) : ''}
-                containerClassName="align-child-column"
-            >
-                {filteredItems.map(([key, item]) => (
-                    <div key={key}>
-                        <strong>{getDisplayValue(item)}</strong>
-                    </div>
-                ))}
-            </SelectField>
+            <div className="station-list-container" style={listHeight ? { height: `${listHeight}px` } : undefined}>
+                <SelectField
+                    onSelect={handleSelect}
+                    value={value ? getDisplayValue(items[value]) : ''}
+                    containerClassName="align-child-column"
+                >
+                    {filteredItems.map(([key, item]) => (
+                        <div key={key}>
+                            <strong>{getDisplayValue(item)}</strong>
+                        </div>
+                    ))}
+                </SelectField>
+            </div>
         </section>
     )
 }

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.css
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.css
@@ -1,3 +1,28 @@
+div.report-form {
+    padding: var(--padding-m);
+    display: flex;
+    flex-direction: column;
+    max-height: 85vh;
+    overflow: hidden;
+}
+
+.report-form > form {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.report-form > form > div {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.station-list-container {
+    flex: 1;
+    min-height: 100px;
+    overflow-y: auto;
+}
+
 .report-form > form > section > div:has(> img) {
     margin-bottom: var(--margin-m);
 }
@@ -40,8 +65,4 @@
 
 .report-form label:has(> input[type='checkbox']) {
     font-size: var(--font-xs);
-}
-
-div.report-form {
-    padding: var(--padding-m);
 }

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.css
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.css
@@ -1,24 +1,9 @@
 div.report-form {
     padding: var(--padding-m);
-    display: flex;
-    flex-direction: column;
     max-height: 85vh;
-    overflow: hidden;
-}
-
-.report-form > form {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-}
-
-.report-form > form > div {
-    flex: 1;
-    overflow-y: auto;
 }
 
 .station-list-container {
-    flex: 1;
     min-height: 100px;
     overflow-y: auto;
 }

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.css
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.css
@@ -1,6 +1,5 @@
 div.report-form {
     padding: var(--padding-m);
-    max-height: 85vh;
     transition: ease-in-out var(--transition-default);
     overflow-y: hidden;
 }

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.css
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.css
@@ -6,6 +6,7 @@ div.report-form {
 
 .station-list-container {
     overflow-y: auto;
+    transition: ease-in-out var(--transition-default);
 }
 
 .report-form > form > section > div:has(> img) {

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.css
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.css
@@ -5,11 +5,6 @@ div.report-form {
     overflow-y: hidden;
 }
 
-.station-list-container {
-    overflow-y: auto;
-    transition: ease-in-out var(--transition-default);
-}
-
 .report-form > form > div > section > * {
     margin-top: var(--margin-s);
     margin-bottom: var(--margin-s);

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.css
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.css
@@ -2,6 +2,7 @@ div.report-form {
     padding: var(--padding-m);
     max-height: 85vh;
     transition: ease-in-out var(--transition-default);
+    overflow-y: hidden;
 }
 
 .station-list-container {
@@ -9,12 +10,9 @@ div.report-form {
     transition: ease-in-out var(--transition-default);
 }
 
-.report-form > form > section > div:has(> img) {
-    margin-bottom: var(--margin-m);
-}
-
-.report-form > form > section > * {
+.report-form > form > div > section > * {
     margin-top: var(--margin-s);
+    margin-bottom: var(--margin-s);
 }
 
 .line {

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.css
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.css
@@ -1,10 +1,10 @@
 div.report-form {
     padding: var(--padding-m);
     max-height: 85vh;
+    transition: ease-in-out var(--transition-default);
 }
 
 .station-list-container {
-    min-height: 100px;
     overflow-y: auto;
 }
 

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -109,7 +109,6 @@ const ReportForm: React.FC<ReportFormProps> = ({ closeModal, notifyParentAboutSu
         return stations
     }, [allLines, allStations, currentEntity, currentLine, currentStation, stationSearch])
 
-    // Simplified calculateStationListHeight function
     const calculateStationListHeight = useCallback(() => {
         if (containerRef.current && topElementsRef.current && bottomElementsRef.current) {
             const container = containerRef.current

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -42,20 +42,32 @@ const ReportForm: React.FC<ReportFormProps> = ({ closeModal, notifyParentAboutSu
 
     const [isPrivacyChecked, setIsPrivacyChecked] = useState<boolean>(false)
 
-    const formRef = useRef<HTMLDivElement>(null) // rename this to div container ref or something like that
+    const containerRef = useRef<HTMLDivElement>(null)
     const topElementsRef = useRef<HTMLDivElement>(null)
-    const stationListRef = useRef<HTMLDivElement>(null)
     const bottomElementsRef = useRef<HTMLDivElement>(null)
     const [stationListHeight, setStationListHeight] = useState<number | null>(null)
 
+    const MINIMUM_LIST_HEIGHT = 50
+    const PADDING_MARGIN_ALLOWANCE = 100
+
     const calculateStationListHeight = useCallback(() => {
-        if (formRef.current && topElementsRef.current && stationListRef.current && bottomElementsRef.current) {
-            const formHeight = formRef.current.clientHeight
-            const topElementsHeight = topElementsRef.current.clientHeight
-            const bottomElementsHeight = bottomElementsRef.current.clientHeight
-            const availableHeight = formHeight - topElementsHeight - bottomElementsHeight
-            const newHeight = Math.max(50, availableHeight - 100) // Minimum height of 50px - 100px to account for magins and paddings
-            setStationListHeight(newHeight)
+        const elements = {
+            container: containerRef.current,
+            topElements: topElementsRef.current,
+            bottomElements: bottomElementsRef.current,
+        }
+
+        if (Object.values(elements).every(Boolean)) {
+            const heights = {
+                container: elements.container!.clientHeight,
+                topElements: elements.topElements!.clientHeight,
+                bottomElements: elements.bottomElements!.clientHeight,
+            }
+
+            const availableHeight = heights.container - heights.topElements - heights.bottomElements
+            const adjustedHeight = availableHeight - PADDING_MARGIN_ALLOWANCE
+
+            setStationListHeight(Math.max(MINIMUM_LIST_HEIGHT, adjustedHeight))
         }
     }, [])
 
@@ -245,7 +257,7 @@ const ReportForm: React.FC<ReportFormProps> = ({ closeModal, notifyParentAboutSu
     }
 
     return (
-        <div className={`report-form container modal ${className}`} ref={formRef}>
+        <div className={`report-form container modal ${className}`} ref={containerRef}>
             <form onSubmit={handleSubmit}>
                 <div>
                     <div ref={topElementsRef}>
@@ -280,19 +292,17 @@ const ReportForm: React.FC<ReportFormProps> = ({ closeModal, notifyParentAboutSu
                             </SelectField>
                         </section>
                     </div>
-                    <div ref={stationListRef}>
-                        <AutocompleteInputForm
-                            items={possibleStations}
-                            onSelect={handleStationSelect}
-                            value={currentStation}
-                            getDisplayValue={(station) => station.name}
-                            placeholder="Suche eine Station"
-                            label="Station"
-                            required={true}
-                            setSearchUsed={setSearchUsed}
-                            listHeight={stationListHeight}
-                        />
-                    </div>
+                    <AutocompleteInputForm
+                        items={possibleStations}
+                        onSelect={handleStationSelect}
+                        value={currentStation}
+                        getDisplayValue={(station) => station.name}
+                        placeholder="Suche eine Station"
+                        label="Station"
+                        required={true}
+                        setSearchUsed={setSearchUsed}
+                        listHeight={stationListHeight}
+                    />
                     <div ref={bottomElementsRef}>
                         {currentLine && currentLine !== 'S41' && currentLine !== 'S42' && (
                             <section>

--- a/packages/frontend/src/components/Miscellaneous/AskForLocation/AskForLocation.css
+++ b/packages/frontend/src/components/Miscellaneous/AskForLocation/AskForLocation.css
@@ -14,3 +14,7 @@
 .ask-for-location h1 {
     margin-bottom: var(--margin-m);
 }
+
+.ask-for-location h2 {
+    margin-bottom: var(--margin-s);
+}


### PR DESCRIPTION
## Describe the issue:
Users complained that the reportform was to crammed that it was overwhelming when using because everything was so packed. Also the usage of space was not optimal because of different screen sizes the listmodal has to have a different size.

## Explain how you solved the issue:
I wrote a central function which will calculate the height of the station list depending on the height of the container and the other elements. This will ensure that we will never have an overflow in the ReportForm and users can always see the submit button, which is key for a checkout form.

## Additional notes or considerations:
