### PR TITLE
Fix report form for very small devices

### DIFF
--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.css
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.css
@@ -44,3 +44,17 @@ div.report-form {
 .report-form label:has(> input[type='checkbox']) {
     font-size: var(--font-xs);
 }
+
+@media (max-width: 375px) {
+    .report-form > form > div h1 + section {
+        display: none;
+    }
+
+    .report-form label:has(> input[type='checkbox']) {
+        font-size: var(--font-xxs);
+    }
+
+    .report-form .description-field textarea {
+        height: 1.5rem;
+    }
+}

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.css
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.css
@@ -1,7 +1,6 @@
 div.report-form {
     padding: var(--padding-m);
     transition: ease-in-out var(--transition-default);
-    overflow-y: hidden;
 }
 
 .report-form > form > div > section > * {

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.css
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.css
@@ -42,6 +42,13 @@ div.report-form {
 
 .report-form label:has(> input[type='checkbox']) {
     font-size: var(--font-xs);
+    display: flex;
+    align-items: center;
+}
+
+.report-form label:has(> input[type='checkbox']) > a {
+    margin-left: var(--margin-xxs);
+    margin-right: var(--margin-xxs);
 }
 
 @media (max-width: 375px) {

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -135,8 +135,7 @@ const ReportForm: React.FC<ReportFormProps> = ({ closeModal, notifyParentAboutSu
             const topAllowance = calculateAllowance(top) + dynamicDivMargins
             const bottomAllowance = calculateAllowance(bottom) + dynamicDivMargins
 
-            // I have no idea why I have to multiply by 2 here, but it works
-            const totalAllowance = containerAllowance + topAllowance + bottomAllowance
+            const totalAllowance = containerAllowance + topAllowance + bottomAllowance + marginS
 
             const stationCount = Object.keys(possibleStations).length
             const availableHeight = containerHeight - topHeight - bottomHeight - totalAllowance


### PR DESCRIPTION
## Describe the issue:
The reportform was impossible to use on very small devices (< 375px) as you could not hit the submit button due to the overflow occurring and it being hidden by default.

This pull request includes several updates to the `ReportForm` component, focusing on CSS styling adjustments and a minor TypeScript logic change. The most important changes are grouped into CSS styling improvements and logic correction.

## Explain how you solved the issue:

I fixed the issue that there should not occur an overflow and allowed overflow to happen, just in case I missed something.

### CSS Styling Improvements:

* [`packages/frontend/src/components/Form/ReportForm/ReportForm.css`](diffhunk://#diff-e12b252eb8a18b1655e2c3020ba44639b288a597a22fb4cd90b6a6c1499acb3eL4): Removed `overflow-y: hidden` from `.report-form` to allow vertical overflow.
* [`packages/frontend/src/components/Form/ReportForm/ReportForm.css`](diffhunk://#diff-e12b252eb8a18b1655e2c3020ba44639b288a597a22fb4cd90b6a6c1499acb3eR45-R65): Added `display: flex` and `align-items: center` to labels containing checkboxes for better alignment.
* [`packages/frontend/src/components/Form/ReportForm/ReportForm.css`](diffhunk://#diff-e12b252eb8a18b1655e2c3020ba44639b288a597a22fb4cd90b6a6c1499acb3eR45-R65): Added margin adjustments for links inside labels containing checkboxes.
* [`packages/frontend/src/components/Form/ReportForm/ReportForm.css`](diffhunk://#diff-e12b252eb8a18b1655e2c3020ba44639b288a597a22fb4cd90b6a6c1499acb3eR45-R65): Added media query for screens smaller than 375px to hide specific sections and adjust font size and textarea height.

### Logic Correction:

* [`packages/frontend/src/components/Form/ReportForm/ReportForm.tsx`](diffhunk://#diff-86e82513bb9ea84267250298165b8f65b3adfc383a6d6ffbe722ce4dd8c35ad8L138-R138): Corrected the calculation of `totalAllowance` by adding `marginS` to the sum.

## Additional notes or considerations:
