### PR TITLE
feat: always show submit button on bottom of modal

### DIFF
--- a/packages/frontend/src/components/Modals/LegalDisclaimer/LegalDisclaimer.css
+++ b/packages/frontend/src/components/Modals/LegalDisclaimer/LegalDisclaimer.css
@@ -1,15 +1,42 @@
-.legal-disclaimer > ul {
+.legal-disclaimer {
+    display: flex !important;
+    flex-direction: column;
+    justify-content: space-between;
+    max-height: 85vh;
+}
+
+.legal-disclaimer .content {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.legal-disclaimer .content ol {
+    padding-left: var(--padding-m);
+}
+
+.legal-disclaimer .content ol li::marker {
+    color: var(--color-primary);
+}
+
+.legal-disclaimer .footer {
+    margin-top: var(--margin-s);
+    flex-shrink: 0;
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.legal-disclaimer .footer > *:last-child {
+    margin-bottom: 0;
+}
+
+.legal-disclaimer .footer ul {
     position: relative;
     top: 10px;
     display: flex;
     justify-content: flex-end;
 }
 
-.legal-disclaimer {
-    max-height: 85vh;
-}
-
-.legal-disclaimer > ul > li {
+.legal-disclaimer .footer ul > li {
     margin-left: var(--margin-xs);
     font-size: var(--font-xxs);
 }

--- a/packages/frontend/src/components/Modals/LegalDisclaimer/LegalDisclaimer.tsx
+++ b/packages/frontend/src/components/Modals/LegalDisclaimer/LegalDisclaimer.tsx
@@ -21,38 +21,42 @@ const LegalDisclaimer: React.FC<LegalDisclaimerProps> = ({ closeModal, openAnima
     }
     return (
         <div className={`legal-disclaimer container modal ${openAnimationClass}`} id="legal-disclaimer">
-            <h1>Bitte bestätigen Sie vor dem Fortfahren</h1>
-            <p>
-                Um die Integrität unserer Community und den Geist fairer Nutzung zu wahren, bitten wir Sie, zwei
-                wichtige Punkte zu bestätigen:
-            </p>
-            <ol>
-                <li>
-                    <strong>Ich besitze ein gültiges Ticket für meine Reise.</strong>
+            <div className="content">
+                <h1>Bitte bestätigen Sie vor dem Fortfahren</h1>
+                <section>
                     <p>
-                        Ich verstehe, dass diese App dazu dient, das Bewusstsein und die Planung im öffentlichen
-                        Nahverkehr zu verbessern, nicht aber um Regeln oder Vorschriften zu umgehen.
+                        Um die Integrität unserer Community und den Geist fairer Nutzung zu wahren, bitten wir Sie, zwei
+                        wichtige Punkte zu bestätigen:
                     </p>
-                </li>
-                <li>
-                    <strong>Ich nutze die App nicht aktiv während der Fahrt.</strong>
-                    <p>
-                        Mir ist bewusst, dass die aktive Nutzung der App während der Fahrt andere Fahrgäste stören und
-                        gegen die Nutzungsbedingungen des Verkehrsbetriebs verstoßen kann.
-                    </p>
-                </li>
-            </ol>
-            <div>
-                <button onClick={handleClose}>Ich bestätige</button>
+                    <ol>
+                        <li>
+                            <strong>Ich besitze ein gültiges Ticket für meine Reise.</strong>
+                            <p>
+                                Ich verstehe, dass diese App dazu dient, das Bewusstsein und die Planung im öffentlichen
+                                Nahverkehr zu verbessern, nicht aber um Regeln oder Vorschriften zu umgehen.
+                            </p>
+                        </li>
+                        <li>
+                            <strong>Ich nutze die App nicht aktiv während der Fahrt.</strong>
+                            <p>
+                                Mir ist bewusst, dass die aktive Nutzung der App während der Fahrt andere Fahrgäste
+                                stören und gegen die Nutzungsbedingungen des Verkehrsbetriebs verstoßen kann.
+                            </p>
+                        </li>
+                    </ol>
+                </section>
             </div>
-            <ul className="align-child-on-line">
-                <li>
-                    <Link to="/impressum">Impressum</Link>
-                </li>
-                <li>
-                    <Link to="/Datenschutz">Datenschutz</Link>
-                </li>
-            </ul>
+            <div className="footer">
+                <button onClick={handleClose}>Ich bestätige</button>
+                <ul className="align-child-on-line">
+                    <li>
+                        <Link to="/impressum">Impressum</Link>
+                    </li>
+                    <li>
+                        <Link to="/Datenschutz">Datenschutz</Link>
+                    </li>
+                </ul>
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Describe the issue:
The users had to scroll on small devices to accept the legal disclaimer modal

This pull request includes significant updates to the `LegalDisclaimer` component in both the CSS and TypeScript files. The changes primarily focus on improving the layout and structure of the modal.

## Explain how you solved the issue:

### Layout and Structure Improvements:

* [`packages/frontend/src/components/Modals/LegalDisclaimer/LegalDisclaimer.css`](diffhunk://#diff-ef8e4170e8e14d4add80cf503227426eb72600a02ff21818419797a1d55d69d7L1-R39): Updated the `.legal-disclaimer` class to use flexbox for better layout management and added new styles for `.content` and `.footer` sections.
* [`packages/frontend/src/components/Modals/LegalDisclaimer/LegalDisclaimer.tsx`](diffhunk://#diff-2a95773fdcc4b8182ecf5deee6aca3baea6ccd530b00b13921c967dd886cd532R24-R26): Wrapped the content and footer sections in new `div` elements with corresponding classes to match the updated CSS. [[1]](diffhunk://#diff-2a95773fdcc4b8182ecf5deee6aca3baea6ccd530b00b13921c967dd886cd532R24-R26) [[2]](diffhunk://#diff-2a95773fdcc4b8182ecf5deee6aca3baea6ccd530b00b13921c967dd886cd532R60)
