### PR TITLE
feat: avoid showing highlight elements when searching

### DIFF
--- a/packages/frontend/src/components/Form/AutocompleteInputForm/AutocompleteInputForm.tsx
+++ b/packages/frontend/src/components/Form/AutocompleteInputForm/AutocompleteInputForm.tsx
@@ -114,7 +114,7 @@ function AutocompleteInputForm<T>({
                 className="list-container"
                 style={listHeight ? { height: `${listHeight}px`, maxHeight: '100%' } : undefined}
             >
-                {highlightElements && !elementIsSelected && (
+                {highlightElements && !elementIsSelected && !showSearchBox && (
                     <>
                         <SelectField
                             onSelect={(selectedValue) => handleSelect(selectedValue, true)}


### PR DESCRIPTION
The user obviously does not want to select the stations from the suggestions so if the user searches it will just block the view.

