### PR TITLE
Johan/fre 317 fix alt tegel issue in telegram bot

### DIFF
--- a/packages/backend/logger/logger.go
+++ b/packages/backend/logger/logger.go
@@ -85,6 +85,8 @@ func Init() {
 	// Use the multi-writer when creating the logger
 	Log = zerolog.New(multi).Level(zerolog.DebugLevel).With().Timestamp().Caller().Logger()
 
-	apiEndpoint := os.Getenv("TELEGRAM_BOTS_URL") + "/report-failure"
-	Log = Log.Hook(&APIHook{Endpoint: apiEndpoint})
+	if os.Getenv("STATUS") != "dev" {
+		apiEndpoint := os.Getenv("TELEGRAM_BOTS_URL") + "/report-failure"
+		Log = Log.Hook(&APIHook{Endpoint: apiEndpoint})
+	}
 }

--- a/packages/telegram_bots/FreiFahren_BE_NLP/data/synonyms.json
+++ b/packages/telegram_bots/FreiFahren_BE_NLP/data/synonyms.json
@@ -2,82 +2,181 @@
     "sBahn_stations_with_synomyms": {
         "Adlershof": [],
         "Ahrensfelde": [],
-        "Alexanderplatz": ["Alex"],
-        "Alt-Reinickendorf": ["Reinickendorf"],
-        "Altglienicke": ["Glienicke"],
-        "Anhalter Bahnhof": ["Anhalter"],
-        "Attilastraße": ["Attila", "Attilastr.", "Attilastrasse"],
+        "Alexanderplatz": [
+            "Alex"
+        ],
+        "Alt-Reinickendorf": [
+            "Reinickendorf"
+        ],
+        "Altglienicke": [
+            "Glienicke"
+        ],
+        "Anhalter Bahnhof": [
+            "Anhalter"
+        ],
+        "Attilastraße": [
+            "Attila",
+            "Attilastr.",
+            "Attilastrasse"
+        ],
         "Babelsberg": [],
         "Baumschulenweg": [],
         "Bellevue": [],
         "Bergfelde": [],
         "Bernau": [],
-        "Bernau-Friedenstal": ["Friedenstal"],
-        "Betriebsbahnhof Rummelsburg": ["Betriebsbahnhof", "Btrbhf Rummelsburg", "Btrb Rummelsburg"],
-        "Beusselstraße": ["Beussel", "besseulstr.", "Beusselstrasse"],
+        "Bernau-Friedenstal": [
+            "Friedenstal"
+        ],
+        "Betriebsbahnhof Rummelsburg": [
+            "Betriebsbahnhof",
+            "Btrbhf Rummelsburg",
+            "Btrb Rummelsburg"
+        ],
+        "Beusselstraße": [
+            "Beussel",
+            "besseulstr.",
+            "Beusselstrasse"
+        ],
         "Biesdorf": [],
-        "Bismarckstraße": ["Bismarckstr", "Bismarckstrasse"],
+        "Bismarckstraße": [
+            "Bismarckstr",
+            "Bismarckstrasse"
+        ],
         "Birkenstein": [],
         "Birkenwerder": [],
         "Blankenburg": [],
         "Blankenfelde": [],
         "Borgsdorf": [],
-        "Bornholmerstraße": ["Bornholmer", "Bornholmerstr.", "Bornholmerstrasse"],
+        "Bornholmerstraße": [
+            "Bornholmer",
+            "Bornholmerstr.",
+            "Bornholmerstrasse"
+        ],
         "Botanischer Garten": [],
-        "Brandenburger Tor": ["Brandenburger"],
+        "Brandenburger Tor": [
+            "Brandenburger"
+        ],
         "Buch": [],
         "Buckower Chaussee": [],
         "Bundesplatz": [],
-        "Charlottenburg": ["Chb"],
+        "Charlottenburg": [
+            "Chb"
+        ],
         "Eichborndamm": [],
         "Eichwalde": [],
         "Erkner": [],
-        "Feuerbachstraße": ["Feuerbach", "Feuerbachstr.", "Feuerbachstrasse"],
-        "Flughafen BER": ["BER", "Flughafen", "Flughafen Berlin Brandenburger"],
-        "Frankfurter Allee": ["Frankfurter"],
+        "Feuerbachstraße": [
+            "Feuerbach",
+            "Feuerbachstr.",
+            "Feuerbachstrasse"
+        ],
+        "Flughafen BER": [
+            "BER",
+            "Flughafen",
+            "Flughafen Berlin Brandenburger"
+        ],
+        "Frankfurter Allee": [
+            "Frankfurter"
+        ],
         "Fredersdorf": [],
         "Friedenau": [],
-        "Friedrichsfelde Ost": ["Friedrichsfelde"],
+        "Friedrichsfelde Ost": [
+            "Friedrichsfelde"
+        ],
         "Friedrichshagen": [],
-        "Friedrichstraße": ["Friedrichstr", "Friedrichstrasse."],
+        "Friedrichstraße": [
+            "Friedrichstr",
+            "Friedrichstrasse."
+        ],
         "Frohnau": [],
-        "Rosenthaler Platz": ["Rosenthaler", "Rosenthalerplz"],
-        "Gehrenseestraße": ["Gehrenseeer", "Gehrenseestrasse", "Gehrenseestr."],
+        "Rosenthaler Platz": [
+            "Rosenthaler",
+            "Rosenthalerplz"
+        ],
+        "Gehrenseestraße": [
+            "Gehrenseeer",
+            "Gehrenseestrasse",
+            "Gehrenseestr."
+        ],
         "Gesundbrunnen": [],
-        "Greifswalderstraße": ["Greifswalder", "Greifswalderstr.", "Greifswalderstrasse"],
+        "Greifswalderstraße": [
+            "Greifswalder",
+            "Greifswalderstr.",
+            "Greifswalderstrasse"
+        ],
         "Griebnitzsee": [],
         "Grünau": [],
-        "Grünbergallee": ["Grünberger"],
+        "Grünbergallee": [
+            "Grünberger"
+        ],
         "Grunewald": [],
-        "Hackescher Markt": ["Hackescher", "Hackeschen Markt"],
+        "Hackescher Markt": [
+            "Hackescher",
+            "Hackeschen Markt"
+        ],
         "Halensee": [],
-        "Hauptbahnhof": ["Hbf"],
-        "Heerstraße": ["Heerstr", "Heerstrasse"],
+        "Hauptbahnhof": [
+            "Hbf"
+        ],
+        "Heerstraße": [
+            "Heerstr",
+            "Heerstrasse"
+        ],
         "Hegermühle": [],
-        "Heidelberger Platz": ["Heidelberger", "Heidelbergerplz"],
-        "Heiligensee": ["Heiligen"],
+        "Heidelberger Platz": [
+            "Heidelberger",
+            "Heidelbergerplz"
+        ],
+        "Heiligensee": [
+            "Heiligen"
+        ],
         "Hennigsdorf": [],
-        "Hermannstraße": ["Hermannstr", "Hermannstrasse"],
+        "Hermannstraße": [
+            "Hermannstr",
+            "Hermannstrasse"
+        ],
         "Hermsdorf": [],
-        "Hirschgarten": ["Hirschgrt"],
-        "Hohen Neuendorf": ["Neuendorf"],
+        "Hirschgarten": [
+            "Hirschgrt"
+        ],
+        "Hohen Neuendorf": [
+            "Neuendorf"
+        ],
         "Hohenschönhausen": [],
-        "Hohenzollerndamm": ["Hohenzollern", "Hohenzollern Damm"],
+        "Hohenzollerndamm": [
+            "Hohenzollern",
+            "Hohenzollern Damm"
+        ],
         "Hoppegarten": [],
-        "Humboldthain": ["Humbolt Hain"],
-        "Innsbrucker Platz": ["Innsbrucker", "Innsbruckerplz"],
-        "Jannowitz Brücke": ["Jannowitz", "Jannowitzbrücke"],
+        "Humboldthain": [
+            "Humbolt Hain"
+        ],
+        "Innsbrucker Platz": [
+            "Innsbrucker",
+            "Innsbruckerplz"
+        ],
+        "Jannowitz Brücke": [
+            "Jannowitz",
+            "Jannowitzbrücke"
+        ],
         "Johannisthal": [],
-        "Julius-Leber-Brücke": ["Julius Leber", "Julius Leber Brücke"],
+        "Julius-Leber-Brücke": [
+            "Julius Leber",
+            "Julius Leber Brücke"
+        ],
         "Jungfernheide": [],
-        "Karl-Bonhoeffer-Nervenklinik": ["Karl Bonhoeffer"],
+        "Karl-Bonhoeffer-Nervenklinik": [
+            "Karl Bonhoeffer"
+        ],
         "Karlshorst": [],
         "Karow": [],
         "Kaulsdorf": [],
         "Köllnische Heide": [],
         "Königs Wusterhausen": [],
         "Köpenick": [],
-        "Landsberger Allee": ["Landsberger"],
+        "Landsberger Allee": [
+            "Landsberger"
+        ],
         "Lankwitz": [],
         "Lehnitz": [],
         "Lichtenberg": [],
@@ -90,31 +189,61 @@
         "Marienfelde": [],
         "Marzahn": [],
         "Mehrower Allee": [],
-        "Messe Nord/ICC": ["Messe Nord"],
+        "Messe Nord/ICC": [
+            "Messe Nord"
+        ],
         "Messe Süd": [],
         "Mexikoplatz": [],
         "Mühlenbeck-Mönchmühle": [],
         "Neuenhagen": [],
         "Neukölln": [],
         "Nikolassee": [],
-        "Nöldnerplatz": ["Nöldner", "Nöldnerplz"],
-        "Nordbahnhof": ["Nordbhf"],
+        "Nöldnerplatz": [
+            "Nöldner",
+            "Nöldnerplz"
+        ],
+        "Nordbahnhof": [
+            "Nordbhf"
+        ],
         "Oberspree": [],
         "Olympia-Stadion": [],
-        "Oranienburgerstraße": ["Oranienburger", "Oranienburgerstr."],
-        "Osdorferstraße": ["Osdorfer", "Osdorferstr."],
-        "Ostbahnhof": ["Ostbhf"],
-        "Ostkreuz": ["Ostkrz"],
+        "Oranienburgerstraße": [
+            "Oranienburger",
+            "Oranienburgerstr."
+        ],
+        "Osdorferstraße": [
+            "Osdorfer",
+            "Osdorferstr."
+        ],
+        "Ostbahnhof": [
+            "Ostbhf"
+        ],
+        "Ostkreuz": [
+            "Ostkrz"
+        ],
         "Pankow": [],
-        "Pankow-Heinersdorf": ["Heinersdorf"],
+        "Pankow-Heinersdorf": [
+            "Heinersdorf"
+        ],
         "Petershagen Nord": [],
-        "Perleberger Brücke": ["Perleberger"],
+        "Perleberger Brücke": [
+            "Perleberger"
+        ],
         "Pichelsberg": [],
         "Plänterwald": [],
-        "Poelchaustraße": ["Poelchaustrasse", "Poelchaustr."],
-        "Potsdamer Platz": ["Potsdamerplz"],
-        "Potsdam Hauptbahnhof": ["Potsdam Hbf"],
-        "Prenzlauer Allee": ["Prenzlauer"],
+        "Poelchaustraße": [
+            "Poelchaustrasse",
+            "Poelchaustr."
+        ],
+        "Potsdamer Platz": [
+            "Potsdamerplz"
+        ],
+        "Potsdam Hauptbahnhof": [
+            "Potsdam Hbf"
+        ],
+        "Prenzlauer Allee": [
+            "Prenzlauer"
+        ],
         "Priesterweg": [],
         "Rahnsdorf": [],
         "Raoul-Wallenberg-Straße": [
@@ -123,109 +252,225 @@
             "Raoul Wallenberg",
             "Raoul Wallenberg Strasse"
         ],
-        "Rathaus Steglitz": ["Rathaus Stglz", "Rathaus Stz"],
+        "Rathaus Steglitz": [
+            "Rathaus Stglz",
+            "Rathaus Stz"
+        ],
         "Röntgental": [],
         "Rummelsburg": [],
-        "Savignyplatz": ["Savigny"],
+        "Savignyplatz": [
+            "Savigny"
+        ],
         "Schichauweg": [],
         "Schlachtensee": [],
         "Schöneberg": [],
         "Schönefeld": [],
         "Schöneweide": [],
         "Schönfließ": [],
-        "Schönhauser Allee": ["Schönhauser"],
+        "Schönhauser Allee": [
+            "Schönhauser"
+        ],
         "Schönholz": [],
         "Schulzendorf": [],
         "Sonnenallee": [],
         "Spandau": [],
         "Spindlersfeld": [],
         "Springpfuhl": [],
-        "Storkowerstraße": ["Storkower", "Storkowerstr.", "Storkowerstrasse"],
+        "Storkowerstraße": [
+            "Storkower",
+            "Storkowerstr.",
+            "Storkowerstrasse"
+        ],
         "Strausberg": [],
         "Strausberg Nord": [],
         "Strausberg Stadt": [],
         "Stresow": [],
-        "Südkreuz": ["Südkrz"],
+        "Südkreuz": [
+            "Südkrz"
+        ],
         "Südende": [],
-        "Sundgauerstraße": ["Sundgauer", "Sundgauerstr.", "Sundgauerstrasse"],
+        "Sundgauerstraße": [
+            "Sundgauer",
+            "Sundgauerstr.",
+            "Sundgauerstrasse"
+        ],
         "Tegel": [],
         "Teltow Stadt": [],
         "Tempelhof": [],
         "Tiergarten": [],
-        "Treptower Park": ["Treptower", "Trepi"],
+        "Treptower Park": [
+            "Treptower",
+            "Trepi"
+        ],
         "Waidmannslust": [],
         "Wannsee": [],
-        "Warschauerstraße": ["Warschauer", "Warschauerstr.", "Warschauerstrasse"],
+        "Warschauerstraße": [
+            "Warschauer",
+            "Warschauerstr.",
+            "Warschauerstrasse"
+        ],
         "Wartenberg": [],
         "Waßmannsdorf": [],
         "Wedding": [],
         "Westend": [],
         "Westhafen": [],
-        "Westkreuz": ["Westkrz"],
+        "Westkreuz": [
+            "Westkrz"
+        ],
         "Wildau": [],
         "Wilhelmshagen": [],
         "Wilhelmsruh": [],
         "Wittenau": [],
-        "Wollankstraße": ["Wollankstr,", "Wollankstrasse"],
+        "Wollankstraße": [
+            "Wollankstr,",
+            "Wollankstrasse"
+        ],
         "Wuhletal": [],
         "Wuhlheide": [],
-        "Yorckstraße": ["Yorcksstrasse", "Yorcksstr."],
+        "Yorckstraße": [
+            "Yorcksstrasse",
+            "Yorcksstr."
+        ],
         "Zehlendorf": [],
         "Zepernick": [],
         "Zeuthen": [],
-        "Zoologischer Garten": ["Zoo"]
+        "Zoologischer Garten": [
+            "Zoo"
+        ]
     },
     "uBahn_stations_with_synomyms": {
         "Adenauer Platz": [],
-        "Afrikanischestraße": ["Afrikanischestr.", "afrikanische strasse"],
-        "Alexanderplatz": ["Alex"],
+        "Afrikanischestraße": [
+            "Afrikanischestr.",
+            "afrikanische strasse"
+        ],
+        "Alexanderplatz": [
+            "Alex"
+        ],
         "Altstadt-Spandau": [],
         "Alt-Mariendorf": [],
         "Alt-Tegel": [],
         "Alt-Tempelhof": [],
-        "Amrumerstraße": ["Amrumerstr.", "Amrumerstrasse"],
-        "Bayrischer Platz": ["Bayrischerplz"],
-        "Berlinerstraße": ["Berlinerstr.", "Berlinerstrasse"],
-        "Bernauerstraße": ["Bernauerstr.", "Bernauerstrasse"],
+        "Amrumerstraße": [
+            "Amrumerstr.",
+            "Amrumerstrasse"
+        ],
+        "Bayrischer Platz": [
+            "Bayrischerplz"
+        ],
+        "Berlinerstraße": [
+            "Berlinerstr.",
+            "Berlinerstrasse"
+        ],
+        "Bernauerstraße": [
+            "Bernauerstr.",
+            "Bernauerstrasse"
+        ],
         "Biesdorf-Süd": [],
-        "Birkenstraße": ["Birkenstr.", "Birkenstrasse"],
+        "Birkenstraße": [
+            "Birkenstr.",
+            "Birkenstrasse"
+        ],
         "Blaschkoallee": [],
-        "Blissestraße": ["Blissestr.", "Blissestrasse"],
-        "Boddinstraße": ["Boddinstr.", "Boddinstrasse"],
+        "Blissestraße": [
+            "Blissestr.",
+            "Blissestrasse"
+        ],
+        "Boddinstraße": [
+            "Boddinstr.",
+            "Boddinstrasse"
+        ],
         "Borsigwerke": [],
-        "Brandenburger Tor": ["Brandenburger"],
-        "Breitenbachplatz": ["Breitenbachplz"],
+        "Brandenburger Tor": [
+            "Brandenburger"
+        ],
+        "Breitenbachplatz": [
+            "Breitenbachplz"
+        ],
         "Britz Süd": [],
-        "Bülowstraße": ["Bülowstr.", "Bülowstrasse"],
+        "Bülowstraße": [
+            "Bülowstr.",
+            "Bülowstrasse"
+        ],
         "Bundestag": [],
-        "Cottbusser Platz": ["Cottbusserplz"],
+        "Cottbusser Platz": [
+            "Cottbusserplz"
+        ],
         "Dahlem-Dorf": [],
         "Deutsche Oper": [],
-        "Eberswalderstraße": ["Eberswalderstr.", "Eberswalderstrasse"],
-        "Eisenacherstraße": ["Eisenacherstr.", "Eisenacherstrasse"],
-        "Elsterwerdaer Platz": ["Elsterwerdaerplz"],
-        "Ernst-Reuter-Platz": ["Ernst Reuter Plz", "Ernst Reuter"],
-        "Fehrbelliner Platz": ["Fehrbellinerplz, Fehrbelliner"],
+        "Eberswalderstraße": [
+            "Eberswalderstr.",
+            "Eberswalderstrasse"
+        ],
+        "Eisenacherstraße": [
+            "Eisenacherstr.",
+            "Eisenacherstrasse"
+        ],
+        "Elsterwerdaer Platz": [
+            "Elsterwerdaerplz"
+        ],
+        "Ernst-Reuter-Platz": [
+            "Ernst Reuter Plz",
+            "Ernst Reuter"
+        ],
+        "Fehrbelliner Platz": [
+            "Fehrbellinerplz, Fehrbelliner"
+        ],
         "Frankfurter Allee": [],
         "Frankfurter Tor": [],
-        "Franz-Neumann-Platz": ["Franz Neumann Plz", "Franz Neumann"],
-        "Freie Universität (Thielplatz)": ["Freie Universität", "Thielplatz", "FU"],
+        "Franz-Neumann-Platz": [
+            "Franz Neumann Plz",
+            "Franz Neumann"
+        ],
+        "Freie Universität (Thielplatz)": [
+            "Freie Universität",
+            "Thielplatz",
+            "FU"
+        ],
         "Friedrichsfelde": [],
-        "Friedrichstraße": ["Friedrichstr", "Friedrichstrasse.", "Friedrichstrasse"],
-        "Friedrich-Wilhelm-Platz": ["Friedrich Wilhelm Plz", "Friedrich Wilhelm"],
+        "Friedrichstraße": [
+            "Friedrichstr",
+            "Friedrichstrasse.",
+            "Friedrichstrasse"
+        ],
+        "Friedrich-Wilhelm-Platz": [
+            "Friedrich Wilhelm Plz",
+            "Friedrich Wilhelm"
+        ],
         "Gesundbrunnen": [],
         "Gleisdreieck": [],
-        "Gneisenaustraße": ["Gneisenaustr.", "Gneisenaustrasse"],
-        "Görlitzer Bahnhof": ["Görli"],
+        "Gneisenaustraße": [
+            "Gneisenaustr.",
+            "Gneisenaustrasse"
+        ],
+        "Görlitzer Bahnhof": [
+            "Görli"
+        ],
         "Grenzallee": [],
-        "Güntzelstraße": ["Güntzelstr.", "Güntzelstrasse"],
+        "Güntzelstraße": [
+            "Güntzelstr.",
+            "Güntzelstrasse"
+        ],
         "Halemweg": [],
-        "Hallesches Tor": ["Hallesches", "Halleschen Tor"],
-        "Hansaplatz": ["Hansaplz"],
+        "Hallesches Tor": [
+            "Hallesches",
+            "Halleschen Tor"
+        ],
+        "Hansaplatz": [
+            "Hansaplz"
+        ],
         "Haselhorst": [],
-        "Hauptbahnhof": ["Hbf"],
-        "Hausvogteiplatz": ["Hausvogtei", "Hausvogteiplz"],
-        "Heidelberger Platz": ["Heidelberger", "Heidelbergerplz"],
+        "Hauptbahnhof": [
+            "Hbf"
+        ],
+        "Hausvogteiplatz": [
+            "Hausvogtei",
+            "Hausvogteiplz"
+        ],
+        "Heidelberger Platz": [
+            "Heidelberger",
+            "Heidelbergerplz"
+        ],
         "Heinrich-Heine-Straße": [
             "Heinrich Heine Str",
             "Heinrich Heine",
@@ -233,121 +478,332 @@
             "HeinrichHeineStraße",
             "HeinrichHeine"
         ],
-        "Hermannplatz": ["Hermannplz", "Hermanplatz"],
-        "Hohenzollernplatz": ["Hohenzollernplz"],
-        "Holzhauserstraße": ["Holzhauserstr.", "Holzhauserstrasse"],
+        "Hermannplatz": [
+            "Hermannplz",
+            "Hermanplatz"
+        ],
+        "Hohenzollernplatz": [
+            "Hohenzollernplz"
+        ],
+        "Holzhauserstraße": [
+            "Holzhauserstr.",
+            "Holzhauserstrasse"
+        ],
         "Hönow": [],
-        "Innsbrucker Platz": ["Innsbrucker", "Innsbruckerplz"],
-        "Jakob Kaiser Platz": ["Jakob Kaiser Plz", "Jakob Kaiser"],
-        "Jannowitzbrücke": ["Jannowitz"],
-        "Johannisthaler Chaussee": ["Johannisthaler Chausse", "Johannisthaler Chausse."],
+        "Innsbrucker Platz": [
+            "Innsbrucker",
+            "Innsbruckerplz"
+        ],
+        "Jakob Kaiser Platz": [
+            "Jakob Kaiser Plz",
+            "Jakob Kaiser"
+        ],
+        "Jannowitzbrücke": [
+            "Jannowitz"
+        ],
+        "Johannisthaler Chaussee": [
+            "Johannisthaler Chausse",
+            "Johannisthaler Chausse."
+        ],
         "Jungfernheide": [],
         "Kaiserdamm": [],
-        "Kaiserin-Augusta-Straße": ["Kaiserin Augusta Str", "Kaiserin Augusta", "Kaiserin Augusta Strasse"],
-        "Karl-Bonhoeffer-Nervenklinik": ["Karl Bonhoeffer"],
-        "Karl-Marx-Straße": ["Karl Marx Str", "Karl Marx Strasse"],
+        "Kaiserin-Augusta-Straße": [
+            "Kaiserin Augusta Str",
+            "Kaiserin Augusta",
+            "Kaiserin Augusta Strasse"
+        ],
+        "Karl-Bonhoeffer-Nervenklinik": [
+            "Karl Bonhoeffer"
+        ],
+        "Karl-Marx-Straße": [
+            "Karl Marx Str",
+            "Karl Marx Strasse"
+        ],
         "Kaulsdorf-Nord": [],
-        "Kienberg (Gärten der Welt)": ["Kienberg", "Gärten der Welt"],
+        "Kienberg (Gärten der Welt)": [
+            "Kienberg",
+            "Gärten der Welt"
+        ],
         "Kleistpark": [],
-        "Klosterstraße": ["Klosterstr.", "Klosterstrasse"],
-        "Kochstraße (Checkpoint Charlie)": ["Kochstr.", "Checkpoint Charlie", "Kochstrasse"],
-        "Konstanzerstraße": ["Konstanzerstr.", "Konstanzerstrasse"],
-        "Kottbusser Tor": ["Kottbusser", "Kotti"],
+        "Klosterstraße": [
+            "Klosterstr.",
+            "Klosterstrasse"
+        ],
+        "Kochstraße (Checkpoint Charlie)": [
+            "Kochstr.",
+            "Checkpoint Charlie",
+            "Kochstrasse"
+        ],
+        "Konstanzerstraße": [
+            "Konstanzerstr.",
+            "Konstanzerstrasse"
+        ],
+        "Kottbusser Tor": [
+            "Kottbusser",
+            "Kotti"
+        ],
         "Krumme Lanke": [],
-        "Kurfürstendamm": ["Kurfürstendam"],
-        "Kurfürstenstraße": ["Kurfürstenstr.", "Kurfürstenstrasse"],
-        "Kurt-Schumacher-Platz": ["Kurt Schumacher Plz", "Kurt Schumacher"],
-        "Leinestraße": ["Leinestr.", "Leinestrasse"],
-        "Leopoldplatz": ["Leopoldplz", "Leo"],
+        "Kurfürstendamm": [
+            "Kurfürstendam"
+        ],
+        "Kurfürstenstraße": [
+            "Kurfürstenstr.",
+            "Kurfürstenstrasse"
+        ],
+        "Kurt-Schumacher-Platz": [
+            "Kurt Schumacher Plz",
+            "Kurt Schumacher",
+            "Kurt Schumacher Platz",
+            "Alt-Tegel",
+            "Alt Tegel"
+        ],
+        "Leinestraße": [
+            "Leinestr.",
+            "Leinestrasse"
+        ],
+        "Leopoldplatz": [
+            "Leopoldplz",
+            "Leo"
+        ],
         "Lichtenberg": [],
-        "Lindauer Allee": ["Lindauerallee"],
+        "Lindauer Allee": [
+            "Lindauerallee"
+        ],
         "Lipschitzallee": [],
-        "Magdalenenstraße": ["Magdalenenstr.", "Magdalenenstrasse"],
-        "Märkisches Museum": ["Märkisches Mus"],
+        "Magdalenenstraße": [
+            "Magdalenenstr.",
+            "Magdalenenstrasse"
+        ],
+        "Märkisches Museum": [
+            "Märkisches Mus"
+        ],
         "Mehringdamm": [],
-        "Mendelssohn-Bartholdy-Park": ["Mendelssohn Bartholdy Park", "Mendelssohn Bartholdy"],
-        "Mierendorffplatz": ["Mierendorffplz"],
-        "Möckernbrücke": ["Möckernbrück"],
-        "Mohrenstraße": ["Mohrenstr.", "Mohrenstrasse"],
-        "Moritzplatz": ["Moritzplz"],
+        "Mendelssohn-Bartholdy-Park": [
+            "Mendelssohn Bartholdy Park",
+            "Mendelssohn Bartholdy"
+        ],
+        "Mierendorffplatz": [
+            "Mierendorffplz"
+        ],
+        "Möckernbrücke": [
+            "Möckernbrück"
+        ],
+        "Mohrenstraße": [
+            "Mohrenstr.",
+            "Mohrenstrasse"
+        ],
+        "Moritzplatz": [
+            "Moritzplz"
+        ],
         "Museumsinsel": [],
-        "Naturkundemuseum": ["Naturkunde Mus"],
-        "Nauener Platz": ["Nauenerplz"],
+        "Naturkundemuseum": [
+            "Naturkunde Mus"
+        ],
+        "Nauener Platz": [
+            "Nauenerplz"
+        ],
         "Neu Westend": [],
         "Neukölln": [],
-        "Nollendorfplatz": ["Nollendorfplz"],
+        "Nollendorfplatz": [
+            "Nollendorfplz"
+        ],
         "Olympia-Stadion": [],
-        "Onkel Toms Hütte": ["Onkel Toms"],
-        "Oranienburger Tor": ["Oranienburger"],
-        "Oskar-Helene-Heim": ["Oskar Helene"],
-        "Osloerstraße": ["Osloerstr.", "Osloerstrasse", "Osloer"],
-        "Otisstraße": ["Otisstr.", "Otisstrasse"],
+        "Onkel Toms Hütte": [
+            "Onkel Toms"
+        ],
+        "Oranienburger Tor": [
+            "Oranienburger"
+        ],
+        "Oskar-Helene-Heim": [
+            "Oskar Helene"
+        ],
+        "Osloerstraße": [
+            "Osloerstr.",
+            "Osloerstrasse",
+            "Osloer"
+        ],
+        "Otisstraße": [
+            "Otisstr.",
+            "Otisstrasse"
+        ],
         "Pankow": [],
-        "Pankstraße": ["Pankstr.", "Pankstrasse"],
-        "Paracelsus-Bad": [""],
-        "Paradestraße": ["Paradestr.", "Paradestrasse"],
-        "Parchimer Allee": ["Parchimerallee"],
-        "Paulsternstraße": ["Paulsternstr.", "Paulsternstrasse"],
+        "Pankstraße": [
+            "Pankstr.",
+            "Pankstrasse"
+        ],
+        "Paracelsus-Bad": [
+            ""
+        ],
+        "Paradestraße": [
+            "Paradestr.",
+            "Paradestrasse"
+        ],
+        "Parchimer Allee": [
+            "Parchimerallee"
+        ],
+        "Paulsternstraße": [
+            "Paulsternstr.",
+            "Paulsternstrasse"
+        ],
         "Platz der Luftbrücke": [],
         "Podbielskiallee": [],
-        "Potsdamer Platz": ["Potsdamerplz"],
-        "Prinzenstraße": ["Prinzenstr.", "Prinzenstrasse"],
+        "Potsdamer Platz": [
+            "Potsdamerplz"
+        ],
+        "Prinzenstraße": [
+            "Prinzenstr.",
+            "Prinzenstrasse"
+        ],
         "Rathaus Neukölln": [],
         "Rathaus Reinickendorf": [],
         "Rathaus Schöneberg": [],
         "Rathaus Spandau": [],
-        "Rathaus Steglitz": ["Rathaus Stglz", "Rathaus Stz"],
+        "Rathaus Steglitz": [
+            "Rathaus Stglz",
+            "Rathaus Stz"
+        ],
         "Rehberge": [],
-        "Reinickendorferstraße": ["Reinickendorferstr.", "Reinickendorferstrasse"],
-        "Residenzstraße": ["Residenzstr.", "Residenzstrasse"],
-        "Richard-Wagner-Platz": ["Richard Wagner Plz", "Richard Wagner"],
+        "Reinickendorferstraße": [
+            "Reinickendorferstr.",
+            "Reinickendorferstrasse"
+        ],
+        "Residenzstraße": [
+            "Residenzstr.",
+            "Residenzstrasse"
+        ],
+        "Richard-Wagner-Platz": [
+            "Richard Wagner Plz",
+            "Richard Wagner"
+        ],
         "Rohrdamm": [],
-        "Rosa-Luxemburg-Platz": ["Rosa Luxemburg Plz", "Rosa Luxemburg"],
+        "Rosa-Luxemburg-Platz": [
+            "Rosa Luxemburg Plz",
+            "Rosa Luxemburg"
+        ],
         "Rotes Rathaus": [],
-        "Rüdesheimer Platz": ["Rüdesheimerplz"],
+        "Rüdesheimer Platz": [
+            "Rüdesheimerplz"
+        ],
         "Rudow": [],
         "Ruhleben": [],
-        "Samariterstraße": ["Samariterstr.", "Samariterstrasse"],
-        "Scharnweberstraße": ["Scharnweberstr.", "Scharnweberstrasse"],
-        "Schillingstraße": ["Schillingstr.", "Schillingstrasse"],
-        "Schlesisches Tor": ["Schlesischestr."],
-        "Schloßstraße": ["Schloßstr.", "Schloßstrasse"],
-        "Schönhauser Allee": ["Schönhauser"],
-        "Schönleinstraße": ["Schönleinstr.", "Schönleinstrasse"],
-        "Schwartzkopffstraße": ["Schwartzkopffstr.", "Schwartzkopffstrasse"],
-        "Senefelderplatz": ["Senefelderplz"],
+        "Samariterstraße": [
+            "Samariterstr.",
+            "Samariterstrasse"
+        ],
+        "Scharnweberstraße": [
+            "Scharnweberstr.",
+            "Scharnweberstrasse"
+        ],
+        "Schillingstraße": [
+            "Schillingstr.",
+            "Schillingstrasse"
+        ],
+        "Schlesisches Tor": [
+            "Schlesischestr."
+        ],
+        "Schloßstraße": [
+            "Schloßstr.",
+            "Schloßstrasse"
+        ],
+        "Schönhauser Allee": [
+            "Schönhauser"
+        ],
+        "Schönleinstraße": [
+            "Schönleinstr.",
+            "Schönleinstrasse"
+        ],
+        "Schwartzkopffstraße": [
+            "Schwartzkopffstr.",
+            "Schwartzkopffstrasse"
+        ],
+        "Senefelderplatz": [
+            "Senefelderplz"
+        ],
         "Siemensdamm": [],
-        "Sophie-Charlotte-Platz": ["Sophie Charlotte Plz", "Sophie Charlotte"],
-        "Spichernstraße": ["Spichernstr.", "Spichernstrasse"],
+        "Sophie-Charlotte-Platz": [
+            "Sophie Charlotte Plz",
+            "Sophie Charlotte"
+        ],
+        "Spichernstraße": [
+            "Spichernstr.",
+            "Spichernstrasse"
+        ],
         "Spittelmarkt": [],
         "Stadtmitte": [],
-        "Strausberger Platz": ["Strausbergerplz"],
+        "Strausberger Platz": [
+            "Strausbergerplz"
+        ],
         "Südstern": [],
         "Tempelhof": [],
-        "Theodor-Heuss-Platz": ["Theodor Heuss Plz", "Theodor Heuss"],
+        "Theodor-Heuss-Platz": [
+            "Theodor Heuss Plz",
+            "Theodor Heuss"
+        ],
         "Tierpark": [],
-        "Turmstraße": ["Turmstr.", "Turmstrasse"],
-        "Uhlandstraße": ["Uhlandstr.", "Uhlandstrasse"],
-        "Ullsteinstraße": ["Ullsteinstr.", "Ullsteinstrasse"],
+        "Turmstraße": [
+            "Turmstr.",
+            "Turmstrasse"
+        ],
+        "Uhlandstraße": [
+            "Uhlandstr.",
+            "Uhlandstrasse"
+        ],
+        "Ullsteinstraße": [
+            "Ullsteinstr.",
+            "Ullsteinstrasse"
+        ],
         "Unter den Linden": [],
-        "Viktoria-Luise-Platz": ["Viktoria Luise Plz", "Viktoria Luise"],
-        "Vinetastraße": ["Vinetastr.", "Vinetastrasse"],
-        "Voltastraße": ["Voltastr.", "Voltastrasse"],
-        "Walther-Schreiber-Platz": ["Walther Schreiber Plz", "Walther Schreiber"],
-        "Warschauerstraße": ["Warschauer", "Warschauerstr.", "Warschauerstrasse"],
+        "Viktoria-Luise-Platz": [
+            "Viktoria Luise Plz",
+            "Viktoria Luise"
+        ],
+        "Vinetastraße": [
+            "Vinetastr.",
+            "Vinetastrasse"
+        ],
+        "Voltastraße": [
+            "Voltastr.",
+            "Voltastrasse"
+        ],
+        "Walther-Schreiber-Platz": [
+            "Walther Schreiber Plz",
+            "Walther Schreiber"
+        ],
+        "Warschauerstraße": [
+            "Warschauer",
+            "Warschauerstr.",
+            "Warschauerstrasse"
+        ],
         "Weberwiese": [],
         "Wedding": [],
-        "Weinmeisterstraße": ["Weinmeisterstr.", "Weinmeisterstrasse"],
+        "Weinmeisterstraße": [
+            "Weinmeisterstr.",
+            "Weinmeisterstrasse"
+        ],
         "Westhafen": [],
         "Westphalweg": [],
-        "Wilmersdorferstraße": ["Wilmersdorferstr.", "Wilmersdorferstrasse", "Wilmersdorf"],
+        "Wilmersdorferstraße": [
+            "Wilmersdorferstr.",
+            "Wilmersdorferstrasse",
+            "Wilmersdorf"
+        ],
         "Wittenau": [],
-        "Wittenbergplatz": ["Wittenbergplz"],
+        "Wittenbergplatz": [
+            "Wittenbergplz"
+        ],
         "Wuhletal": [],
         "Wutzkyallee": [],
-        "Yorckstraße": ["Yorcksstrasse", "Yorcksstr.", "Yorcksstr."],
+        "Yorckstraße": [
+            "Yorcksstrasse",
+            "Yorcksstr.",
+            "Yorcksstr."
+        ],
         "Zitadelle": [],
-        "Zoologischer Garten": ["Zoo"],
-        "Zwickauer Damm": ["Zwickauer"]
+        "Zoologischer Garten": [
+            "Zoo"
+        ],
+        "Zwickauer Damm": [
+            "Zwickauer"
+        ]
     }
 }


### PR DESCRIPTION
## Describe the issue:
The U6 is only going to Kurt-Schumacher-Platz but people keep writing that Alt-Tegel as direction, which caused the NLP Bot to be confused and misslabel the direction.

## Explain how you solved the issue:
I added Alt-Tegel as a synonym for Kurt-Schumacher-Platz so now when trying to find the best match from the possible stations it will find Alt-Tegel and set the direction to Kurt-Schumacher-Platz.

## Additional notes or considerations:
- I also added a check so that before sending a bug report the status has to be something else than dev, inorder to avoid getting spammed with messages when working with the backend locally.
