### PR TITLE
refactor: only show `LegalDisclaimer` once a week

### DIFF
--- a/packages/frontend/public/locales/de.json
+++ b/packages/frontend/public/locales/de.json
@@ -11,13 +11,15 @@
         "activeUsageDescription": "Ich verstehe, dass die aktive Nutzung der App während der Fahrt andere Fahrgäste stören und gegen die Nutzungsbedingungen des Verkehrsbetriebs verstoßen kann.",
         "confirm": "Ich bestätige",
         "impressum": "Impressum",
-        "privacy": "Datenschutz"
+        "privacy": "Datenschutz",
+        "saved": "Die Bestätigung wird in Ihrem Browser gespeichert."
     },
     "UtilModal": {
         "title": "Informationen",
         "feedback-button": "Kontakt & Feedback",
         "impressum": "Impressum",
-        "privacy": "Datenschutz"
+        "privacy": "Datenschutz",
+        "terms": "Nutzungsbedingungen"
     },
     "FeedbackModal": {
         "title": "Sende dein Feedback an:",

--- a/packages/frontend/public/locales/en.json
+++ b/packages/frontend/public/locales/en.json
@@ -11,13 +11,15 @@
         "activeUsageDescription": "I understand that the active use of the app during my journey can disturb other passengers and violate the terms of use of the public transport operator.",
         "confirm": "I confirm",
         "impressum": "Legal notice",
-        "privacy": "Privacy"
+        "privacy": "Privacy",
+        "saved": "Your confirmation will be saved to your browser's local storage."
     },
     "UtilModal": {
         "title": "Information",
         "feedback-button": "Contact & Feedback",
         "impressum": "Legal notice",
-        "privacy": "Privacy"
+        "privacy": "Privacy",
+        "terms": "Terms of use"
     },
     "FeedbackModal": {
         "title": "Send your feedback to:",

--- a/packages/frontend/src/components/Modals/LegalDisclaimer/LegalDisclaimer.tsx
+++ b/packages/frontend/src/components/Modals/LegalDisclaimer/LegalDisclaimer.tsx
@@ -28,6 +28,7 @@ const LegalDisclaimer: React.FC<LegalDisclaimerProps> = ({ closeModal, openAnima
                             <p>{t('LegalDisclaimer.activeUsageDescription')}</p>
                         </li>
                     </ol>
+                    <p>{t('LegalDisclaimer.saved')}</p>
                 </section>
             </div>
             <div className="footer">

--- a/packages/frontend/src/components/Modals/UtilModal/UtilModal.css
+++ b/packages/frontend/src/components/Modals/UtilModal/UtilModal.css
@@ -20,7 +20,6 @@
 
 .util-modal ul {
     position: relative;
-    width: 65%;
     max-width: 300px;
     margin-top: var(--margin-m);
     margin-right: 0;
@@ -40,7 +39,6 @@
     padding: 0;
     margin: 0 var(--margin-s) 0 0;
     flex-grow: 1;
-    width: 0;
 }
 
 .util-modal ul:last-of-type {
@@ -49,6 +47,11 @@
     list-style: none;
     padding: 0;
     margin: 0;
+}
+
+.util-modal li p {
+    cursor: pointer;
+    text-decoration: underline;
 }
 
 .util-modal li {

--- a/packages/frontend/src/components/Modals/UtilModal/UtilModal.tsx
+++ b/packages/frontend/src/components/Modals/UtilModal/UtilModal.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import './UtilModal.css'
 import FeedbackModal from '../FeedbackModal/FeedbackModal'
 import Backdrop from '../../../components/Miscellaneous/Backdrop/Backdrop'
+import LegalDisclaimer from '../LegalDisclaimer/LegalDisclaimer'
 
 interface UtilModalProps {
     className: string
@@ -21,6 +22,7 @@ const UtilModal: React.FC<UtilModalProps> = ({ className, children, colorTheme, 
     const { t } = useTranslation()
 
     const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false)
+    const [isLegalDisclaimerOpen, setIsLegalDisclaimerOpen] = useState(false)
 
     return (
         <>
@@ -50,6 +52,9 @@ const UtilModal: React.FC<UtilModalProps> = ({ className, children, colorTheme, 
                             <Link to="/Datenschutz">{t('UtilModal.privacy')}</Link>
                         </li>
                         <li>
+                            <p onClick={() => setIsLegalDisclaimerOpen(true)}>{t('UtilModal.terms')}</p>
+                        </li>
+                        <li>
                             <a
                                 className="github-icon"
                                 href="https://github.com/FreiFahren/FreiFahren"
@@ -66,6 +71,15 @@ const UtilModal: React.FC<UtilModalProps> = ({ className, children, colorTheme, 
                 <>
                     <FeedbackModal openAnimationClass={isFeedbackModalOpen ? 'open center-animation' : ''} />
                     <Backdrop onClick={() => setIsFeedbackModalOpen(false)} Zindex={3} />
+                </>
+            )}
+            {isLegalDisclaimerOpen && (
+                <>
+                    <LegalDisclaimer
+                        closeModal={() => setIsLegalDisclaimerOpen(false)}
+                        openAnimationClass={isLegalDisclaimerOpen ? 'open center-animation high-z-index' : ''}
+                    />
+                    <Backdrop onClick={() => setIsLegalDisclaimerOpen(false)} Zindex={3} />
                 </>
             )}
         </>

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -323,6 +323,10 @@ button .plus {
     height: 100%;
 }
 
+.high-z-index {
+    z-index: 10000;
+}
+
 .button-gray {
     background-color: var(--color-gray) !important;
 }

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -32,6 +32,7 @@ type AppUIState = {
     currentColorTheme: string
     isRiskLayerOpen: boolean
     isListModalOpen: boolean
+    isLegalDisclaimerOpen: boolean
 }
 
 const initialAppUIState: AppUIState = {
@@ -42,6 +43,7 @@ const initialAppUIState: AppUIState = {
     currentColorTheme: currentColorTheme(),
     isRiskLayerOpen: false,
     isListModalOpen: false,
+    isLegalDisclaimerOpen: false,
 }
 
 function App() {
@@ -137,13 +139,19 @@ function App() {
     }
 
     function closeLegalDisclaimer() {
-        setAppUIState({ ...appUIState, isFirstOpen: false, isStatsPopUpOpen: true })
         localStorage.setItem('legalDisclaimerAcceptedAt', new Date().toISOString())
+        setAppUIState({ ...appUIState, isFirstOpen: false, isStatsPopUpOpen: true })
     }
+
+    useEffect(() => {
+        if (!shouldShowLegalDisclaimer()) {
+            setAppUIState({ ...appUIState, isFirstOpen: false, isStatsPopUpOpen: true })
+        }
+    }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
         <div className="App">
-            {appUIState.isFirstOpen && appMounted && shouldShowLegalDisclaimer() && (
+            {appMounted && shouldShowLegalDisclaimer() && (
                 <>
                     <LegalDisclaimer
                         openAnimationClass={appUIState.isFirstOpen ? 'open center-animation' : ''}

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -56,10 +56,6 @@ function App() {
         setAppUIState((appUIState) => ({ ...appUIState, formSubmitted: !appUIState.formSubmitted }))
     }
 
-    function closeLegalDisclaimer() {
-        setAppUIState({ ...appUIState, isFirstOpen: false, isStatsPopUpOpen: true })
-    }
-
     const {
         isOpen: isUtilOpen,
         isAnimatingOut: isUtilAnimatingOut,
@@ -129,9 +125,25 @@ function App() {
         }))
     }
 
+    const shouldShowLegalDisclaimer = (): boolean => {
+        const legalDisclaimerAcceptedAt = localStorage.getItem('legalDisclaimerAcceptedAt')
+        if (!legalDisclaimerAcceptedAt) return true
+
+        const lastAcceptedDate = new Date(legalDisclaimerAcceptedAt)
+        const currentDate = new Date()
+        const oneWeek = 7 * 24 * 60 * 60 * 1000 // One week in milliseconds
+
+        return currentDate.getTime() - lastAcceptedDate.getTime() > oneWeek
+    }
+
+    function closeLegalDisclaimer() {
+        setAppUIState({ ...appUIState, isFirstOpen: false, isStatsPopUpOpen: true })
+        localStorage.setItem('legalDisclaimerAcceptedAt', new Date().toISOString())
+    }
+
     return (
         <div className="App">
-            {appUIState.isFirstOpen && appMounted && (
+            {appUIState.isFirstOpen && appMounted && shouldShowLegalDisclaimer() && (
                 <>
                     <LegalDisclaimer
                         openAnimationClass={appUIState.isFirstOpen ? 'open center-animation' : ''}


### PR DESCRIPTION
## Describe the issue:
It was annoying to close the legal disclaimer every time.

## Explain how you solved the issue:
- I saved the last time that the user has accepted the legal disclaimer in the localstorage
- It will only show the modal if it was accepted more than a week ago
- I made the disclaimer readable under: "Terms and Services"

## Additional notes or considerations:
- Accepting the legal disclaimer is a bit hacky the way it is made sure that the statsPopUp will open and the markers will be visible
