### PR TITLE
fix: adjust list max-height

### DIFF
--- a/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.tsx
+++ b/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.tsx
@@ -126,7 +126,7 @@ const MarkerModal: React.FC<MarkerModalProps> = ({ className, children, selected
                 setDisclaimerMessage(disclaimerWithLink)
                 setIsDisclaimerVisible(true)
             }, TRANSITION_DURATION)
-        }, 5 * 1000)
+        }, 2.5 * 1000)
 
         return () => clearTimeout(timer)
     }, [disclaimerWithLink])

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
@@ -73,8 +73,8 @@
     border: none;
     cursor: pointer;
     min-width: 20px;
-    width: 20px;
-    height: 20px;
+    width: 30px;
+    height: 30px;
     padding: 0;
     outline: none;
 }
@@ -102,7 +102,7 @@
 }
 
 .clustered-report-item-list.expanded {
-    max-height: 1000px;
+    max-height: 2000px;
     transition: max-height var(--transition-long) ease-in;
 }
 .clustered-report-item-list .inner-list {


### PR DESCRIPTION
## Describe the issue:
The clustered item list had a max-height of 1000px this caused the list to be cut off when expanding a very long list.

## Explain how you solved the issue:
I increased the max-height to 2000px this should be sufficient as the U8 is 1300px long on a busy day.
I also made the expand button easier to click and decreased the time until the next slide on the Marker takes.
## Additional notes or considerations:
