### PR TITLE
feat: Show all of the lines in the risk section

### DIFF
--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
@@ -201,7 +201,7 @@ section.summary .risk h2 {
 }
 
 .risk-grid {
-    min-height: 174px;
+    min-height: 100px;
 }
 
 .summary .lines > div:last-of-type .clustered-report-item {

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
@@ -131,16 +131,33 @@ section.summary .risk h2 {
 .risk-grid {
     display: flex;
     flex-direction: column;
-    overflow-x: auto;
 }
 
 .risk-grid-item {
+    width: auto;
     justify-content: left;
+    margin-top: var(--margin-m);
+    overflow-x: auto;
+    display: flex;
+    padding-bottom: var(--padding-xs);
+}
+
+.risk-grid-item > div {
+    flex-shrink: 0;
+    margin-right: var(--margin-m);
+}
+
+.risk-grid-item > div:last-child {
+    margin-right: 0;
+}
+
+.risk-grid-item:first-child {
+    margin-top: 0;
 }
 
 .risk-line {
     text-align: center;
-    width: 85px;
+    width: 50px;
     height: 65px;
     margin-right: var(--margin-m);
     border-radius: var(--borderRadius-small);
@@ -175,8 +192,8 @@ section.summary .risk h2 {
     filter: none;
     margin: auto 0;
     align-self: center;
-    height: 25px;
-    width: 25px;
+    height: 20px;
+    width: 20px;
 }
 
 .lines {

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
@@ -129,48 +129,52 @@ section.summary .risk h2 {
 }
 
 .risk-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: var(--margin-l);
+    display: flex;
+    flex-direction: column;
+    overflow-x: auto;
 }
 
 .risk-grid-item {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
-    height: 75px;
-    background-color: white;
-    padding-left: var(--padding-xxs);
-    padding-right: var(--padding-xxs);
-    border-radius: var(--borderRadius-small);
+    justify-content: left;
 }
 
-.risk-grid-item.risk-level-0 {
+.risk-line {
+    text-align: center;
+    width: 85px;
+    height: 65px;
+    margin-right: var(--margin-m);
+    border-radius: var(--borderRadius-small);
+    display: flex;
+    flex-direction: column;
+}
+
+.risk-line.risk-level-0 {
     background-color: #7cc7ab;
 }
 
-.risk-grid-item.risk-level-1 {
+.risk-line.risk-level-1 {
     background-color: #ffe498;
 }
 
-.risk-grid-item.risk-level-2 {
+.risk-line.risk-level-2 {
     background-color: #f16c63;
 }
 
-.risk-grid-item.risk-level-3 {
+.risk-line.risk-level-3 {
     background-color: #f16c63;
 }
 
-.risk-grid-item h4.line-label {
+.risk-line h4.line-label {
     width: 100%;
     margin-top: 0;
     text-align: center;
+    padding: 0;
 }
 
-.risk-grid .risk-grid-item img {
+.risk-grid .risk-line img {
     filter: none;
     margin: auto 0;
+    align-self: center;
     height: 25px;
     width: 25px;
 }

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -195,19 +195,48 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                     <section className="risk">
                         <h2>{t('ReportsModal.risk')}</h2>
                         <div className="risk-grid">
-                            {Array.from(riskLines).map(([line, riskLevel]) => (
-                                <div
-                                    key={line}
-                                    className={`risk-grid-item risk-level-${riskLevel}`}
-                                    onClick={() => closeModal()}
-                                >
-                                    <img
-                                        src={`/icons/risk-${riskLevel}.svg`}
-                                        alt={`Icon for risk level ${riskLevel}`}
-                                    />
-                                    <h4 className={`${line} line-label`}>{line}</h4>
-                                </div>
-                            ))}
+                            <div className="risk-grid-item align-child-on-line">
+                                {Array.from(riskLines.entries())
+                                    .filter(([, level]) => level === 2 || level === 3)
+                                    .map(([line, level]) => (
+                                        <div
+                                            key={line}
+                                            className={`risk-line risk-level-${level}`}
+                                            onClick={() => closeModal()}
+                                        >
+                                            <img src={`/icons/risk-${level}.svg`} />
+                                            <h4 className={`line-label ${line}`}>{line}</h4>
+                                        </div>
+                                    ))}
+                            </div>
+                            <div className="risk-grid-item align-child-on-line">
+                                {Array.from(riskLines.entries())
+                                    .filter(([, level]) => level === 1)
+                                    .map(([line, level]) => (
+                                        <div
+                                            key={line}
+                                            className={`risk-line risk-level-${level}`}
+                                            onClick={() => closeModal()}
+                                        >
+                                            <img src={`/icons/risk-${level}.svg`} />
+                                            <h4 className={`line-label ${line}`}>{line}</h4>
+                                        </div>
+                                    ))}
+                            </div>
+                            <div className="risk-grid-item align-child-on-line">
+                                {Array.from(riskLines.entries())
+                                    .filter(([, level]) => level === 0)
+                                    .map(([line, level]) => (
+                                        <div
+                                            key={line}
+                                            className={`risk-line risk-level-${level}`}
+                                            onClick={() => closeModal()}
+                                        >
+                                            <img src={`/icons/risk-${level}.svg`} />
+                                            <h4 className={`line-label ${line}`}>{line}</h4>
+                                        </div>
+                                    ))}
+                            </div>
                         </div>
                     </section>
                 </section>

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -183,7 +183,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                     <section className="risk">
                         <h2>{t('ReportsModal.risk')}</h2>
                         <div className="risk-grid">
-                            <div className="risk-grid-item align-child-on-line">
+                            <div className="risk-grid-item">
                                 {Array.from(riskLines.entries())
                                     .filter(([, level]) => level === 2 || level === 3)
                                     .map(([line, level]) => (
@@ -197,7 +197,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                         </div>
                                     ))}
                             </div>
-                            <div className="risk-grid-item align-child-on-line">
+                            <div className="risk-grid-item">
                                 {Array.from(riskLines.entries())
                                     .filter(([, level]) => level === 1)
                                     .map(([line, level]) => (
@@ -211,7 +211,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                         </div>
                                     ))}
                             </div>
-                            <div className="risk-grid-item align-child-on-line">
+                            <div className="risk-grid-item">
                                 {Array.from(riskLines.entries())
                                     .filter(([, level]) => level === 0)
                                     .map(([line, level]) => (

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -131,29 +131,17 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                 lineScores.set(line, score)
             }
         })
-        return new Map(
-            Array.from(lineScores.entries())
-                .sort((a, b) => b[1] - a[1])
-                .slice(0, 8)
-        )
+        return new Map(Array.from(lineScores.entries()).sort((a, b) => b[1] - a[1]))
     }
 
     useEffect(() => {
         if (segmentRiskData && segmentRiskData.segment_colors) {
             const riskMap = extractMostRiskLines(segmentRiskData.segment_colors)
-            if (riskMap.size < 8) {
-                // Fill remaining slots with lines from sortedLinesWithReports
-                const remainingLines = Array.from(sortedLinesWithReports.keys())
-                    .filter((line) => !riskMap.has(line))
-                    .slice(0, 8 - riskMap.size)
-                remainingLines.forEach((line) => riskMap.set(line, 0))
-            } else if (riskMap.size > 8) {
-                // remove the least risky lines
-                const leastRiskLines = Array.from(riskMap.entries())
-                    .sort((a, b) => a[1] - b[1])
-                    .slice(0, riskMap.size - 8)
-                leastRiskLines.forEach(([line]) => riskMap.delete(line))
-            }
+            Array.from(sortedLinesWithReports.entries()).forEach(([line]) => {
+                if (!riskMap.has(line)) {
+                    riskMap.set(line, 0)
+                }
+            })
             setRiskLines(riskMap)
         }
     }, [segmentRiskData, sortedLinesWithReports])

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -183,48 +183,54 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                     <section className="risk">
                         <h2>{t('ReportsModal.risk')}</h2>
                         <div className="risk-grid">
-                            <div className="risk-grid-item">
-                                {Array.from(riskLines.entries())
-                                    .filter(([, level]) => level === 2 || level === 3)
-                                    .map(([line, level]) => (
-                                        <div
-                                            key={line}
-                                            className={`risk-line risk-level-${level}`}
-                                            onClick={() => closeModal()}
-                                        >
-                                            <img src={`/icons/risk-${level}.svg`} alt="Icon to show risk level" />
-                                            <h4 className={`line-label ${line}`}>{line}</h4>
-                                        </div>
-                                    ))}
-                            </div>
-                            <div className="risk-grid-item">
-                                {Array.from(riskLines.entries())
-                                    .filter(([, level]) => level === 1)
-                                    .map(([line, level]) => (
-                                        <div
-                                            key={line}
-                                            className={`risk-line risk-level-${level}`}
-                                            onClick={() => closeModal()}
-                                        >
-                                            <img src={`/icons/risk-${level}.svg`} alt="Icon to show risk level" />
-                                            <h4 className={`line-label ${line}`}>{line}</h4>
-                                        </div>
-                                    ))}
-                            </div>
-                            <div className="risk-grid-item">
-                                {Array.from(riskLines.entries())
-                                    .filter(([, level]) => level === 0)
-                                    .map(([line, level]) => (
-                                        <div
-                                            key={line}
-                                            className={`risk-line risk-level-${level}`}
-                                            onClick={() => closeModal()}
-                                        >
-                                            <img src={`/icons/risk-${level}.svg`} alt="Icon to show risk level" />
-                                            <h4 className={`line-label ${line}`}>{line}</h4>
-                                        </div>
-                                    ))}
-                            </div>
+                            {Array.from(riskLines.entries()).some(([, level]) => level === 2 || level === 3) && (
+                                <div className="risk-grid-item">
+                                    {Array.from(riskLines.entries())
+                                        .filter(([, level]) => level === 2 || level === 3)
+                                        .map(([line, level]) => (
+                                            <div
+                                                key={line}
+                                                className={`risk-line risk-level-${level}`}
+                                                onClick={() => closeModal()}
+                                            >
+                                                <img src={`/icons/risk-${level}.svg`} alt="Icon to show risk level" />
+                                                <h4 className={`line-label ${line}`}>{line}</h4>
+                                            </div>
+                                        ))}
+                                </div>
+                            )}
+                            {Array.from(riskLines.entries()).some(([, level]) => level === 1) && (
+                                <div className="risk-grid-item">
+                                    {Array.from(riskLines.entries())
+                                        .filter(([, level]) => level === 1)
+                                        .map(([line, level]) => (
+                                            <div
+                                                key={line}
+                                                className={`risk-line risk-level-${level}`}
+                                                onClick={() => closeModal()}
+                                            >
+                                                <img src={`/icons/risk-${level}.svg`} alt="Icon to show risk level" />
+                                                <h4 className={`line-label ${line}`}>{line}</h4>
+                                            </div>
+                                        ))}
+                                </div>
+                            )}
+                            {Array.from(riskLines.entries()).some(([, level]) => level === 0) && (
+                                <div className="risk-grid-item">
+                                    {Array.from(riskLines.entries())
+                                        .filter(([, level]) => level === 0)
+                                        .map(([line, level]) => (
+                                            <div
+                                                key={line}
+                                                className={`risk-line risk-level-${level}`}
+                                                onClick={() => closeModal()}
+                                            >
+                                                <img src={`/icons/risk-${level}.svg`} alt="Icon to show risk level" />
+                                                <h4 className={`line-label ${line}`}>{line}</h4>
+                                            </div>
+                                        ))}
+                                </div>
+                            )}
                         </div>
                     </section>
                 </section>

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -204,7 +204,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                             className={`risk-line risk-level-${level}`}
                                             onClick={() => closeModal()}
                                         >
-                                            <img src={`/icons/risk-${level}.svg`} />
+                                            <img src={`/icons/risk-${level}.svg`} alt="Icon to show risk level" />
                                             <h4 className={`line-label ${line}`}>{line}</h4>
                                         </div>
                                     ))}
@@ -218,7 +218,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                             className={`risk-line risk-level-${level}`}
                                             onClick={() => closeModal()}
                                         >
-                                            <img src={`/icons/risk-${level}.svg`} />
+                                            <img src={`/icons/risk-${level}.svg`} alt="Icon to show risk level" />
                                             <h4 className={`line-label ${line}`}>{line}</h4>
                                         </div>
                                     ))}
@@ -232,7 +232,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                             className={`risk-line risk-level-${level}`}
                                             onClick={() => closeModal()}
                                         >
-                                            <img src={`/icons/risk-${level}.svg`} />
+                                            <img src={`/icons/risk-${level}.svg`} alt="Icon to show risk level" />
                                             <h4 className={`line-label ${line}`}>{line}</h4>
                                         </div>
                                     ))}


### PR DESCRIPTION
## Describe the issue:
The risk section was quite useless when there were a lot of inspectors because a lot of lines would be at highest risk, this caused valuable info to be lost because we were only showing the top 8 lines with the highest risk. Also users dont care about the line with the highest risk they just seem to care about their line that they are on.

<img width="200" alt="Bildschirmfoto 2024-10-25 um 20 54 54" src="https://github.com/user-attachments/assets/9881b2ef-5e59-4ae5-b0ca-9890ca9054f9">

## Explain how you solved the issue:
I changed the risk section to show three rows with all of the lines that correspond to this risk level.
<img width="200" alt="Bildschirmfoto 2024-10-25 um 20 55 43" src="https://github.com/user-attachments/assets/09fcee71-316b-4cb5-8a97-3e012f55428a">

## Additional notes or considerations:
