### PR TITLE
refactor: avoid showing dropdown when there is only one item

### DIFF
--- a/packages/frontend/src/components/Modals/ReportsModal/ClusteredReportItem.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ClusteredReportItem.tsx
@@ -29,10 +29,12 @@ const ClusteredReportItem: React.FC<ClusteredReportItemProps> = ({ inspectors })
                 <div className="title-report-item">
                     <ReportItem ticketInspector={inspectorsWithoutDirection[0]} currentTime={currentTime} />
                 </div>
-                <button
-                    className={isListExpanded ? 'expanded' : ''}
-                    onClick={() => setIsListExpanded(!isListExpanded)}
-                />
+                {inspectorsWithoutDirection.length > 1 && (
+                    <button
+                        className={isListExpanded ? 'expanded' : ''}
+                        onClick={() => setIsListExpanded(!isListExpanded)}
+                    />
+                )}
             </div>
             <div className={`clustered-report-item-list list-modal ${isListExpanded ? 'expanded' : ''}`}>
                 {isListExpanded &&


### PR DESCRIPTION
We were showing the dropdown button at all times, this was causing strange behaviour in which even if there was nothing to expand to the dropdown button would be visible

