### PR TITLE
feat: tabs stick to the top

### DIFF
--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
@@ -1,5 +1,15 @@
 .reports-modal {
+    padding-top: 0;
     max-height: 70vh;
+}
+
+.reports-modal > section.tabs {
+    margin-top: var(--margin-m);
+    position: sticky;
+    top: 0;
+    background-color: var(--color-background);
+    padding: var(--padding-s) 0;
+    width: 100%;
 }
 
 .reports-modal > section:first-child {
@@ -201,7 +211,7 @@ section.summary .risk h2 {
 }
 
 .risk-grid {
-    min-height: 100px;
+    min-height: 69px;
 }
 
 .summary .lines > div:last-of-type .clustered-report-item {

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -164,7 +164,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
 
     return (
         <div className={`reports-modal modal container ${className}`}>
-            <section className="align-child-on-line">
+            <section className="tabs align-child-on-line">
                 {tabs.map((tab) => (
                     <button
                         key={tab}


### PR DESCRIPTION
before it was difficult to switch the tabs if you were scrolling the list becasue you had to scroll back to the top.

now that the tabs are sticky to the top of the modal you can always switch the tabs.

