### PR TITLE
fix: avoid showing most recent line report in top 5

### DIFF
--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -98,16 +98,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                 lineReports.set(line, [...(lineReports.get(line) || []), inspector])
             }
 
-            // Sort lines by their latest report timestamp (first item in each array)
-            return new Map(
-                Array.from(lineReports.entries())
-                    .sort((a, b) => {
-                        const aTime = new Date(a[1][0].timestamp).getTime()
-                        const bTime = new Date(b[1][0].timestamp).getTime()
-                        return bTime - aTime
-                    })
-                    .map(([line, reports]) => [line, reports])
-            )
+            return new Map(Array.from(lineReports.entries()).sort((a, b) => b[1].length - a[1].length))
         }
 
         const sortedLines = getAllLinesWithReportsSorted()
@@ -192,6 +183,11 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                         <h2>{t('ReportsModal.top5Lines')}</h2>
                         {Array.from(sortedLinesWithReports.entries())
                             .slice(0, 5)
+                            .sort(([, inspectorsA], [, inspectorsB]) => {
+                                const timestampA = new Date(inspectorsA[0].timestamp).getTime()
+                                const timestampB = new Date(inspectorsB[0].timestamp).getTime()
+                                return timestampB - timestampA // most recent first
+                            })
                             .map(([line, inspectors]) => (
                                 <ClusteredReportItem key={line} inspectors={inspectors} />
                             ))}


### PR DESCRIPTION
We were sorting all of the lines by their timestamp of the most recent report and then displaying the first 5 as the top 5. This caused issues as it would show the latest reports and not the top 5 reports but sorted by most recent.

To fix this we are now sorting the lines by the number of their reports, selecting the top 5 and then sorting them by their most recent report again.

