### PR TITLE
fix: avoid overlap of tabs and content

### DIFF
--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
@@ -4,6 +4,7 @@
 }
 
 .reports-modal > section.tabs {
+    z-index: var(--zIndex-modal);
     margin-top: var(--margin-m);
     position: sticky;
     top: 0;


### PR DESCRIPTION
The tab was fixed to the top and when scrolling down the content would visually overlap the tabs. I fixed it by increasing the z-index of the tabs to make sure that the modals content will hide behind the background of the tabs.
