### PR TITLE
feat: add a tab to see barcharts of the most common lines

### DIFF
--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -22,6 +22,7 @@
                 "react-map-gl": "^7.1.7",
                 "react-router-dom": "^6.22.3",
                 "react-scripts": "5.0.1",
+                "recharts": "^2.13.2",
                 "testcafe": "^3.5.0",
                 "typescript": "^4.9.5",
                 "typescript-eslint": "^7.2.0",
@@ -4825,6 +4826,60 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/d3-array": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+            "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+        },
+        "node_modules/@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+            "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+            "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+            "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+        },
+        "node_modules/@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+        },
         "node_modules/@types/eslint": {
             "version": "8.56.5",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.5.tgz",
@@ -7075,6 +7130,14 @@
                 "node": ">=12"
             }
         },
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7885,6 +7948,116 @@
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -7924,6 +8097,11 @@
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
             "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+        },
+        "node_modules/decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
         },
         "node_modules/dedent": {
             "version": "1.5.1",
@@ -8273,6 +8451,15 @@
             "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
             "dependencies": {
                 "utila": "~0.4"
+            }
+        },
+        "node_modules/dom-helpers": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+            "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "csstype": "^3.0.2"
             }
         },
         "node_modules/dom-serializer": {
@@ -9632,6 +9819,14 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "node_modules/fast-equals": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+            "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
         },
         "node_modules/fast-glob": {
             "version": "3.3.2",
@@ -11072,6 +11267,14 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/ip": {
@@ -20144,6 +20347,35 @@
                 "node": ">=10"
             }
         },
+        "node_modules/react-smooth": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
+            "integrity": "sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==",
+            "dependencies": {
+                "fast-equals": "^5.0.1",
+                "prop-types": "^15.8.1",
+                "react-transition-group": "^4.4.5"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/react-transition-group": {
+            "version": "4.4.5",
+            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+            "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+            "dependencies": {
+                "@babel/runtime": "^7.5.5",
+                "dom-helpers": "^5.0.1",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.6.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.6.0",
+                "react-dom": ">=16.6.0"
+            }
+        },
         "node_modules/read-cache": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -20183,6 +20415,41 @@
             "engines": {
                 "node": ">=8.10.0"
             }
+        },
+        "node_modules/recharts": {
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.13.2.tgz",
+            "integrity": "sha512-UDLGFmnsBluDIPpQb9uty0ejb+jiVI71vkki8vVsR6ZCJdgjBfKQoQfft4re99CKlTy9qjQApxCLG6TrxJkeAg==",
+            "dependencies": {
+                "clsx": "^2.0.0",
+                "eventemitter3": "^4.0.1",
+                "lodash": "^4.17.21",
+                "react-is": "^18.3.1",
+                "react-smooth": "^4.0.0",
+                "recharts-scale": "^0.4.4",
+                "tiny-invariant": "^1.3.1",
+                "victory-vendor": "^36.6.8"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/recharts-scale": {
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+            "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+            "dependencies": {
+                "decimal.js-light": "^2.4.1"
+            }
+        },
+        "node_modules/recharts/node_modules/react-is": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
         },
         "node_modules/recursive-readdir": {
             "version": "2.2.3",
@@ -22676,6 +22943,11 @@
                 "node": ">= 0.12"
             }
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+        },
         "node_modules/tinyqueue": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
@@ -23649,6 +23921,27 @@
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/victory-vendor": {
+            "version": "36.9.2",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+            "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+            "dependencies": {
+                "@types/d3-array": "^3.0.3",
+                "@types/d3-ease": "^3.0.0",
+                "@types/d3-interpolate": "^3.0.1",
+                "@types/d3-scale": "^4.0.2",
+                "@types/d3-shape": "^3.1.0",
+                "@types/d3-time": "^3.0.0",
+                "@types/d3-timer": "^3.0.0",
+                "d3-array": "^3.1.6",
+                "d3-ease": "^3.0.1",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "d3-time": "^3.0.0",
+                "d3-timer": "^3.0.1"
             }
         },
         "node_modules/void-elements": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,6 +18,7 @@
         "react-map-gl": "^7.1.7",
         "react-router-dom": "^6.22.3",
         "react-scripts": "5.0.1",
+        "recharts": "^2.13.2",
         "testcafe": "^3.5.0",
         "typescript": "^4.9.5",
         "typescript-eslint": "^7.2.0",

--- a/packages/frontend/public/locales/de.json
+++ b/packages/frontend/public/locales/de.json
@@ -90,6 +90,8 @@
         "risk": "aktuelles Risiko",
         "topLines": "Top Linien",
         "topStations": "Top Stationen",
-        "past24Hours": "letzte 24 Stunden"
+        "past24Hours": "letzte 24 Stunden",
+        "ofTotal": "von allen Meldungen",
+        "reports": "Meldungen"
     }
 }

--- a/packages/frontend/public/locales/de.json
+++ b/packages/frontend/public/locales/de.json
@@ -87,6 +87,9 @@
         "lines": "Linien",
         "stations": "Stationen",
         "top5Lines": "Top 5 Linien",
-        "risk": "aktuelles Risiko"
+        "risk": "aktuelles Risiko",
+        "topLines": "Top Linien",
+        "topStations": "Top Stationen",
+        "past24Hours": "letzte 24 Stunden"
     }
 }

--- a/packages/frontend/public/locales/en.json
+++ b/packages/frontend/public/locales/en.json
@@ -87,6 +87,9 @@
         "lines": "Lines",
         "stations": "Stations",
         "top5Lines": "Top 5 Lines",
-        "risk": "Current Risk"
+        "risk": "Current Risk",
+        "topLines": "Top Lines",
+        "topStations": "Top Stations",
+        "past24Hours": "Past 24 hours"
     }
 }

--- a/packages/frontend/public/locales/en.json
+++ b/packages/frontend/public/locales/en.json
@@ -90,6 +90,8 @@
         "risk": "Current Risk",
         "topLines": "Top Lines",
         "topStations": "Top Stations",
-        "past24Hours": "Past 24 hours"
+        "past24Hours": "Past 24 hours",
+        "ofTotal": "of all reports",
+        "reports": "reports"
     }
 }

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
@@ -14,7 +14,7 @@
 }
 
 .reports-modal > section:first-child {
-    margin-bottom: var(--margin-m);
+    margin-bottom: var(--margin-s);
 }
 
 .reports-modal > section > button {

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
@@ -223,3 +223,7 @@ section.summary .risk h2 {
 .custom-tooltip p {
     margin: 0;
 }
+
+.list-modal svg {
+    filter: none;
+}

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
@@ -227,3 +227,7 @@ section.summary .risk h2 {
 .list-modal svg {
     filter: none;
 }
+
+.recharts-tooltip-cursor {
+    fill: rgba(121, 120, 120, 0.1) !important;
+}

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.css
@@ -218,3 +218,8 @@ section.summary .risk h2 {
 .summary .lines > div:last-of-type .clustered-report-item {
     border-bottom: none;
 }
+
+.custom-tooltip h4,
+.custom-tooltip p {
+    margin: 0;
+}

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -274,7 +274,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                 <section className="list-modal">
                     <ResponsiveContainer
                         width="100%"
-                        height={getChartData.length * (34 + 8)} // height of bar + margin
+                        height={getChartData.length * (34 + 12)} // height of bar + margin
                     >
                         <BarChart data={getChartData} layout="vertical">
                             <XAxis type="number" hide />
@@ -292,7 +292,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                 }}
                             />
                             <Tooltip />
-                            <Bar dataKey="reports" barSize={34} fill="#8884d8" />
+                            <Bar dataKey="reports" barSize={34} fill="#8884d8" radius={[4, 4, 4, 4]} />
                         </BarChart>
                     </ResponsiveContainer>
                 </section>

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, TooltipProps } from 'recharts'
+import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent'
 
 import { useTicketInspectors } from 'src/contexts/TicketInspectorsContext'
 import { MarkerData } from 'src/utils/types'
@@ -176,6 +177,29 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
         return () => window.removeEventListener('storage', handleStorageChange)
     }, [])
 
+    const CustomTooltip: React.FC<TooltipProps<ValueType, NameType>> = ({ active, payload }) => {
+        if (!active || !payload || !payload.length) return null
+
+        const data = payload[0].payload
+        const totalReports = getChartData.reduce((sum, item) => sum + item.reports, 0)
+        const percentage = ((data.reports / totalReports) * 100).toFixed(1)
+
+        return (
+            <div
+                className="custom-tooltip"
+                style={{
+                    backgroundColor: isDarkTheme ? '#fff' : '#000',
+                    color: isDarkTheme ? '#000' : '#fff',
+                    padding: '8px',
+                    borderRadius: '4px',
+                }}
+            >
+                <h4>{`${percentage}% ${t('ReportsModal.ofTotal')}`}</h4>
+                <p>{`${data.reports} ${t('ReportsModal.reports')}`}</p>
+            </div>
+        )
+    }
+
     return (
         <div className={`reports-modal modal container ${className}`}>
             <section className="tabs align-child-on-line">
@@ -275,10 +299,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                 <section className="list-modal">
                     <h2>{t('ReportsModal.topLines')}</h2>
                     <p>{t('ReportsModal.past24Hours')}</p>
-                    <ResponsiveContainer
-                        width="100%"
-                        height={getChartData.length * (34 + 12)} // height of bar + margin
-                    >
+                    <ResponsiveContainer width="100%" height={getChartData.length * (34 + 12)}>
                         <BarChart data={getChartData} layout="vertical">
                             <XAxis type="number" hide />
                             <YAxis
@@ -295,7 +316,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                     dx: -5,
                                 }}
                             />
-                            <Tooltip />
+                            <Tooltip content={<CustomTooltip />} />
                             <Bar dataKey="reports" barSize={34} fill="#7e5330" radius={[4, 4, 4, 4]} />
                         </BarChart>
                     </ResponsiveContainer>

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -193,6 +193,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                 <section className="summary">
                     <section className="lines">
                         <h2>{t('ReportsModal.top5Lines')}</h2>
+                        <p>{t('ReportsModal.past24Hours')}</p>
                         {Array.from(sortedLinesWithReports.entries())
                             .slice(0, 5)
                             .sort(([, inspectorsA], [, inspectorsB]) => {
@@ -272,6 +273,8 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
             )}
             {currentTab === 'lines' && (
                 <section className="list-modal">
+                    <h2>{t('ReportsModal.topLines')}</h2>
+                    <p>{t('ReportsModal.past24Hours')}</p>
                     <ResponsiveContainer
                         width="100%"
                         height={getChartData.length * (34 + 12)} // height of bar + margin
@@ -289,7 +292,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                     fontSize: 16,
                                     fontWeight: 800,
                                     fill: isDarkTheme ? '#000' : '#000000',
-                                    dx: -8,
+                                    dx: -5,
                                 }}
                             />
                             <Tooltip />
@@ -300,6 +303,8 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
             )}
             {currentTab === 'stations' && (
                 <section className="list-modal">
+                    <h2>{t('ReportsModal.topStations')}</h2>
+                    <p>{t('ReportsModal.past24Hours')}</p>
                     {ticketInspectorList.map((ticketInspector) => (
                         <ReportItem
                             key={ticketInspector.station.id + ticketInspector.timestamp}

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -200,6 +200,11 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
         )
     }
 
+    const getLineColor = (line: string): string => {
+        const cssVar = `--line-${line.toLowerCase()}`
+        return getComputedStyle(document.documentElement).getPropertyValue(cssVar).trim()
+    }
+
     return (
         <div className={`reports-modal modal container ${className}`}>
             <section className="tabs align-child-on-line">
@@ -317,7 +322,20 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                 }}
                             />
                             <Tooltip content={<CustomTooltip />} />
-                            <Bar dataKey="reports" barSize={34} fill="#7e5330" radius={[4, 4, 4, 4]} />
+                            <Bar
+                                dataKey="reports"
+                                barSize={34}
+                                radius={[4, 4, 4, 4]}
+                                fill="#7e5330"
+                                name="reports"
+                                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                                shape={(props: any) => {
+                                    const { x, y, width, height } = props
+                                    const line = props.payload.line
+                                    const color = getLineColor(line)
+                                    return <rect x={x} y={y} width={width} height={height} fill={color} rx={4} ry={4} />
+                                }}
+                            />
                         </BarChart>
                     </ResponsiveContainer>
                 </section>

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -188,8 +188,8 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
             <div
                 className="custom-tooltip"
                 style={{
-                    backgroundColor: isDarkTheme ? '#fff' : '#000',
-                    color: isDarkTheme ? '#000' : '#fff',
+                    backgroundColor: isDarkTheme ? '#000' : '#fff',
+                    color: isDarkTheme ? '#fff' : '#000',
                     padding: '8px',
                     borderRadius: '4px',
                 }}
@@ -312,7 +312,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                 tick={{
                                     fontSize: 16,
                                     fontWeight: 800,
-                                    fill: isDarkTheme ? '#000' : '#000000',
+                                    fill: isDarkTheme ? '#fff' : '#000',
                                     dx: -5,
                                 }}
                             />

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -259,12 +259,8 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                 <section className="list-modal">
                     <div style={{ width: '100%', height: '400px' }}>
                         <ResponsiveContainer width="100%" height="100%">
-                            <BarChart
-                                data={getChartData}
-                                layout="vertical"
-                                margin={{ top: 5, right: 30, left: 40, bottom: 5 }}
-                            >
-                                <XAxis type="number" />
+                            <BarChart data={getChartData} layout="vertical">
+                                <XAxis type="number" hide />
                                 <YAxis type="category" dataKey="line" width={40} />
                                 <Tooltip />
                                 <Bar dataKey="reports" fill="#8884d8" barSize={20} />

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -162,15 +162,15 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
         }))
     }, [sortedLinesWithReports])
 
-    const [isDarkTheme, setIsDarkTheme] = useState<boolean>(false)
+    const [isLightTheme, setIsLightTheme] = useState<boolean>(false)
 
     useEffect(() => {
         const theme = localStorage.getItem('colorTheme')
-        setIsDarkTheme(theme === 'dark')
+        setIsLightTheme(theme === 'light')
 
         const handleStorageChange = (e: StorageEvent) => {
             if (e.key === 'theme') {
-                setIsDarkTheme(e.newValue === 'dark')
+                setIsLightTheme(e.newValue === 'dark')
             }
         }
         window.addEventListener('storage', handleStorageChange)
@@ -188,8 +188,8 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
             <div
                 className="custom-tooltip"
                 style={{
-                    backgroundColor: isDarkTheme ? '#000' : '#fff',
-                    color: isDarkTheme ? '#fff' : '#000',
+                    backgroundColor: isLightTheme ? '#fff' : '#000',
+                    color: isLightTheme ? '#000' : '#fff',
                     padding: '8px',
                     borderRadius: '4px',
                 }}
@@ -312,7 +312,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                 tick={{
                                     fontSize: 16,
                                     fontWeight: 800,
-                                    fill: isDarkTheme ? '#fff' : '#000',
+                                    fill: isLightTheme ? '#000' : '#fff',
                                     dx: -5,
                                 }}
                             />

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -24,7 +24,7 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
     const { t } = useTranslation()
     const [currentTab, setCurrentTab] = useState<TabType>('summary')
 
-    const tabs: TabType[] = ['summary', 'stations']
+    const tabs: TabType[] = ['summary', 'lines', 'stations']
 
     const handleTabChange = (tab: TabType) => {
         setCurrentTab(tab)
@@ -166,17 +166,6 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                     </button>
                 ))}
             </section>
-            {currentTab === 'stations' && (
-                <section className="list-modal">
-                    {ticketInspectorList.map((ticketInspector) => (
-                        <ReportItem
-                            key={ticketInspector.station.id + ticketInspector.timestamp}
-                            ticketInspector={ticketInspector}
-                            currentTime={currentTime}
-                        />
-                    ))}
-                </section>
-            )}
             {currentTab === 'summary' && (
                 <section className="summary">
                     <section className="lines">
@@ -256,6 +245,18 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                             )}
                         </div>
                     </section>
+                </section>
+            )}
+            {currentTab === 'lines' && <section className="list-modal"></section>}
+            {currentTab === 'stations' && (
+                <section className="list-modal">
+                    {ticketInspectorList.map((ticketInspector) => (
+                        <ReportItem
+                            key={ticketInspector.station.id + ticketInspector.timestamp}
+                            ticketInspector={ticketInspector}
+                            currentTime={currentTime}
+                        />
+                    ))}
                 </section>
             )}
         </div>

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -161,6 +161,21 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
         }))
     }, [sortedLinesWithReports])
 
+    const [isDarkTheme, setIsDarkTheme] = useState<boolean>(false)
+
+    useEffect(() => {
+        const theme = localStorage.getItem('colorTheme')
+        setIsDarkTheme(theme === 'dark')
+
+        const handleStorageChange = (e: StorageEvent) => {
+            if (e.key === 'theme') {
+                setIsDarkTheme(e.newValue === 'dark')
+            }
+        }
+        window.addEventListener('storage', handleStorageChange)
+        return () => window.removeEventListener('storage', handleStorageChange)
+    }, [])
+
     return (
         <div className={`reports-modal modal container ${className}`}>
             <section className="tabs align-child-on-line">
@@ -257,16 +272,29 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
             )}
             {currentTab === 'lines' && (
                 <section className="list-modal">
-                    <div style={{ width: '100%', height: '400px' }}>
-                        <ResponsiveContainer width="100%" height="100%">
-                            <BarChart data={getChartData} layout="vertical">
-                                <XAxis type="number" hide />
-                                <YAxis type="category" dataKey="line" width={40} />
-                                <Tooltip />
-                                <Bar dataKey="reports" fill="#8884d8" barSize={20} />
-                            </BarChart>
-                        </ResponsiveContainer>
-                    </div>
+                    <ResponsiveContainer
+                        width="100%"
+                        height={getChartData.length * (34 + 8)} // height of bar + margin
+                    >
+                        <BarChart data={getChartData} layout="vertical">
+                            <XAxis type="number" hide />
+                            <YAxis
+                                type="category"
+                                dataKey="line"
+                                width={40}
+                                interval={0}
+                                axisLine={false}
+                                tickLine={false}
+                                tick={{
+                                    fontSize: 14,
+                                    fill: isDarkTheme ? '#000' : '#000000',
+                                    dx: -10,
+                                }}
+                            />
+                            <Tooltip />
+                            <Bar dataKey="reports" barSize={34} fill="#8884d8" />
+                        </BarChart>
+                    </ResponsiveContainer>
                 </section>
             )}
             {currentTab === 'stations' && (

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -286,13 +286,14 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                 axisLine={false}
                                 tickLine={false}
                                 tick={{
-                                    fontSize: 14,
+                                    fontSize: 16,
+                                    fontWeight: 800,
                                     fill: isDarkTheme ? '#000' : '#000000',
-                                    dx: -10,
+                                    dx: -8,
                                 }}
                             />
                             <Tooltip />
-                            <Bar dataKey="reports" barSize={34} fill="#8884d8" radius={[4, 4, 4, 4]} />
+                            <Bar dataKey="reports" barSize={34} fill="#7e5330" radius={[4, 4, 4, 4]} />
                         </BarChart>
                     </ResponsiveContainer>
                 </section>

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 
 import { useTicketInspectors } from 'src/contexts/TicketInspectorsContext'
 import { MarkerData } from 'src/utils/types'
@@ -153,6 +154,13 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
         }
     }, [segmentRiskData, allLines])
 
+    const getChartData = useMemo(() => {
+        return Array.from(sortedLinesWithReports.entries()).map(([line, reports]) => ({
+            line,
+            reports: reports.length,
+        }))
+    }, [sortedLinesWithReports])
+
     return (
         <div className={`reports-modal modal container ${className}`}>
             <section className="tabs align-child-on-line">
@@ -247,7 +255,24 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                     </section>
                 </section>
             )}
-            {currentTab === 'lines' && <section className="list-modal"></section>}
+            {currentTab === 'lines' && (
+                <section className="list-modal">
+                    <div style={{ width: '100%', height: '400px' }}>
+                        <ResponsiveContainer width="100%" height="100%">
+                            <BarChart
+                                data={getChartData}
+                                layout="vertical"
+                                margin={{ top: 5, right: 30, left: 40, bottom: 5 }}
+                            >
+                                <XAxis type="number" />
+                                <YAxis type="category" dataKey="line" width={40} />
+                                <Tooltip />
+                                <Bar dataKey="reports" fill="#8884d8" barSize={20} />
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </div>
+                </section>
+            )}
             {currentTab === 'stations' && (
                 <section className="list-modal">
                     {ticketInspectorList.map((ticketInspector) => (

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -77,6 +77,32 @@
     --distance-from-edge-default: 15px;
     --button-size: 50px;
     --height-streched-button: 45px;
+
+    --line-s1: #da6ba2;
+    --line-s2: #007734;
+    --line-s3: #0066ad;
+    --line-s25: #007734;
+    --line-s26: #007734;
+    --line-s5: #eb7405;
+    --line-s41: #ad5937;
+    --line-s42: #cb6418;
+    --line-s45: #cd9c53;
+    --line-s46: #cd9c53;
+    --line-s47: #cd9c53;
+    --line-s7: #816da6;
+    --line-s75: #816da6;
+    --line-s8: #6a2;
+    --line-s85: #6a2;
+    --line-s9: #992746;
+    --line-u1: #7dad4c;
+    --line-u2: #da421e;
+    --line-u3: #16683d;
+    --line-u4: #f0d722;
+    --line-u5: #7e5330;
+    --line-u6: #8c6dab;
+    --line-u7: #528dba;
+    --line-u8: #224f86;
+    --line-u9: #f3791d;
 }
 
 :root.light {
@@ -435,103 +461,103 @@ button .plus {
 }
 
 .S1 {
-    background-color: #da6ba2;
+    background-color: var(--line-s1);
 }
 
 .S2 {
-    background-color: #007734;
+    background-color: var(--line-s2);
 }
 
 .S3 {
-    background-color: #0066ad;
+    background-color: var(--line-s3);
 }
 
 .S25 {
-    background-color: #007734;
+    background-color: var(--line-s25);
 }
 
 .S26 {
-    background-color: #007734;
+    background-color: var(--line-s26);
 }
 
 .S5 {
-    background-color: #eb7405;
+    background-color: var(--line-s5);
 }
 
 .S41 {
-    background-color: #ad5937;
+    background-color: var(--line-s41);
 }
 
 .S42 {
-    background-color: #cb6418;
+    background-color: var(--line-s42);
 }
 
 .S45 {
-    background-color: #cd9c53;
+    background-color: var(--line-s45);
 }
 
 .S46 {
-    background-color: #cd9c53;
+    background-color: var(--line-s46);
 }
 
 .S47 {
-    background-color: #cd9c53;
+    background-color: var(--line-s47);
 }
 
 .S7 {
-    background-color: #816da6;
+    background-color: var(--line-s7);
 }
 
 .S75 {
-    background-color: #816da6;
+    background-color: var(--line-s75);
 }
 
 .S8 {
-    background-color: #6a2;
+    background-color: var(--line-s8);
 }
 
 .S85 {
-    background-color: #6a2;
+    background-color: var(--line-s85);
 }
 
 .S9 {
-    background-color: #992746;
+    background-color: var(--line-s9);
 }
 
 .U1 {
-    background-color: #7dad4c;
+    background-color: var(--line-u1);
 }
 
 .U2 {
-    background-color: #da421e;
+    background-color: var(--line-u2);
 }
 
 .U3 {
-    background-color: #16683d;
+    background-color: var(--line-u3);
 }
 
 .U4 {
-    background-color: #f0d722;
+    background-color: var(--line-u4);
 }
 
 .U5 {
-    background-color: #7e5330;
+    background-color: var(--line-u5);
 }
 
 .U6 {
-    background-color: #8c6dab;
+    background-color: var(--line-u6);
 }
 
 .U7 {
-    background-color: #528dba;
+    background-color: var(--line-u7);
 }
 
 .U8 {
-    background-color: #224f86;
+    background-color: var(--line-u8);
 }
 
 .U9 {
-    background-color: #f3791d;
+    background-color: var(--line-u9);
 }
 
 .elapsed-time {


### PR DESCRIPTION
## Describe the issue:
There was little absolute way of knowing what the most common lines are on this day.

## Explain how you solved the issue:
I added a barchart where you can see the distribution of the reports per line. I used recharts to add this.
<img width="371" alt="Bildschirmfoto 2024-10-31 um 13 20 48" src="https://github.com/user-attachments/assets/d7e84b45-a53a-4ddb-a16e-d6f004c15179">

## Additional notes or considerations:
