### PR TITLE
Johan/fre 361 highlight color should be the same as in the mobile app

### DIFF
--- a/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.css
+++ b/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.css
@@ -41,9 +41,5 @@
     width: 35px;
     height: 35px;
     border: 2px solid transparent;
-}
-
-.layer-options img.active {
-    border: 2px solid var(--color-primary);
     border-radius: var(--borderRadius-medium);
 }

--- a/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
+++ b/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
@@ -55,7 +55,7 @@ const LayerSwitcher: React.FC<LayerSwitcherProps> = ({ changeLayer, isRiskLayerO
                     <img
                         src={process.env.PUBLIC_URL + '/icons/risk.png'}
                         alt="Showing how the risk layer looks like"
-                        className={isRiskLayerOpen ? 'active' : ''}
+                        className={isRiskLayerOpen ? 'selected' : ''}
                         draggable={areLayerOptionsVisible}
                     />
                     <p>{t('LayerSwitcher.risk')}</p>
@@ -66,7 +66,7 @@ const LayerSwitcher: React.FC<LayerSwitcherProps> = ({ changeLayer, isRiskLayerO
                     <img
                         src={process.env.PUBLIC_URL + '/icons/lines.png'}
                         alt="Showing how the line layer looks like"
-                        className={isRiskLayerOpen ? '' : 'active'}
+                        className={isRiskLayerOpen ? '' : 'selected'}
                         draggable={areLayerOptionsVisible}
                     />
                     <p>{t('LayerSwitcher.lines')}</p>

--- a/packages/frontend/src/components/Buttons/ReportButton/ReportButton.css
+++ b/packages/frontend/src/components/Buttons/ReportButton/ReportButton.css
@@ -8,16 +8,16 @@
     right: var(--distance-from-edge-default);
     padding: var(--padding-s);
     cursor: pointer;
+    border: 2px solid var(--color-white);
     border-radius: 50%;
     overflow: hidden;
     margin-bottom: 15px;
     z-index: var(--zIndex-button);
-    border: 2px solid #000;
 }
 
 .report-button .plus span {
     position: absolute;
-    background-color: #000;
+    background-color: var(--color-white);
     border-radius: 1px;
     box-shadow: var(--boxShadow-default);
 }

--- a/packages/frontend/src/components/Buttons/ReportButton/ReportButton.css
+++ b/packages/frontend/src/components/Buttons/ReportButton/ReportButton.css
@@ -23,7 +23,7 @@
 }
 
 .report-button .plus span:first-child {
-    height: 5px;
+    height: 4px;
     width: 50%;
     left: 25%;
     top: 50%;
@@ -31,7 +31,7 @@
 }
 
 .report-button .plus span:last-child {
-    width: 5px;
+    width: 4px;
     height: 50%;
     top: 25%;
     left: 50%;

--- a/packages/frontend/src/components/Buttons/ReportButton/ReportButton.css
+++ b/packages/frontend/src/components/Buttons/ReportButton/ReportButton.css
@@ -8,22 +8,22 @@
     right: var(--distance-from-edge-default);
     padding: var(--padding-s);
     cursor: pointer;
-    border: 2px solid var(--color-white);
     border-radius: 50%;
     overflow: hidden;
     margin-bottom: 15px;
     z-index: var(--zIndex-button);
+    border: 2px solid #000;
 }
 
 .report-button .plus span {
     position: absolute;
-    background-color: var(--color-white);
+    background-color: #000;
     border-radius: 1px;
     box-shadow: var(--boxShadow-default);
 }
 
 .report-button .plus span:first-child {
-    height: 4px;
+    height: 5px;
     width: 50%;
     left: 25%;
     top: 50%;
@@ -31,7 +31,7 @@
 }
 
 .report-button .plus span:last-child {
-    width: 4px;
+    width: 5px;
     height: 50%;
     top: 25%;
     left: 50%;

--- a/packages/frontend/src/components/Form/SelectField/SelectField.css
+++ b/packages/frontend/src/components/Form/SelectField/SelectField.css
@@ -4,7 +4,7 @@
 
 .select-field {
     display: flex;
-    border: var(--border-weak);
+    border: var(--border-default);
     border-radius: var(--borderRadius-small);
     padding: var(--padding-s);
     width: 100%;

--- a/packages/frontend/src/components/Form/SelectField/SelectField.css
+++ b/packages/frontend/src/components/Form/SelectField/SelectField.css
@@ -4,17 +4,13 @@
 
 .select-field {
     display: flex;
-    border: var(--border-default);
+    border: var(--border-weak);
     border-radius: var(--borderRadius-small);
     padding: var(--padding-s);
     width: 100%;
     height: 100%;
     box-sizing: border-box;
     transition: border var(--transition-default);
-}
-
-.selected {
-    border: 1px solid var(--incentive-blue);
 }
 
 .long-selector {

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -17,7 +17,7 @@
 
 :root {
     --color-blue: #0075ff;
-    --incentive-blue: #68f9ff;
+    --incentive-blue: #0168dd;
     --color-red: #ff0017f5;
     --color-gray: #636363;
     --color-box-text: #807f7f;
@@ -208,11 +208,7 @@ button {
 
 button[type='submit'] {
     background-color: var(--incentive-blue);
-}
-
-.light button[type='submit'],
-button.action {
-    color: #000;
+    color: var(--color-white);
 }
 
 button:hover {
@@ -225,6 +221,7 @@ button:hover {
 
 button.action {
     background-color: var(--incentive-blue);
+    color: var(--color-white);
 }
 
 button a {

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -71,7 +71,7 @@
     --text-relation-weak: 3.2%;
 
     --border-default: 2px solid #000;
-    --border-weak: 1px solid #000;
+    --border-weak: 1.5px solid #000;
     --border-marker: 3px solid #ffffff;
 
     --distance-from-edge-default: 15px;
@@ -210,6 +210,11 @@ button[type='submit'] {
     background-color: var(--incentive-blue);
 }
 
+.light button[type='submit'],
+button.action {
+    color: #000;
+}
+
 button:hover {
     filter: brightness(1.1);
 }
@@ -220,7 +225,6 @@ button:hover {
 
 button.action {
     background-color: var(--incentive-blue);
-    box-shadow: var(--boxShadow-default);
 }
 
 button a {
@@ -239,7 +243,7 @@ span {
 }
 
 .selected {
-    border: 2px solid var(--incentive-blue) !important;
+    border: 1.5px solid var(--incentive-blue) !important;
 }
 
 /* CLASS STYLES */
@@ -355,8 +359,9 @@ button .plus {
     z-index: 10000;
 }
 
-.button-gray {
+button.button-gray {
     background-color: var(--color-gray) !important;
+    color: var(--color-white) !important;
 }
 
 .dark .button-gray {

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -17,7 +17,7 @@
 
 :root {
     --color-blue: #0075ff;
-    --incentive-blue: #0168dd;
+    --incentive-blue: #68f9ff;
     --color-red: #ff0017f5;
     --color-gray: #636363;
     --color-box-text: #807f7f;
@@ -208,7 +208,6 @@ button {
 
 button[type='submit'] {
     background-color: var(--incentive-blue);
-    color: var(--color-white);
 }
 
 button:hover {
@@ -221,7 +220,6 @@ button:hover {
 
 button.action {
     background-color: var(--incentive-blue);
-    color: var(--color-white);
     box-shadow: var(--boxShadow-default);
 }
 
@@ -238,6 +236,10 @@ button:has(a) {
 
 span {
     user-select: none;
+}
+
+.selected {
+    border: 2px solid var(--incentive-blue) !important;
 }
 
 /* CLASS STYLES */


### PR DESCRIPTION
## Describe the issue:
The app used a light blue as the incentive color while the web app used a darker blue. This is an issue as it is easier to keep our styling and ui in sync.

## Explain how you solved the issue:
Before:
<img width="200" alt="Bildschirmfoto 2024-11-17 um 11 56 20" src="https://github.com/user-attachments/assets/ce15ed0f-43d9-4891-976d-0fe2864cee31">
<img width="200" alt="Bildschirmfoto 2024-11-17 um 11 56 01" src="https://github.com/user-attachments/assets/19487cfb-5169-44e1-b1b1-e12c41be1a07">
<img width="200" alt="Bildschirmfoto 2024-11-17 um 11 55 48" src="https://github.com/user-attachments/assets/3c514ef0-8f9f-4639-90d2-7b7800a7f65b">


After:
<img width="200" alt="Bildschirmfoto 2024-11-17 um 11 54 58" src="https://github.com/user-attachments/assets/2d67193c-249f-4560-98dd-b03db0f406d7">
<img width="200" alt="Bildschirmfoto 2024-11-17 um 11 55 15" src="https://github.com/user-attachments/assets/e2ac3320-9683-4433-a017-dc691c41503b">
<img width="200" alt="Bildschirmfoto 2024-11-17 um 11 54 49" src="https://github.com/user-attachments/assets/8c5380fa-c958-44e4-9ade-fe3aabf727d7">

## Additional notes or considerations:
