### PR TITLE
refactor: improved layer tracking

### DIFF
--- a/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
+++ b/packages/frontend/src/components/Buttons/LayerSwitcher/LayerSwitcher.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 
 import './LayerSwitcher.css'
 import Backdrop from '../../../../src/components/Miscellaneous/Backdrop/Backdrop'
-import { sendAnalyticsEvent } from '../../../../src/utils/analytics'
 
 interface LayerSwitcherProps {
     changeLayer: (layer: string) => void
@@ -12,23 +11,14 @@ interface LayerSwitcherProps {
 
 const LayerSwitcher: React.FC<LayerSwitcherProps> = ({ changeLayer, isRiskLayerOpen }) => {
     const { t } = useTranslation()
-
     const [areLayerOptionsVisible, setAreLayerOptionsVisible] = useState(false)
 
     const closeModalAndHighlightSelectedLayer = useCallback(
-        async (layer: string) => {
-            changeLayer(layer)
+        async (selectedLayer: string) => {
+            changeLayer(selectedLayer)
             setAreLayerOptionsVisible(false)
-
-            if (layer === 'risk' && !isRiskLayerOpen) {
-                try {
-                    await sendAnalyticsEvent('Risk Layer Opened')
-                } catch (error) {
-                    console.error('Failed to send analytics event:', error)
-                }
-            }
         },
-        [changeLayer, isRiskLayerOpen]
+        [changeLayer]
     )
 
     return (

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -132,31 +132,33 @@ function App() {
         }
     }, [initalTrackingRef])
 
-    async function changeLayer(clickedLayer: string) {
+    async function changeLayer(clickedLayer: string, source: string = 'layer switcher') {
         const previousLayer = appUIState.isRiskLayerOpen ? 'risk' : 'line'
+
+        if (previousLayer === clickedLayer) return
 
         try {
             await sendAnalyticsEvent('Layer Switch', {
                 meta: {
                     from: previousLayer,
                     to: clickedLayer,
+                    source: source,
                 },
             })
         } catch (error) {
             console.error('Failed to send layer switch analytics event:', error)
         }
 
-        setAppUIState({ ...appUIState, isRiskLayerOpen: clickedLayer === 'risk' })
+        setAppUIState((prevState) => ({
+            ...prevState,
+            isRiskLayerOpen: clickedLayer === 'risk',
+        }))
         localStorage.setItem('layer', clickedLayer)
     }
 
     function handleRiskGridItemClick() {
-        localStorage.setItem('layer', 'risk')
-        setAppUIState((prevState) => ({
-            ...prevState,
-            isListModalOpen: false,
-            isRiskLayerOpen: localStorage.getItem('layer') === 'risk',
-        }))
+        setAppUIState((prevState) => ({ ...prevState, isListModalOpen: false }))
+        changeLayer('risk', 'reports modal')
     }
 
     const shouldShowLegalDisclaimer = (): boolean => {

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 
 import Map from '../../components/Map/Map'
 import LayerSwitcher from '../../components/Buttons/LayerSwitcher/LayerSwitcher'
@@ -20,7 +20,7 @@ import { getNumberOfReportsInLast24Hours } from '../../utils/dbUtils'
 import { CloseButton } from '../../components/Buttons/CloseButton/CloseButton'
 import { highlightElement, currentColorTheme, setColorThemeInLocalStorage } from '../../utils/uiUtils'
 import { useModalAnimation } from '../../hooks/UseModalAnimation'
-import { sendSavedEvents } from '../../utils/analytics'
+import { sendAnalyticsEvent, sendSavedEvents } from '../../utils/analytics'
 
 import './App.css'
 
@@ -115,7 +115,37 @@ function App() {
         fetchReports()
     }, [appUIState])
 
-    function changeLayer(clickedLayer: string) {
+    const initalTrackingRef = useRef(false)
+    useEffect(() => {
+        if (initalTrackingRef.current) return
+
+        const initialLayer = localStorage.getItem('layer') || 'line'
+        try {
+            sendAnalyticsEvent('Initial Layer View', {
+                meta: {
+                    layer: initialLayer,
+                },
+            })
+            initalTrackingRef.current = true
+        } catch (error) {
+            console.error('Failed to send initial layer analytics event:', error)
+        }
+    }, [initalTrackingRef])
+
+    async function changeLayer(clickedLayer: string) {
+        const previousLayer = appUIState.isRiskLayerOpen ? 'risk' : 'line'
+
+        try {
+            await sendAnalyticsEvent('Layer Switch', {
+                meta: {
+                    from: previousLayer,
+                    to: clickedLayer,
+                },
+            })
+        } catch (error) {
+            console.error('Failed to send layer switch analytics event:', error)
+        }
+
         setAppUIState({ ...appUIState, isRiskLayerOpen: clickedLayer === 'risk' })
         localStorage.setItem('layer', clickedLayer)
     }


### PR DESCRIPTION
## Describe the issue:
We were only checking if the the risk layer was being changed to. This caused some issues when we have the risk layer as the default because we did not know how many people have selected it before.

## Explain how you solved the issue:
- On page load track initial layer
- When switching layer attach "from" and "to" parameter
- When switching layer attach "source" parameter to know where the switch is coming from

## Additional notes or considerations:
