### PR TITLE
refactor: better sharing

### DIFF
--- a/packages/frontend/public/locales/de.json
+++ b/packages/frontend/public/locales/de.json
@@ -71,8 +71,8 @@
         "disclaimer": "Daten vielleicht ungenau."
     },
     "Share": {
-        "title": "Schau dir diese App an",
-        "text": "Siehe wo Kontrolleure in Berlin sind",
+        "title": "Schau dir mal diese App an.",
+        "text": "Siehe, wo Kontrolleure in Berlin sind!\n\nHier ist eine Meldung:\nStation: {{station}}\nRichtung: {{direction}}\nLinie: {{line}}\n",
         "copied": "Link kopiert!"
     },
     "StatsPopUp": {

--- a/packages/frontend/public/locales/en.json
+++ b/packages/frontend/public/locales/en.json
@@ -71,8 +71,8 @@
         "disclaimer": "Data may be inaccurate."
     },
     "Share": {
-        "title": "Check out this app",
-        "text": "See where ticket inspectors are in Berlin",
+        "title": "Check out this app.",
+        "text": "See where ticket inspectors are in Berlin!\n\nHere's a report:\nStation: {{station}}\nDirection: {{direction}}\nLine: {{line}}\n",
         "copied": "Link copied to clipboard!"
     },
     "StatsPopUp": {

--- a/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.tsx
+++ b/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.tsx
@@ -74,10 +74,25 @@ const MarkerModal: React.FC<MarkerModalProps> = ({ className, children, selected
         async (e: React.MouseEvent) => {
             e.preventDefault()
             try {
+                let directionTextShare = direction.name
+                let lineTextShare = line
+                
+                if (direction.name === '') {
+                    directionTextShare = '?'
+                }
+
+                if (line === '') {
+                    lineTextShare = '?'
+                }
+
                 if (navigator.share) {
                     await navigator.share({
-                        title: t('Share.title', 'Check out this app'),
-                        text: t('Share.text', 'See where ticket inspectors are in Berlin'),
+                        title: t('Share.title'),
+                        text: t('Share.text', {
+                            station: station.name,
+                            direction: directionTextShare,
+                            line: lineTextShare,
+                        }),
                         url: window.location.href,
                     })
                     await sendAnalyticsEvent('Marker Shared', {


### PR DESCRIPTION
include station, line and direction
add a check for empty string in marker modal for line and direction
