### PR TITLE
refactor: single source of truth for line colors

### DIFF
--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -6,7 +6,7 @@ import AutocompleteInputForm from '../AutocompleteInputForm/AutocompleteInputFor
 
 import { LinesList, StationList, reportInspector } from '../../../utils/dbUtils'
 import { sendAnalyticsEvent } from '../../../utils/analytics'
-import { highlightElement, createWarningSpan } from '../../../utils/uiUtils'
+import { highlightElement, createWarningSpan, getLineColor } from '../../../utils/uiUtils'
 import { calculateDistance } from '../../../utils/mapUtils'
 import { useLocation } from '../../../contexts/LocationContext'
 import { useStationsAndLines } from '../../../contexts/StationsAndLinesContext'
@@ -328,13 +328,13 @@ const ReportForm: React.FC<ReportFormProps> = ({ closeModal, notifyParentAboutSu
                                 onSelect={handleEntitySelect}
                                 value={currentEntity}
                             >
-                                <span className="line U8">
+                                <span className="line" style={{ backgroundColor: getLineColor('U8') }}>
                                     <strong>U</strong>
                                 </span>
-                                <span className="line S2">
+                                <span className="line" style={{ backgroundColor: getLineColor('S2') }}>
                                     <strong>S</strong>
                                 </span>
-                                <span className="line M1">
+                                <span className="line" style={{ backgroundColor: getLineColor('M1') }}>
                                     <strong>M</strong>
                                 </span>
                             </SelectField>
@@ -347,7 +347,7 @@ const ReportForm: React.FC<ReportFormProps> = ({ closeModal, notifyParentAboutSu
                                 value={currentLine}
                             >
                                 {Object.keys(possibleLines).map((line) => (
-                                    <span key={line} className={`line ${line}`}>
+                                    <span key={line} className="line" style={{ backgroundColor: getLineColor(line) }}>
                                         <strong>{line}</strong>
                                     </span>
                                 ))}

--- a/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.tsx
+++ b/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.tsx
@@ -5,6 +5,7 @@ import { MarkerData } from 'src/utils/types'
 import { useElapsedTimeMessage, useStationDistanceMessage } from '../../../hooks/Messages'
 import { getStationDistance, fetchNumberOfReports } from '../../../utils/dbUtils'
 import { getNearestStation } from '../../../utils/mapUtils'
+import { getLineColor } from '../../../utils/uiUtils'
 import { useStationsAndLines } from '../../../contexts/StationsAndLinesContext'
 import Skeleton, { useSkeleton } from '../../Miscellaneous/LoadingPlaceholder/Skeleton'
 
@@ -137,7 +138,10 @@ const MarkerModal: React.FC<MarkerModalProps> = ({ className, children, selected
             <h1>{station.name}</h1>
             {(direction.name !== '' || line !== '') && (
                 <h2>
-                    <span className={`line-label ${line}`}>{line}</span> {direction.name}
+                    <span className="line-label" style={{ backgroundColor: getLineColor(line) }}>
+                        {line}
+                    </span>{' '}
+                    {direction.name}
                 </h2>
             )}
             <div>

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportItem.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportItem.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { MarkerData } from 'src/utils/types'
 import { useElapsedTimeMessage } from 'src/hooks/Messages'
-
+import { getLineColor } from 'src/utils/uiUtils'
 const ReportItem: React.FC<{ ticketInspector: MarkerData; currentTime: number }> = ({
     ticketInspector,
     currentTime,
@@ -17,7 +17,9 @@ const ReportItem: React.FC<{ ticketInspector: MarkerData; currentTime: number }>
         <div key={ticketInspector.station.id + ticketInspector.timestamp} className="report-item">
             <div className="align-child-on-line">
                 {ticketInspector.line && (
-                    <h4 className={`${ticketInspector.line} line-label`}>{ticketInspector.line}</h4>
+                    <h4 className="line-label" style={{ backgroundColor: getLineColor(ticketInspector.line) }}>
+                        {ticketInspector.line}
+                    </h4>
                 )}
                 <h4>{ticketInspector.station.name}</h4>
                 <p>{elapsedTimeMessage}</p>

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -6,6 +6,7 @@ import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipCont
 import { useTicketInspectors } from 'src/contexts/TicketInspectorsContext'
 import { MarkerData } from 'src/utils/types'
 import { getRecentDataWithIfModifiedSince } from 'src/utils/dbUtils'
+import { getLineColor } from 'src/utils/uiUtils'
 
 import ReportItem from './ReportItem'
 import ClusteredReportItem from './ClusteredReportItem'
@@ -200,11 +201,6 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
         )
     }
 
-    const getLineColor = (line: string): string => {
-        const cssVar = `--line-${line.toLowerCase()}`
-        return getComputedStyle(document.documentElement).getPropertyValue(cssVar).trim()
-    }
-
     return (
         <div className={`reports-modal modal container ${className}`}>
             <section className="tabs align-child-on-line">
@@ -253,7 +249,12 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                                     src={`/icons/risk-${riskData.class}.svg`}
                                                     alt="Icon to show risk level"
                                                 />
-                                                <h4 className={`line-label ${line}`}>{line}</h4>
+                                                <h4
+                                                    className="line-label"
+                                                    style={{ backgroundColor: getLineColor(line) }}
+                                                >
+                                                    {line}
+                                                </h4>
                                             </div>
                                         ))}
                                 </div>
@@ -272,7 +273,12 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                                     src={`/icons/risk-${riskData.class}.svg`}
                                                     alt="Icon to show risk level"
                                                 />
-                                                <h4 className={`line-label ${line}`}>{line}</h4>
+                                                <h4
+                                                    className="line-label"
+                                                    style={{ backgroundColor: getLineColor(line) }}
+                                                >
+                                                    {line}
+                                                </h4>
                                             </div>
                                         ))}
                                 </div>
@@ -291,7 +297,12 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, closeModal }) =>
                                                     src={`/icons/risk-${riskData.class}.svg`}
                                                     alt="Icon to show risk level"
                                                 />
-                                                <h4 className={`line-label ${line}`}>{line}</h4>
+                                                <h4
+                                                    className="line-label"
+                                                    style={{ backgroundColor: getLineColor(line) }}
+                                                >
+                                                    {line}
+                                                </h4>
                                             </div>
                                         ))}
                                 </div>

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -77,33 +77,6 @@
     --distance-from-edge-default: 15px;
     --button-size: 50px;
     --height-streched-button: 45px;
-
-    --line-s1: #da6ba2;
-    --line-s2: #007734;
-    --line-s3: #0066ad;
-    --line-s25: #007734;
-    --line-s26: #007734;
-    --line-s5: #eb7405;
-    --line-s41: #ad5937;
-    --line-s42: #cb6418;
-    --line-s45: #cd9c53;
-    --line-s46: #cd9c53;
-    --line-s47: #cd9c53;
-    --line-s7: #816da6;
-    --line-s75: #816da6;
-    --line-s8: #6a2;
-    --line-s85: #6a2;
-    --line-s9: #992746;
-    --line-u1: #7dad4c;
-    --line-u2: #da421e;
-    --line-u3: #16683d;
-    --line-u4: #f0d722;
-    --line-u5: #7e5330;
-    --line-u6: #8c6dab;
-    --line-u7: #528dba;
-    --line-u8: #224f86;
-    --line-u9: #f3791d;
-    --line-tram: #be1414;
 }
 
 :root.light {
@@ -321,7 +294,7 @@ span {
 }
 
 .legal-text h2 {
-  margin-top: var(--margin-m);
+    margin-top: var(--margin-m);
 }
 
 .legal-text li {
@@ -333,8 +306,8 @@ span {
 }
 
 .row {
-  display: flex;
-  gap: var(--margin-m);
+    display: flex;
+    gap: var(--margin-m);
 }
 
 .small-button {
@@ -469,118 +442,6 @@ button .plus {
     padding: var(--padding-xxs);
     border-radius: var(--borderRadius-small);
     color: var(--color-primary);
-}
-
-.S1 {
-    background-color: var(--line-s1);
-}
-
-.S2 {
-    background-color: var(--line-s2);
-}
-
-.S3 {
-    background-color: var(--line-s3);
-}
-
-.S25 {
-    background-color: var(--line-s25);
-}
-
-.S26 {
-    background-color: var(--line-s26);
-}
-
-.S5 {
-    background-color: var(--line-s5);
-}
-
-.S41 {
-    background-color: var(--line-s41);
-}
-
-.S42 {
-    background-color: var(--line-s42);
-}
-
-.S45 {
-    background-color: var(--line-s45);
-}
-
-.S46 {
-    background-color: var(--line-s46);
-}
-
-.S47 {
-    background-color: var(--line-s47);
-}
-
-.S7 {
-    background-color: var(--line-s7);
-}
-
-.S75 {
-    background-color: var(--line-s75);
-}
-
-.S8 {
-    background-color: var(--line-s8);
-}
-
-.S85 {
-    background-color: var(--line-s85);
-}
-
-.S9 {
-    background-color: var(--line-s9);
-}
-
-.U1 {
-    background-color: var(--line-u1);
-}
-
-.U2 {
-    background-color: var(--line-u2);
-}
-
-.U3 {
-    background-color: var(--line-u3);
-}
-
-.U4 {
-    background-color: var(--line-u4);
-}
-
-.U5 {
-    background-color: var(--line-u5);
-}
-
-.U6 {
-    background-color: var(--line-u6);
-}
-
-.U7 {
-    background-color: var(--line-u7);
-}
-
-.U8 {
-    background-color: var(--line-u8);
-}
-
-.U9 {
-    background-color: var(--line-u9);
-}
-
-.M1,
-.M2,
-.M4,
-.M5,
-.M6,
-.M8,
-.M10,
-.M13,
-.M17 {
-    background-color: var(--line-tram);
 }
 
 .elapsed-time {

--- a/packages/frontend/src/utils/uiUtils.tsx
+++ b/packages/frontend/src/utils/uiUtils.tsx
@@ -45,3 +45,83 @@ export function setColorThemeInLocalStorage() {
         localStorage.setItem('colorTheme', 'dark')
     }
 }
+
+/**
+ * Returns the color of a line based on the line name.
+ * @param line - The name of the line.
+ * @returns The color of the line as a hex string.
+ */
+export function getLineColor(line: string) {
+    switch (line) {
+        case 'S1':
+            return '#da6ba2'
+        case 'S2':
+            return '#007734'
+        case 'S3':
+            return '#0066ad'
+        case 'S5':
+            return '#eb7405'
+        case 'S25':
+            return '#007734'
+        case 'S26':
+            return '#007734'
+        case 'S41':
+            return '#ad5937'
+        case 'S42':
+            return '#cb6418'
+        case 'S45':
+            return '#cd9c53'
+        case 'S46':
+            return '#cd9c53'
+        case 'S47':
+            return '#cd9c53'
+        case 'S7':
+            return '#816da6'
+        case 'S75':
+            return '#816da6'
+        case 'S8':
+            return '#6a2'
+        case 'S85':
+            return '#6a2'
+        case 'S9':
+            return '#992746'
+        case 'U1':
+            return '#7dad4c'
+        case 'U2':
+            return '#da421e'
+        case 'U3':
+            return '#16683d'
+        case 'U4':
+            return '#f0d722'
+        case 'U5':
+            return '#7e5330'
+        case 'U6':
+            return '#8c6dab'
+        case 'U7':
+            return '#528dba'
+        case 'U8':
+            return '#224f86'
+        case 'U9':
+            return '#f3791d'
+        case 'M1':
+            return '#be1414'
+        case 'M2':
+            return '#be1414'
+        case 'M4':
+            return '#be1414'
+        case 'M5':
+            return '#be1414'
+        case 'M6':
+            return '#be1414'
+        case 'M8':
+            return '#be1414'
+        case 'M10':
+            return '#be1414'
+        case 'M13':
+            return '#be1414'
+        case 'M17':
+            return '#be1414'
+        default:
+            return '#000000'
+    }
+}


### PR DESCRIPTION
This will make the UI less error prone as we now have a single source of truth for the colors of the line.
This change was introduced because I forgot to update the colors of the trams everywhere. It will now be harder for someone to forget to do this.

## Notes and Considerations:
In a perfect wold we would also use the `getLineColor` in the `RegularLineLayer` but I could not figure out how to get this to work.