### PR TITLE
refactor: minize resorting logic

### DIFF
--- a/packages/frontend/src/components/Map/MapLayers/LineLayer/RegularLineLayer.tsx
+++ b/packages/frontend/src/components/Map/MapLayers/LineLayer/RegularLineLayer.tsx
@@ -2,20 +2,21 @@ import React from 'react'
 import { Source, Layer } from 'react-map-gl/maplibre'
 
 interface RegularLineLayerProps {
-    linesGeoJSON: GeoJSON.FeatureCollection<GeoJSON.LineString> | null
+    lineSegments: GeoJSON.FeatureCollection<GeoJSON.LineString> | null
     textColor: string
 }
 
-const RegularLineLayer: React.FC<RegularLineLayerProps> = ({ linesGeoJSON, textColor }) => {
+const RegularLineLayer: React.FC<RegularLineLayerProps> = ({ lineSegments, textColor }) => {
     const firstPriorityLines = ['U1', 'U2', 'U3', 'U4', 'U5', 'U6', 'U7', 'U8', 'U9']
 
-    if (!linesGeoJSON) return null
+    if (!lineSegments) return null
     return (
         <>
-            <Source id="line-data" type="geojson" data={linesGeoJSON}>
+            <Source id="line-data" type="geojson" data={lineSegments}>
                 <Layer
                     id="line-layer"
                     type="line"
+                    beforeId="stationLayer"
                     source="line-data"
                     layout={{
                         'line-join': 'round',
@@ -29,6 +30,7 @@ const RegularLineLayer: React.FC<RegularLineLayerProps> = ({ linesGeoJSON, textC
                 <Layer
                     id="label-layer"
                     type="symbol"
+                    beforeId="stationLayer"
                     source="line-data"
                     layout={{
                         'text-field': ['get', 'line'],

--- a/packages/frontend/src/components/Map/MapLayers/LineLayer/RiskLineLayer.tsx
+++ b/packages/frontend/src/components/Map/MapLayers/LineLayer/RiskLineLayer.tsx
@@ -7,11 +7,11 @@ import { useRiskData } from 'src/contexts/RiskDataContext'
 
 interface RiskLineLayerProps {
     preloadedRiskData: RiskData | null
-    linesGeoJSON: GeoJSON.FeatureCollection<GeoJSON.LineString> | null
+    lineSegments: GeoJSON.FeatureCollection<GeoJSON.LineString> | null
     textColor: string
 }
 
-const RiskLineLayer: React.FC<RiskLineLayerProps> = ({ linesGeoJSON, textColor, preloadedRiskData }) => {
+const RiskLineLayer: React.FC<RiskLineLayerProps> = ({ lineSegments, textColor, preloadedRiskData }) => {
     const { segmentRiskData, refreshRiskData } = useRiskData()
     const [geoJSON, setGeoJSON] = useState<GeoJSON.FeatureCollection<GeoJSON.LineString> | null>(null)
 
@@ -34,19 +34,19 @@ const RiskLineLayer: React.FC<RiskLineLayerProps> = ({ linesGeoJSON, textColor, 
 
     // If the segment risk data changes, update the GeoJSON
     useEffect(() => {
-        if (linesGeoJSON && segmentRiskData?.segment_colors) {
-            setGeoJSON(applySegmentColors(linesGeoJSON, segmentRiskData.segment_colors))
+        if (lineSegments && segmentRiskData?.segment_colors) {
+            setGeoJSON(applySegmentColors(lineSegments, segmentRiskData.segment_colors))
         }
-    }, [segmentRiskData, linesGeoJSON])
+    }, [segmentRiskData, lineSegments])
 
     // Initialize with preloaded data
     useEffect(() => {
-        if (linesGeoJSON && preloadedRiskData?.segment_colors) {
-            setGeoJSON(applySegmentColors(linesGeoJSON, preloadedRiskData.segment_colors))
-        } else if (linesGeoJSON) {
-            setGeoJSON(applySegmentColors(linesGeoJSON))
+        if (lineSegments && preloadedRiskData?.segment_colors) {
+            setGeoJSON(applySegmentColors(lineSegments, preloadedRiskData.segment_colors))
+        } else if (lineSegments) {
+            setGeoJSON(applySegmentColors(lineSegments))
         }
-    }, [preloadedRiskData, linesGeoJSON])
+    }, [preloadedRiskData, lineSegments])
 
     // Periodically fetch new risk data to account for changes
     useEffect(() => {
@@ -56,7 +56,9 @@ const RiskLineLayer: React.FC<RiskLineLayerProps> = ({ linesGeoJSON, textColor, 
         return () => clearInterval(interval)
     }, [refreshRiskData])
 
-    if (!geoJSON) return null
+    if (!geoJSON) {
+        return null
+    }
 
     return (
         <>
@@ -64,6 +66,7 @@ const RiskLineLayer: React.FC<RiskLineLayerProps> = ({ linesGeoJSON, textColor, 
                 <Layer
                     id="risk-line-layer"
                     type="line"
+                    beforeId="stationLayer"
                     source="risk-line-data"
                     layout={{
                         'line-join': 'round',
@@ -77,6 +80,7 @@ const RiskLineLayer: React.FC<RiskLineLayerProps> = ({ linesGeoJSON, textColor, 
                 <Layer
                     id="risk-label-layer"
                     type="symbol"
+                    beforeId="stationLayer"
                     source="risk-line-data"
                     layout={{
                         'text-field': ['get', 'line'],


### PR DESCRIPTION
Instead of tracking each layer change and manually moving the stationLayer an top we are now just moving the line layers below the station layer.

This will make the logic a lot more robust and fix the issue of the segments taking longer to load and thus being painted on top of the station layer without a switch in layer state.

This will be avoided:
<img width="387" alt="Bildschirmfoto 2024-11-20 um 16 15 33" src="https://github.com/user-attachments/assets/7c9902b9-f853-480f-be9d-5fb32ed7f7e9">

