### PR TITLE
refactor: label report button

### DIFF
--- a/packages/frontend/src/components/Buttons/ReportButton/ReportButton.css
+++ b/packages/frontend/src/components/Buttons/ReportButton/ReportButton.css
@@ -1,47 +1,33 @@
 .report-button {
     position: fixed;
-    height: 90px;
-    min-height: auto;
-    min-width: auto;
-    width: 90px;
     bottom: var(--distance-from-edge-default);
+    width: 110px;
     right: var(--distance-from-edge-default);
-    padding: var(--padding-s);
-    cursor: pointer;
-    border: 2px solid var(--color-white);
-    border-radius: 50%;
-    overflow: hidden;
     margin-bottom: 15px;
+    padding-left: 10px;
     z-index: var(--zIndex-button);
+    background-color: var(--incentive-blue);
+    border: 2px solid var(--color-white);
 }
 
 .report-button .plus span {
     position: absolute;
     background-color: var(--color-white);
     border-radius: 1px;
-    box-shadow: var(--boxShadow-default);
 }
 
 .report-button .plus span:first-child {
-    height: 4px;
-    width: 50%;
+    height: 3px;
+    width: 20px;
     left: 25%;
-    top: 50%;
+    top: 48%;
     transform: translateY(-50%);
 }
 
 .report-button .plus span:last-child {
-    width: 4px;
-    height: 50%;
+    width: 3px;
+    height: 20px;
     top: 25%;
-    left: 50%;
+    left: 52%;
     transform: translateX(-50%);
-}
-
-@media (max-width: 400px) {
-    .report-button {
-        height: 60px;
-        width: 60px;
-        padding: var(--padding-xs);
-    }
 }

--- a/packages/frontend/src/components/Buttons/ReportButton/ReportButton.tsx
+++ b/packages/frontend/src/components/Buttons/ReportButton/ReportButton.tsx
@@ -3,12 +3,13 @@ import React, { MouseEventHandler } from 'react'
 import './ReportButton.css'
 
 interface ReportButtonProps {
-    onClick: MouseEventHandler<HTMLButtonElement>
+    openReportModal: MouseEventHandler<HTMLButtonElement>
 }
 
-const ReportButton: React.FC<ReportButtonProps> = ({ onClick }) => {
+const ReportButton: React.FC<ReportButtonProps> = ({ openReportModal }) => {
     return (
-        <button className="report-button action center-child" onClick={onClick} aria-label="report ticketinspector">
+        <button className="report-button small-button align-child-on-line" onClick={openReportModal}>
+            <p>Melden</p>
             <div className="plus">
                 <span></span>
                 <span></span>

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -257,7 +257,7 @@ function App() {
                 </div>
             )}
             <ReportButton
-                onClick={() => setAppUIState({ ...appUIState, isReportFormOpen: !appUIState.isReportFormOpen })}
+                openReportModal={() => setAppUIState({ ...appUIState, isReportFormOpen: !appUIState.isReportFormOpen })}
             />
             {appUIState.isStatsPopUpOpen && statsData !== 0 && (
                 <StatsPopUp


### PR DESCRIPTION
This change is being made to test if we can improve the number of reports if the button is labeled.

New style:
<img width="524" alt="Bildschirmfoto 2024-11-21 um 15 12 11" src="https://github.com/user-attachments/assets/20bd8d4b-8212-4519-abe9-f849f93fee66">

