### PR TITLE
Sort stations by name in report form

### DIFF
--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -87,7 +87,6 @@ const ReportForm: React.FC<ReportFormProps> = ({ closeModal, notifyParentAboutSu
 
     // Calculate possible stations based on entity, line, station, and search input
     const possibleStations = useMemo(() => {
-        // Sort station records from a station record [stationKey, station] array by station name
         const sortStationRecordsByStationName = (
             recordA: (string | StationProperty)[],
             recordB: (string | StationProperty)[]
@@ -106,9 +105,7 @@ const ReportForm: React.FC<ReportFormProps> = ({ closeModal, notifyParentAboutSu
             stations = { [currentStation]: allStations[currentStation] }
         } else if (currentLine) {
             stations = Object.fromEntries(
-                allLines[currentLine]
-                    .map((stationKey) => [stationKey, allStations[stationKey]])
-                    .sort(sortStationRecordsByStationName)
+                allLines[currentLine].map((stationKey) => [stationKey, allStations[stationKey]])
             )
         } else if (currentEntity) {
             stations = Object.entries(sortedAllStations)


### PR DESCRIPTION
## Describe the issue:
Stations are not sorted by name when submitting a report. (issue #300)
## Explain how you solved the issue:
In `ReportForm`, the list of stations is populated and stored in `possibleStations`. All stations are now sorted by name from the start (`sortedAllStations`).

When a `currentLine` is selected, stations of the line will be sorted since they are mapped from `allLines`.

When a `currentEntity` is selected or a station is searched, the list of stations is taken from `sortedAllStations`, which is already sorted.

## Additional notes or considerations:
N/A