### PR TITLE
fix: detect telegram in-app browser

### DIFF
--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -12,18 +12,6 @@ import { PrivacyPolicy } from './pages/PrivacyPolicy/PrivacyPolicy'
 import { Support } from './pages/Support/Support'
 import { reportWebVitals } from './reportWebVitals'
 
-export type FunnelConfig = {
-    path: string
-    source: string
-}
-
-const FUNNEL_ROUTES: FunnelConfig[] = [
-    {
-        path: '/invite',
-        source: 'FreiFahren_BE Telegram',
-    },
-]
-
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 
 root.render(
@@ -41,17 +29,6 @@ root.render(
                     />
                     <Route path="/datenschutz" element={<PrivacyPolicy />} />
                     <Route path="/support" element={<Support />} />
-                    {FUNNEL_ROUTES.map((config) => (
-                        <Route
-                            key={config.path}
-                            path={config.path}
-                            element={
-                                <LocationProvider>
-                                    <App funnelEvent={config} />
-                                </LocationProvider>
-                            }
-                        />
-                    ))}
                 </Routes>
             </BrowserRouter>
         </I18nextProvider>

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -254,6 +254,12 @@ const App = ({ funnelEvent }: { funnelEvent?: FunnelConfig }) => {
         }
     }, [funnelEvent, navigate])
 
+    useEffect(() => {
+        if (typeof navigator !== 'undefined' && navigator.userAgent && navigator.userAgent.includes('Telegram')) {
+            alert('DETECTED')
+        }
+    }, []) // Only run once on mount
+
     return (
         <div className="App">
             {appMounted && shouldShowLegalDisclaimer() ? (

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -255,7 +255,7 @@ const App = ({ funnelEvent }: { funnelEvent?: FunnelConfig }) => {
     }, [funnelEvent, navigate])
 
     useEffect(() => {
-        if (typeof navigator !== 'undefined' && navigator.userAgent && navigator.userAgent.includes('Telegram')) {
+        if (navigator.userAgent.includes('Telegram')) {
             setAppUIState({ ...appUIState, isListModalOpen: true })
         }
     }, []) // Only run once on mount

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -256,7 +256,7 @@ const App = ({ funnelEvent }: { funnelEvent?: FunnelConfig }) => {
 
     useEffect(() => {
         if (typeof navigator !== 'undefined' && navigator.userAgent && navigator.userAgent.includes('Telegram')) {
-            alert('DETECTED')
+            setAppUIState({ ...appUIState, isListModalOpen: true })
         }
     }, []) // Only run once on mount
 

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -47,10 +47,10 @@ const initialAppUIState: AppUIState = {
     isLegalDisclaimerOpen: false,
 }
 
-const isTelegramWebApp = (): boolean => {
+const isTelegramWebApp = (): boolean => 
     // @ts-ignore since TelegramWebviewProxy is not in the window type definitions
-    return typeof TelegramWebviewProxy !== 'undefined'
-}
+     typeof TelegramWebviewProxy !== 'undefined'
+
 
 const App = () => {
     const [appUIState, setAppUIState] = useState<AppUIState>(initialAppUIState)
@@ -239,6 +239,10 @@ const App = () => {
         if (isTelegramWebApp()) {
             sendAnalyticsEvent('Opened from Telegram', {
                 meta: {},
+            }).catch((error) => {
+                // fix later with sentry
+                // eslint-disable-next-line no-console
+                console.error('Failed to send opened from telegram analytics event:', error)
             })
         }
     }, [])

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -1,8 +1,6 @@
 import './App.css'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { FunnelConfig } from 'src'
 import { ReportsModalButton } from 'src/components/Buttons/ReportsModalButton/ReportsModalButton'
 import { ReportsModal } from 'src/components/Modals/ReportsModal/ReportsModal'
 import { ReportSummaryModal } from 'src/components/Modals/ReportSummaryModal/ReportSummaryModal'
@@ -54,7 +52,7 @@ const isTelegramWebApp = (): boolean => {
     return typeof TelegramWebviewProxy !== 'undefined'
 }
 
-const App = ({ funnelEvent }: { funnelEvent?: FunnelConfig }) => {
+const App = () => {
     const [appUIState, setAppUIState] = useState<AppUIState>(initialAppUIState)
     const [appMounted, setAppMounted] = useState(false)
 
@@ -237,33 +235,13 @@ const App = ({ funnelEvent }: { funnelEvent?: FunnelConfig }) => {
     // in the future this will be automatically fetched from the analytics platform + telegram user count
     const numberOfUsers = useMemo(() => Math.floor(Math.random() * (36000 - 35000 + 1)) + 35000, [])
 
-    const funnelEventSentRef = useRef(false)
-    const navigate = useNavigate()
-    useEffect(() => {
-        if (funnelEvent && !funnelEventSentRef.current) {
-            funnelEventSentRef.current = true
-            sendAnalyticsEvent('Clicked on Funnel link', {
-                meta: {
-                    source: funnelEvent.source,
-                    path: funnelEvent.path,
-                },
-            })
-                .catch((error) => {
-                    // fix later with sentry
-                    // eslint-disable-next-line no-console
-                    console.error('Failed to send funnel event:', error)
-                })
-                .finally(() => {
-                    navigate('/')
-                })
-        }
-    }, [funnelEvent, navigate])
-
     useEffect(() => {
         if (isTelegramWebApp()) {
-            setAppUIState((prev) => ({ ...prev, isListModalOpen: true }))
+            sendAnalyticsEvent('Opened from Telegram', {
+                meta: {},
+            })
         }
-    }, []) // Only run once on mount
+    }, [])
 
     return (
         <div className="App">

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -49,6 +49,11 @@ const initialAppUIState: AppUIState = {
     isLegalDisclaimerOpen: false,
 }
 
+const isTelegramWebApp = (): boolean => {
+    // @ts-ignore since TelegramWebviewProxy is not in the window type definitions
+    return typeof TelegramWebviewProxy !== 'undefined'
+}
+
 const App = ({ funnelEvent }: { funnelEvent?: FunnelConfig }) => {
     const [appUIState, setAppUIState] = useState<AppUIState>(initialAppUIState)
     const [appMounted, setAppMounted] = useState(false)
@@ -255,8 +260,8 @@ const App = ({ funnelEvent }: { funnelEvent?: FunnelConfig }) => {
     }, [funnelEvent, navigate])
 
     useEffect(() => {
-        if (navigator.userAgent.includes('Telegram')) {
-            setAppUIState({ ...appUIState, isListModalOpen: true })
+        if (isTelegramWebApp()) {
+            setAppUIState((prev) => ({ ...prev, isListModalOpen: true }))
         }
     }, []) // Only run once on mount
 

--- a/packages/telegram_bots/main.py
+++ b/packages/telegram_bots/main.py
@@ -55,7 +55,7 @@ def report_inspector() -> tuple:
         f"Received a report from an inspector: Line: {line}, Station: {station}, Direction: {direction}, Message: {message}"
     )
 
-    telegram_message = "Über app.freifahren.org/invite gab es folgende Meldung:"
+    telegram_message = "Über app.freifahren.org gab es folgende Meldung:"
     telegram_message += "\n"
     telegram_message += f"\n<b>Station</b>: {station}"
     if line:


### PR DESCRIPTION
## Describe the issue:
We needed a reliable way to track user engagement from Telegram group invite links for future A/B testing of different messaging strategies. Our initial approach of tracking funnel events wasn't working because Telegram's in-app browser interferes with our analytics tracking.

## Explain how you solved the issue:
Instead of relying on funnel tracking, we now detect Telegram's in-app browser directly by checking for the presence of the `TelegramWebviewProxy` object, which is injected by Telegram's WebView. This provides a more reliable way to identify users coming from Telegram.
Key changes:
- Removed unreliable funnel tracking code
- Added detection of Telegram's WebView using `TelegramWebviewProxy`
- Implemented analytics event 'Opened from Telegram' to track these visits

## Additional notes or considerations:
While we can now accurately track visits from Telegram, we still can't:
- Track which specific invite message brought the user
- Perform traditional A/B testing of different invite messages
