### PR TITLE
feat: feat allow users to opt out of tracking

### DIFF
--- a/packages/frontend/public/locales/de.json
+++ b/packages/frontend/public/locales/de.json
@@ -18,7 +18,9 @@
         "feedback-button": "Kontakt",
         "impressum": "Impressum",
         "privacy": "Datenschutz",
-        "terms": "Nutzungsbedingungen"
+        "terms": "Nutzungsbedingungen",
+        "analytics-opted-in": "anonyme Analytics - Klicken zum Deaktivieren",
+        "analytics-opted-out": "anonyme Analytics - Klicken zum Aktivieren"
     },
     "ContactSection": {
         "title": "Kontaktiere uns",

--- a/packages/frontend/public/locales/en.json
+++ b/packages/frontend/public/locales/en.json
@@ -17,8 +17,10 @@
         "title": "Information",
         "feedback-button": "Contact",
         "impressum": "Legal notice",
-        "privacy": "Privacy",
-        "terms": "Terms of use"
+        "privacy": "Privacy Policy",
+        "terms": "Terms of Use",
+        "analytics-opted-in": "anonyme analytics - Click to disable",
+        "analytics-opted-out": "anonyme analytics - Click to enable"
     },
     "ContactSection": {
         "title": "Contact us",

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -489,7 +489,10 @@ const ReportForm: FC<ReportFormProps> = ({ closeModal, onNotifyParentAboutSubmis
                         </section>
                         <section>
                             <div>
-                                <PrivacyCheckbox isChecked={isPrivacyChecked} onChange={() => setIsPrivacyChecked} />
+                                <PrivacyCheckbox
+                                    isChecked={isPrivacyChecked}
+                                    onChange={() => setIsPrivacyChecked(!isPrivacyChecked)}
+                                />
                             </div>
                             <div>
                                 <button

--- a/packages/frontend/src/components/Map/Map.tsx
+++ b/packages/frontend/src/components/Map/Map.tsx
@@ -90,6 +90,8 @@ const FreifahrenMap: React.FC<FreifahrenMapProps> = ({
         [onRotationChange]
     )
 
+    const currentColorTheme = 'dark'
+
     return (
         <div id="map-container" data-testid="map-container">
             <Suspense fallback={<div>Loading...</div>}>
@@ -107,7 +109,7 @@ const FreifahrenMap: React.FC<FreifahrenMapProps> = ({
                     minZoom={10}
                     maxBounds={maxBounds}
                     onRotate={handleRotate}
-                    mapStyle="https://api.jawg.io/styles/848dfeff-2d26-4044-8b83-3b1851256e3d.json?access-token=${process.env.REACT_APP_JAWG_ACCESS_TOKEN}"
+                    mapStyle={`https://api.jawg.io/styles/848dfeff-2d26-4044-8b83-3b1851256e3d.json?access-token=${process.env.REACT_APP_JAWG_ACCESS_TOKEN}`}
                 >
                     {!isFirstOpen ? <LocationMarker userPosition={userPosition} /> : null}
                     <MarkerContainer

--- a/packages/frontend/src/components/Map/Map.tsx
+++ b/packages/frontend/src/components/Map/Map.tsx
@@ -20,7 +20,6 @@ const Map = lazy(() => import('react-map-gl/maplibre'))
 interface FreifahrenMapProps {
     formSubmitted: boolean
     isFirstOpen: boolean
-    currentColorTheme: string
     isRiskLayerOpen: boolean
     onRotationChange: (bearing: number) => void
 }
@@ -32,7 +31,6 @@ const INSTAGRAM_ICON = `${process.env.PUBLIC_URL}/icons/instagram.svg`
 const FreifahrenMap: React.FC<FreifahrenMapProps> = ({
     formSubmitted,
     isFirstOpen,
-    currentColorTheme,
     isRiskLayerOpen,
     onRotationChange,
 }) => {
@@ -67,8 +65,6 @@ const FreifahrenMap: React.FC<FreifahrenMapProps> = ({
             initializeLocationTracking()
         }
     }, [isFirstOpen, initializeLocationTracking])
-
-    const textColor = currentColorTheme === 'light' ? '#000' : '#fff'
 
     // preload colors before risklayer component mounts to instantly show the highlighted segments
     const { segmentRiskData, refreshRiskData } = useRiskData()
@@ -111,11 +107,7 @@ const FreifahrenMap: React.FC<FreifahrenMapProps> = ({
                     minZoom={10}
                     maxBounds={maxBounds}
                     onRotate={handleRotate}
-                    mapStyle={
-                        currentColorTheme === 'light'
-                            ? `https://api.jawg.io/styles/359ec2e4-39f7-4fb5-8e3a-52037d043f96.json?access-token=${process.env.REACT_APP_JAWG_ACCESS_TOKEN}`
-                            : `https://api.jawg.io/styles/848dfeff-2d26-4044-8b83-3b1851256e3d.json?access-token=${process.env.REACT_APP_JAWG_ACCESS_TOKEN}`
-                    }
+                    mapStyle="https://api.jawg.io/styles/848dfeff-2d26-4044-8b83-3b1851256e3d.json?access-token=${process.env.REACT_APP_JAWG_ACCESS_TOKEN}"
                 >
                     {!isFirstOpen ? <LocationMarker userPosition={userPosition} /> : null}
                     <MarkerContainer
@@ -123,15 +115,11 @@ const FreifahrenMap: React.FC<FreifahrenMapProps> = ({
                         formSubmitted={formSubmitted}
                         userPosition={userPosition}
                     />
-                    <StationLayer stations={stationGeoJSON} textColor={textColor} />
+                    <StationLayer stations={stationGeoJSON} />
                     {isRiskLayerOpen ? (
-                        <RiskLineLayer
-                            preloadedRiskData={segmentRiskData}
-                            lineSegments={lineSegments}
-                            textColor={textColor}
-                        />
+                        <RiskLineLayer preloadedRiskData={segmentRiskData} lineSegments={lineSegments} />
                     ) : (
-                        <RegularLineLayer lineSegments={lineSegments} textColor={textColor} />
+                        <RegularLineLayer lineSegments={lineSegments} />
                     )}
                 </Map>
             </Suspense>

--- a/packages/frontend/src/components/Map/Map.tsx
+++ b/packages/frontend/src/components/Map/Map.tsx
@@ -90,8 +90,6 @@ const FreifahrenMap: React.FC<FreifahrenMapProps> = ({
         [onRotationChange]
     )
 
-    const currentColorTheme = 'dark'
-
     return (
         <div id="map-container" data-testid="map-container">
             <Suspense fallback={<div>Loading...</div>}>

--- a/packages/frontend/src/components/Map/MapLayers/LineLayer/RegularLineLayer.tsx
+++ b/packages/frontend/src/components/Map/MapLayers/LineLayer/RegularLineLayer.tsx
@@ -1,59 +1,58 @@
 import React from 'react'
-import { Layer,Source } from 'react-map-gl/maplibre'
+import { Layer, Source } from 'react-map-gl/maplibre'
 
 interface RegularLineLayerProps {
     lineSegments: GeoJSON.FeatureCollection<GeoJSON.LineString> | null
-    textColor: string
 }
 
-const RegularLineLayer: React.FC<RegularLineLayerProps> = ({ lineSegments, textColor }) => {
+const RegularLineLayer: React.FC<RegularLineLayerProps> = ({ lineSegments }) => {
     const firstPriorityLines = ['U1', 'U2', 'U3', 'U4', 'U5', 'U6', 'U7', 'U8', 'U9']
 
     if (!lineSegments) return null
     return (
         <Source id="line-data" type="geojson" data={lineSegments}>
-                <Layer
-                    id="line-layer"
-                    type="line"
-                    beforeId="stationLayer"
-                    source="line-data"
-                    layout={{
-                        'line-join': 'round',
-                        'line-cap': 'round',
-                    }}
-                    paint={{
-                        'line-color': ['get', 'line_color'], // Set the base color from the GeoJSON
-                        'line-width': 3,
-                    }}
-                />
-                <Layer
-                    id="label-layer"
-                    type="symbol"
-                    beforeId="stationLayer"
-                    source="line-data"
-                    layout={{
-                        'text-field': ['get', 'line'],
-                        'text-size': 13,
-                        'symbol-placement': 'line',
-                        'text-anchor': 'top',
-                        'text-offset': [0, 1.5],
-                        'text-keep-upright': true,
-                        'text-optional': true,
-                    }}
-                    paint={{
-                        'text-color': textColor,
-                        'text-opacity': [
-                            'interpolate',
-                            ['linear'],
-                            ['zoom'],
-                            10,
-                            ['case', ['in', ['get', 'line'], ['literal', firstPriorityLines]], 1, 0],
-                            12,
-                            1,
-                        ],
-                    }}
-                />
-            </Source>
+            <Layer
+                id="line-layer"
+                type="line"
+                beforeId="stationLayer"
+                source="line-data"
+                layout={{
+                    'line-join': 'round',
+                    'line-cap': 'round',
+                }}
+                paint={{
+                    'line-color': ['get', 'line_color'], // Set the base color from the GeoJSON
+                    'line-width': 3,
+                }}
+            />
+            <Layer
+                id="label-layer"
+                type="symbol"
+                beforeId="stationLayer"
+                source="line-data"
+                layout={{
+                    'text-field': ['get', 'line'],
+                    'text-size': 13,
+                    'symbol-placement': 'line',
+                    'text-anchor': 'top',
+                    'text-offset': [0, 1.5],
+                    'text-keep-upright': true,
+                    'text-optional': true,
+                }}
+                paint={{
+                    'text-color': '#fff',
+                    'text-opacity': [
+                        'interpolate',
+                        ['linear'],
+                        ['zoom'],
+                        10,
+                        ['case', ['in', ['get', 'line'], ['literal', firstPriorityLines]], 1, 0],
+                        12,
+                        1,
+                    ],
+                }}
+            />
+        </Source>
     )
 }
 

--- a/packages/frontend/src/components/Map/MapLayers/LineLayer/RiskLineLayer.tsx
+++ b/packages/frontend/src/components/Map/MapLayers/LineLayer/RiskLineLayer.tsx
@@ -1,15 +1,14 @@
-import React, { useEffect,useState } from 'react'
-import { Layer,Source } from 'react-map-gl/maplibre'
+import React, { useEffect, useState } from 'react'
+import { Layer, Source } from 'react-map-gl/maplibre'
 import { useRiskData } from 'src/contexts/RiskDataContext'
 import { RiskData } from 'src/utils/types'
 
 interface RiskLineLayerProps {
     preloadedRiskData: RiskData | null
     lineSegments: GeoJSON.FeatureCollection<GeoJSON.LineString> | null
-    textColor: string
 }
 
-const RiskLineLayer: React.FC<RiskLineLayerProps> = ({ lineSegments, textColor, preloadedRiskData }) => {
+const RiskLineLayer: React.FC<RiskLineLayerProps> = ({ lineSegments, preloadedRiskData }) => {
     const { segmentRiskData, refreshRiskData } = useRiskData()
     const [geoJSON, setGeoJSON] = useState<GeoJSON.FeatureCollection<GeoJSON.LineString> | null>(null)
 
@@ -66,39 +65,39 @@ const RiskLineLayer: React.FC<RiskLineLayerProps> = ({ lineSegments, textColor, 
 
     return (
         <Source id="risk-line-data" type="geojson" data={geoJSON}>
-                <Layer
-                    id="risk-line-layer"
-                    type="line"
-                    beforeId="stationLayer"
-                    source="risk-line-data"
-                    layout={{
-                        'line-join': 'round',
-                        'line-cap': 'round',
-                    }}
-                    paint={{
-                        'line-color': ['get', 'line_color'],
-                        'line-width': 3,
-                    }}
-                />
-                <Layer
-                    id="risk-label-layer"
-                    type="symbol"
-                    beforeId="stationLayer"
-                    source="risk-line-data"
-                    layout={{
-                        'text-field': ['get', 'line'],
-                        'text-size': 15,
-                        'symbol-placement': 'line',
-                        'text-anchor': 'top',
-                        'text-offset': [0, 1.5],
-                        'text-keep-upright': true,
-                    }}
-                    paint={{
-                        'text-color': textColor,
-                        'text-opacity': ['interpolate', ['linear'], ['zoom'], 11, 0, 12, 1],
-                    }}
-                />
-            </Source>
+            <Layer
+                id="risk-line-layer"
+                type="line"
+                beforeId="stationLayer"
+                source="risk-line-data"
+                layout={{
+                    'line-join': 'round',
+                    'line-cap': 'round',
+                }}
+                paint={{
+                    'line-color': ['get', 'line_color'],
+                    'line-width': 3,
+                }}
+            />
+            <Layer
+                id="risk-label-layer"
+                type="symbol"
+                beforeId="stationLayer"
+                source="risk-line-data"
+                layout={{
+                    'text-field': ['get', 'line'],
+                    'text-size': 15,
+                    'symbol-placement': 'line',
+                    'text-anchor': 'top',
+                    'text-offset': [0, 1.5],
+                    'text-keep-upright': true,
+                }}
+                paint={{
+                    'text-color': '#fff',
+                    'text-opacity': ['interpolate', ['linear'], ['zoom'], 11, 0, 12, 1],
+                }}
+            />
+        </Source>
     )
 }
 

--- a/packages/frontend/src/components/Map/MapLayers/StationLayer/StationLayer.tsx
+++ b/packages/frontend/src/components/Map/MapLayers/StationLayer/StationLayer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Layer, MapRef,Source, useMap } from 'react-map-gl/maplibre'
+import { Layer, MapRef, Source, useMap } from 'react-map-gl/maplibre'
 
 import { StationGeoJSON } from '../../../../utils/types'
 
@@ -8,7 +8,6 @@ const SBAHN_ICON = `${process.env.PUBLIC_URL}/icons/sbahn.svg`
 
 interface StationLayerProps {
     stations: StationGeoJSON
-    textColor: string
 }
 class IconFactory {
     constructor(private map: MapRef | undefined) {}
@@ -18,14 +17,14 @@ class IconFactory {
 
         image.src = source
         image.onload = () => {
-            if (!((this.map?.hasImage(name)) ?? false)) {
+            if (!(this.map?.hasImage(name) ?? false)) {
                 this.map?.addImage(name, image)
             }
         }
     }
 }
 
-const StationLayer: React.FC<StationLayerProps> = ({ stations, textColor }) => {
+const StationLayer: React.FC<StationLayerProps> = ({ stations }) => {
     const map = useMap()
 
     useEffect(() => {
@@ -147,7 +146,7 @@ const StationLayer: React.FC<StationLayerProps> = ({ stations, textColor }) => {
                     'text-offset': [0, 1],
                 }}
                 paint={{
-                    'text-color': textColor,
+                    'text-color': '#fff',
                     'text-halo-color': 'black',
                     'text-halo-width': 0.2,
                     'text-opacity': [

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportsModal.tsx
@@ -26,10 +26,9 @@ type TabType = 'summary' | 'lines' | 'stations'
 
 interface CustomTooltipProps extends TooltipProps<ValueType, NameType> {
     getChartData: { line: string; reports: number }[]
-    isLightTheme: boolean
 }
 
-const CustomTooltip: React.FC<CustomTooltipProps> = ({ active, payload, getChartData, isLightTheme }) => {
+const CustomTooltip: React.FC<CustomTooltipProps> = ({ active, payload, getChartData }) => {
     const { t } = useTranslation()
 
     if (!(active ?? false) || !payload || payload.length === 0) return null
@@ -42,8 +41,8 @@ const CustomTooltip: React.FC<CustomTooltipProps> = ({ active, payload, getChart
         <div
             className="custom-tooltip"
             style={{
-                backgroundColor: isLightTheme === true ? '#fff' : '#000',
-                color: isLightTheme === true ? '#000' : '#fff',
+                backgroundColor: '#000',
+                color: '#fff',
                 padding: '8px',
                 borderRadius: '4px',
             }}
@@ -217,23 +216,6 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, onCloseModal }) 
         [sortedLinesWithReports]
     )
 
-    const [isLightTheme, setIsLightTheme] = useState<boolean>(false)
-
-    useEffect(() => {
-        const theme = localStorage.getItem('colorTheme')
-
-        setIsLightTheme(theme === 'light')
-
-        const handleStorageChange = (event: StorageEvent) => {
-            if (event.key === 'theme') {
-                setIsLightTheme(event.newValue === 'dark')
-            }
-        }
-
-        window.addEventListener('storage', handleStorageChange)
-        return () => window.removeEventListener('storage', handleStorageChange)
-    }, [])
-
     if (showFeedback) {
         return <FeedbackForm openAnimationClass={className} />
     }
@@ -358,13 +340,11 @@ const ReportsModal: React.FC<ReportsModalProps> = ({ className, onCloseModal }) 
                                 tick={{
                                     fontSize: 16,
                                     fontWeight: 800,
-                                    fill: isLightTheme ? '#000' : '#fff',
+                                    fill: '#fff',
                                     dx: -5,
                                 }}
                             />
-                            <Tooltip
-                                content={<CustomTooltip getChartData={getChartData} isLightTheme={isLightTheme} />}
-                            />
+                            <Tooltip content={<CustomTooltip getChartData={getChartData} />} />
                             <Bar
                                 dataKey="reports"
                                 barSize={34}

--- a/packages/frontend/src/components/Modals/UtilModal/UtilModal.css
+++ b/packages/frontend/src/components/Modals/UtilModal/UtilModal.css
@@ -1,85 +1,65 @@
 .util-modal {
     display: flex !important;
     flex-direction: column;
-    align-items: flex-end;
     width: fit-content;
+    min-width: 300px;
+    padding: var(--padding-l);
 }
 
-.util-modal h1 {
-    margin-right: var(--margin-s);
-}
-
-.util-modal div:first-child {
-    gap: var(--margin-l);
-    margin: 0 0 auto 0;
-}
-
-.util-modal li a img {
-    height: 20px;
-    width: 20px;
-}
-
-.util-modal ul {
-    position: relative;
-    max-width: 300px;
-    margin-top: var(--margin-m);
-    margin-right: 0;
-}
-
-.util-modal div:last-of-type {
+.modal-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     width: 100%;
-    padding: var(--padding-m) 0;
+    margin-bottom: var(--margin-l);
 }
 
-.util-modal ul:first-of-type {
-    display: flex;
-    list-style: none;
-    padding: 0;
-    margin: 0 var(--margin-s) 0 0;
-    flex-grow: 1;
+.modal-header h1 {
+    margin: 0;
+    margin-right: var(--margin-m);
+    font-size: var(--font-l);
 }
 
-.util-modal ul:last-of-type {
+.modal-content {
     display: flex;
-    justify-content: flex-end;
+    flex-direction: column;
+    width: 100%;
+    gap: var(--margin-s);
+}
+
+.social-media-row {
+    display: flex;
     gap: var(--margin-m);
 }
 
-.util-modal li p {
-    cursor: pointer;
-    text-decoration: underline;
-}
-
-.util-modal li {
-    margin: 0;
-}
-
-@media (max-width: 500px) {
-    .util-modal .align-child-on-line button {
-        font-size: var(--font-xs);
-    }
-
-    .util-modal h1 {
-        font-size: var(--font-l);
-    }
-
-    .util-modal ul:last-of-type {
-        flex-direction: row;
-        flex-wrap: wrap;
-        gap: var(--margin-s);
-    }
-}
-
-.theme-toggle {
+.social-media-button {
     background: none;
     border: none;
     padding: 0;
     cursor: pointer;
     display: flex;
     align-items: center;
+    min-width: auto;
+    width: auto;
+    height: auto;
+}
+
+.social-media-button img {
+    height: 20px;
+    width: 20px;
+}
+
+.links-row {
+    display: flex;
+    gap: var(--margin-l);
+}
+
+.links-row a,
+.links-row button {
+    color: var(--color-primary);
+    text-decoration: underline;
+    font-size: var(--font-xs);
+    height: fit-content;
 }
 
 .text-button {
@@ -87,8 +67,72 @@
     border: none;
     padding: 0;
     cursor: pointer;
-    text-decoration: underline;
     color: var(--color-primary);
     font: inherit;
     text-align: left;
+}
+
+.separator {
+    width: 100%;
+    height: 1px;
+    background-color: var(--color-light-gray);
+    margin: var(--margin-s) 0;
+}
+
+.toggle-switch {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.toggle-switch__label {
+    font-size: var(--font-xs);
+    color: var(--color-primary);
+    user-select: none;
+}
+
+.toggle-switch__input {
+    position: relative;
+    width: 40px;
+    height: 20px;
+    appearance: none;
+    background-color: var(--color-light-gray);
+    border-radius: 20px;
+    cursor: pointer;
+    transition: background-color var(--transition-default);
+}
+
+.toggle-switch__input::before {
+    content: '';
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    top: 2px;
+    left: 2px;
+    background-color: var(--color-white);
+    transition: transform var(--transition-default);
+}
+
+.toggle-switch__input:checked {
+    background-color: var(--incentive-blue);
+}
+
+.toggle-switch__input:checked::before {
+    transform: translateX(20px);
+}
+
+@media (max-width: 500px) {
+    .util-modal {
+        width: 85%;
+    }
+
+    .modal-header h1 {
+        font-size: var(--font-m);
+    }
+
+    .toggle-switch__label {
+        font-size: var(--font-xxs);
+    }
 }

--- a/packages/frontend/src/components/Modals/UtilModal/UtilModal.tsx
+++ b/packages/frontend/src/components/Modals/UtilModal/UtilModal.tsx
@@ -12,15 +12,13 @@ import { LegalDisclaimer } from '../LegalDisclaimer/LegalDisclaimer'
 interface UtilModalProps {
     className: string
     children?: React.ReactNode
-    colorTheme: string
-    handleColorThemeToggle: () => void
 }
 
 const GITHUB_ICON = `${process.env.PUBLIC_URL}/icons/github.svg`
 
-const UtilModal: React.FC<UtilModalProps> = ({ className, children, colorTheme, handleColorThemeToggle }) => {
+const UtilModal: React.FC<UtilModalProps> = ({ className, children }) => {
     const { t } = useTranslation()
-    const [isOptedOut, setIsOptedOut] = useAnalyticsOptOut()
+    const [isOptedOut, updateOptOut] = useAnalyticsOptOut()
 
     const [isContactModalOpen, setIsContactModalOpen] = useState(false)
     const [isLegalDisclaimerOpen, setIsLegalDisclaimerOpen] = useState(false)
@@ -28,6 +26,7 @@ const UtilModal: React.FC<UtilModalProps> = ({ className, children, colorTheme, 
     return (
         <>
             <div className={`util-modal info-popup modal ${className}`}>
+                {children}
                 <div className="modal-header">
                     <h1>{t('UtilModal.title')}</h1>
                     <button className="action" onClick={() => setIsContactModalOpen(true)} type="button">
@@ -55,7 +54,7 @@ const UtilModal: React.FC<UtilModalProps> = ({ className, children, colorTheme, 
                             type="checkbox"
                             className="toggle-switch__input"
                             checked={!isOptedOut}
-                            onChange={() => setIsOptedOut(!isOptedOut)}
+                            onChange={() => updateOptOut(!isOptedOut)}
                             aria-label={t('UtilModal.analytics-opted-out')}
                         />
                     </div>

--- a/packages/frontend/src/components/Modals/UtilModal/UtilModal.tsx
+++ b/packages/frontend/src/components/Modals/UtilModal/UtilModal.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
+import { useAnalyticsOptOut } from '../../../hooks/useAnalyticsOptOut'
 import { Backdrop } from '../../Miscellaneous/Backdrop/Backdrop'
 import { ContactSection } from '../ContactSection/ContactSection'
 import { LegalDisclaimer } from '../LegalDisclaimer/LegalDisclaimer'
@@ -16,11 +17,10 @@ interface UtilModalProps {
 }
 
 const GITHUB_ICON = `${process.env.PUBLIC_URL}/icons/github.svg`
-const LIGHT_ICON = `${process.env.PUBLIC_URL}/icons/light.svg`
-const DARK_ICON = `${process.env.PUBLIC_URL}/icons/dark.svg`
 
 const UtilModal: React.FC<UtilModalProps> = ({ className, children, colorTheme, handleColorThemeToggle }) => {
     const { t } = useTranslation()
+    const [isOptedOut, setIsOptedOut] = useAnalyticsOptOut()
 
     const [isContactModalOpen, setIsContactModalOpen] = useState(false)
     const [isLegalDisclaimerOpen, setIsLegalDisclaimerOpen] = useState(false)
@@ -28,47 +28,37 @@ const UtilModal: React.FC<UtilModalProps> = ({ className, children, colorTheme, 
     return (
         <>
             <div className={`util-modal info-popup modal ${className}`}>
-                {children}
-                <div className="align-child-on-line">
+                <div className="modal-header">
                     <h1>{t('UtilModal.title')}</h1>
                     <button className="action" onClick={() => setIsContactModalOpen(true)} type="button">
                         {t('UtilModal.feedback-button')}
                     </button>
                 </div>
-                <div>
-                    <ul>
-                        <button className="theme-toggle" onClick={handleColorThemeToggle} type="button">
-                            {colorTheme === 'light' ? (
-                                <img src={LIGHT_ICON} alt="Light Icon" />
-                            ) : (
-                                <img src={DARK_ICON} alt="Dark Icon" />
-                            )}
+                <div className="modal-content">
+                    <div className="social-media-row">
+                        <button className="social-media-button" type="button">
+                            <img src={GITHUB_ICON} alt="GitHub Icon" />
                         </button>
-                    </ul>
-                    <ul className="align-child-on-line">
-                        <li>
-                            <Link to="/Datenschutz">{t('UtilModal.privacy')}</Link>
-                        </li>
-                        <li>
-                            <button
-                                className="text-button"
-                                onClick={() => setIsLegalDisclaimerOpen(true)}
-                                type="button"
-                            >
-                                {t('UtilModal.terms')}
-                            </button>
-                        </li>
-                        <li>
-                            <a
-                                className="github-icon"
-                                href="https://github.com/FreiFahren/FreiFahren"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                <img src={GITHUB_ICON} alt="Github Icon" />
-                            </a>
-                        </li>
-                    </ul>
+                    </div>
+                    <div className="links-row">
+                        <Link to="/Datenschutz">{t('UtilModal.privacy')}</Link>
+                        <button className="text-button" onClick={() => setIsLegalDisclaimerOpen(true)} type="button">
+                            {t('UtilModal.terms')}
+                        </button>
+                    </div>
+                    <div className="separator" />
+                    <div className="toggle-switch">
+                        <span className="toggle-switch__label">
+                            {isOptedOut ? t('UtilModal.analytics-opted-out') : t('UtilModal.analytics-opted-in')}
+                        </span>
+                        <input
+                            type="checkbox"
+                            className="toggle-switch__input"
+                            checked={!isOptedOut}
+                            onChange={() => setIsOptedOut(!isOptedOut)}
+                            aria-label={t('UtilModal.analytics-opted-out')}
+                        />
+                    </div>
                 </div>
             </div>
             {isContactModalOpen ? (

--- a/packages/frontend/src/hooks/useAnalytics.ts
+++ b/packages/frontend/src/hooks/useAnalytics.ts
@@ -1,4 +1,5 @@
 import { AnalyticsOptions, SavedEvent } from '../utils/types'
+import { isAnalyticsOptedOut } from './useAnalyticsOptOut'
 
 /**
  * Checks if the Pirsch analytics SDK is loaded and available.
@@ -54,6 +55,10 @@ const saveUnsuccessfulEvent = (eventName: string, options: AnalyticsOptions): vo
  * @returns {Promise<void>} A promise that resolves if the event is sent successfully, or rejects with an error.
  */
 export const sendAnalyticsEvent = async (eventName: string, options?: AnalyticsOptions): Promise<void> => {
+    if (isAnalyticsOptedOut()) {
+        return
+    }
+
     try {
         await waitForPirsch()
         return await new Promise((resolve, reject) => {

--- a/packages/frontend/src/hooks/useAnalytics.ts
+++ b/packages/frontend/src/hooks/useAnalytics.ts
@@ -56,7 +56,7 @@ const saveUnsuccessfulEvent = (eventName: string, options: AnalyticsOptions): vo
  */
 export const sendAnalyticsEvent = async (eventName: string, options?: AnalyticsOptions): Promise<void> => {
     if (isAnalyticsOptedOut()) {
-        return
+        return Promise.resolve()
     }
 
     try {

--- a/packages/frontend/src/hooks/useAnalyticsOptOut.ts
+++ b/packages/frontend/src/hooks/useAnalyticsOptOut.ts
@@ -1,22 +1,24 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 
 const ANALYTICS_OPT_OUT_KEY = 'analyticsOptOut'
 
+const getStoredPreference = (): boolean => {
+    const savedPreference = localStorage.getItem(ANALYTICS_OPT_OUT_KEY)
+    return savedPreference !== null && JSON.parse(savedPreference)
+}
+
 export const useAnalyticsOptOut = (): [boolean, (optOut: boolean) => void] => {
-    const [isOptedOut, setIsOptedOut] = useState<boolean>(() => {
-        const savedPreference = localStorage.getItem(ANALYTICS_OPT_OUT_KEY)
-        return savedPreference ? JSON.parse(savedPreference) : false
-    })
+    const [isOptedOut, setIsOptedOut] = useState<boolean>(getStoredPreference)
 
-    // Note: this is do able without a useEffect
-    useEffect(() => {
-        localStorage.setItem(ANALYTICS_OPT_OUT_KEY, JSON.stringify(isOptedOut))
-    }, [isOptedOut])
+    const updateOptOut = (optOut: boolean): void => {
+        localStorage.setItem(ANALYTICS_OPT_OUT_KEY, JSON.stringify(optOut))
+        setIsOptedOut(optOut)
+    }
 
-    return [isOptedOut, setIsOptedOut]
+    return [isOptedOut, updateOptOut]
 }
 
 export const isAnalyticsOptedOut = (): boolean => {
     const savedPreference = localStorage.getItem(ANALYTICS_OPT_OUT_KEY)
-    return savedPreference ? JSON.parse(savedPreference) : false
+    return savedPreference !== null && JSON.parse(savedPreference)
 }

--- a/packages/frontend/src/hooks/useAnalyticsOptOut.ts
+++ b/packages/frontend/src/hooks/useAnalyticsOptOut.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react'
+
+const ANALYTICS_OPT_OUT_KEY = 'analyticsOptOut'
+
+export const useAnalyticsOptOut = (): [boolean, (optOut: boolean) => void] => {
+    const [isOptedOut, setIsOptedOut] = useState<boolean>(() => {
+        const savedPreference = localStorage.getItem(ANALYTICS_OPT_OUT_KEY)
+        return savedPreference ? JSON.parse(savedPreference) : false
+    })
+
+    // Note: this is do able without a useEffect
+    useEffect(() => {
+        localStorage.setItem(ANALYTICS_OPT_OUT_KEY, JSON.stringify(isOptedOut))
+    }, [isOptedOut])
+
+    return [isOptedOut, setIsOptedOut]
+}
+
+export const isAnalyticsOptedOut = (): boolean => {
+    const savedPreference = localStorage.getItem(ANALYTICS_OPT_OUT_KEY)
+    return savedPreference ? JSON.parse(savedPreference) : false
+}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -16,6 +16,8 @@
 }
 
 :root {
+    --color-primary: #dee2e6;
+    --color-background: #232323;
     --color-blue: #0075ff;
     --incentive-blue: #0f90ff;
     --color-red: #ff0017f5;
@@ -78,16 +80,6 @@
     --distance-from-edge-default: 15px;
     --button-size: 50px;
     --height-streched-button: 45px;
-}
-
-:root.light {
-    --color-primary: #191d21;
-    --color-background: #ffffff;
-}
-
-:root.dark {
-    --color-primary: #dee2e6;
-    --color-background: #232323;
 }
 
 /* ELEMENT STYLES */
@@ -156,8 +148,8 @@ hr {
     border-radius: var(--borderRadius-small);
 }
 
-.dark svg,
-.dark img[src$='.svg'] {
+svg,
+img[src$='.svg'] {
     filter: invert(1);
 }
 
@@ -194,7 +186,7 @@ button:hover {
     filter: brightness(1.1);
 }
 
-:root.dark button a {
+button a {
     color: var(--color-primary);
 }
 

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -23,14 +23,13 @@ import { ViewedReportsProvider } from '../../contexts/ViewedReportsContext'
 import { sendAnalyticsEvent, sendSavedEvents } from '../../hooks/useAnalytics'
 import { useModalAnimation } from '../../hooks/UseModalAnimation'
 import { getNumberOfReportsInLast24Hours } from '../../utils/databaseUtils'
-import { currentColorTheme, highlightElement, setColorThemeInLocalStorage } from '../../utils/uiUtils'
+import { highlightElement } from '../../utils/uiUtils'
 
 type AppUIState = {
     isReportFormOpen: boolean
     formSubmitted: boolean
     isFirstOpen: boolean
     isStatsPopUpOpen: boolean
-    currentColorTheme: string
     isRiskLayerOpen: boolean
     isListModalOpen: boolean
     isLegalDisclaimerOpen: boolean
@@ -41,16 +40,14 @@ const initialAppUIState: AppUIState = {
     formSubmitted: false,
     isFirstOpen: true,
     isStatsPopUpOpen: false,
-    currentColorTheme: currentColorTheme(),
     isRiskLayerOpen: localStorage.getItem('layer') === 'risk',
     isListModalOpen: false,
     isLegalDisclaimerOpen: false,
 }
 
-const isTelegramWebApp = (): boolean => 
+const isTelegramWebApp = (): boolean =>
     // @ts-ignore since TelegramWebviewProxy is not in the window type definitions
-     typeof TelegramWebviewProxy !== 'undefined'
-
+    typeof TelegramWebviewProxy !== 'undefined'
 
 const App = () => {
     const [appUIState, setAppUIState] = useState<AppUIState>(initialAppUIState)
@@ -86,30 +83,7 @@ const App = () => {
         }
     }
 
-    const toggleColorTheme = () => {
-        setColorThemeInLocalStorage()
-        setAppUIState({ ...appUIState, currentColorTheme: currentColorTheme() })
-
-        // add classes to the root element to change the color theme
-        const root = document.documentElement
-
-        if (currentColorTheme() === 'light') {
-            root.classList.add('light')
-            root.classList.remove('dark')
-        } else {
-            root.classList.add('dark')
-            root.classList.remove('light')
-        }
-    }
-
-    // run on app mount
     useEffect(() => {
-        // set the color theme by manipulating the root element
-        const root = document.documentElement
-
-        root.classList.add(currentColorTheme())
-
-        // send saved events to the backend
         sendSavedEvents().catch((error) => {
             // fix later with sentry
             // eslint-disable-next-line no-console
@@ -259,11 +233,7 @@ const App = () => {
                 </>
             ) : null}
             {isUtilOpen ? (
-                <UtilModal
-                    className={`open ${isUtilAnimatingOut ? 'slide-out' : 'slide-in'}`}
-                    colorTheme={appUIState.currentColorTheme}
-                    handleColorThemeToggle={toggleColorTheme}
-                >
+                <UtilModal className={`open ${isUtilAnimatingOut ? 'slide-out' : 'slide-in'}`}>
                     <CloseButton handleClose={closeUtilModal} />
                 </UtilModal>
             ) : null}
@@ -296,7 +266,6 @@ const App = () => {
                             <FreifahrenMap
                                 isFirstOpen={appUIState.isFirstOpen}
                                 formSubmitted={appUIState.formSubmitted}
-                                currentColorTheme={appUIState.currentColorTheme}
                                 isRiskLayerOpen={appUIState.isRiskLayerOpen}
                                 onRotationChange={handleRotationChange}
                             />

--- a/packages/frontend/src/utils/uiUtils.tsx
+++ b/packages/frontend/src/utils/uiUtils.tsx
@@ -30,22 +30,6 @@ export const createWarningSpan = (elementId: string, message: string): void => {
     }
 }
 
-export const currentColorTheme = (): string => {
-    const colorTheme = localStorage.getItem('colorTheme')
-
-    return colorTheme ?? 'dark'
-}
-
-export const setColorThemeInLocalStorage = (): void => {
-    const colorTheme = currentColorTheme()
-
-    if (colorTheme === 'dark') {
-        localStorage.setItem('colorTheme', 'light')
-    } else {
-        localStorage.setItem('colorTheme', 'dark')
-    }
-}
-
 /**
  * Returns the color of a line based on the line name.
  * @param line - The name of the line.


### PR DESCRIPTION
## Describe the Issue:
We were tracking anonymized user behavior. While this is legal and does not pose any privacy concerns for users, it would be considerate to provide users with the option to opt out of tracking. This demonstrates our commitment to privacy and ensures users feel secure when using the app.

## Explain How You Solved the Issue:
I added a button that stores the opt-out preference in `localStorage`. Each time an analytics event is triggered, the app first checks whether the user has opted out before sending the event.

## Additional Notes or Considerations:
I removed the light mode button since light mode will be removed entirely very soon. Additionally, it was causing layout issues.
