### PR TITLE
chore: adapt api requests to explicit version

### DIFF
--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -37,7 +37,7 @@ const client = axios.create({
 })
 
 const getReports = async (start: DateTime, end: DateTime): Promise<Report[]> => {
-    const { data } = await client.get('/basics/inspectors', {
+    const { data } = await client.get('/v0/basics/inspectors', {
         params: {
             start: start.toISO(),
             end: end.toISO(),
@@ -62,7 +62,7 @@ type PostReport = {
 }
 
 const postReport = async (report: PostReport) => {
-    const { data } = await client.post('/basics/inspectors', {
+    const { data } = await client.post('/v0/basics/inspectors', {
         ...report,
         directionId: report.directionId ?? '',
     })
@@ -83,7 +83,7 @@ const riskSchema = z
 export type RiskData = z.infer<typeof riskSchema>
 
 export const getRiskData = async (): Promise<RiskData> => {
-    const { data } = await client.get('/risk-prediction/segment-colors')
+    const { data } = await client.get('/v0/risk-prediction/segment-colors')
 
     return riskSchema.parse(data)
 }
@@ -103,7 +103,7 @@ export const stationsSchema = z.record(stationSchema)
 export type Stations = z.infer<typeof stationsSchema>
 
 export const getStations = async (): Promise<Record<string, Station>> => {
-    const { data } = await client.get('/stations')
+    const { data } = await client.get('/v0/stations')
 
     return stationsSchema.parse(data)
 }
@@ -112,7 +112,7 @@ export const linesSchema = z.record(z.array(z.string()))
 export type Lines = z.infer<typeof linesSchema>
 
 export const getLines = async (): Promise<Record<string, string[]>> => {
-    const { data } = await client.get('/lines')
+    const { data } = await client.get('/v0/lines')
 
     return linesSchema.parse(data)
 }
@@ -124,7 +124,7 @@ export const stationStatisticsSchema = z.object({
 export type StationStatistics = z.infer<typeof stationStatisticsSchema>
 
 export const getStationStatistics = async (stationId: string) => {
-    const { data } = await client.get(`/stations/${stationId}/statistics`)
+    const { data } = await client.get(`/v0/stations/${stationId}/statistics`)
 
     return stationStatisticsSchema.parse(data)
 }

--- a/packages/frontend/src/components/Map/Map.tsx
+++ b/packages/frontend/src/components/Map/Map.tsx
@@ -39,7 +39,7 @@ const FreifahrenMap: React.FC<FreifahrenMapProps> = ({
     const maxBounds: LngLatBoundsLike = [SouthWestBounds, NorthEastBounds]
 
     const { data: lineSegments, error: segmentsError } = useETagCache<GeoJSON.FeatureCollection<GeoJSON.LineString>>({
-        endpoint: '/lines/segments',
+        endpoint: '/v0/lines/segments',
         storageKeyPrefix: 'segments',
         onError: (error) => {
             // fix this later with sentry

--- a/packages/frontend/src/contexts/ReportsContext.tsx
+++ b/packages/frontend/src/contexts/ReportsContext.tsx
@@ -33,7 +33,7 @@ export const ReportsProvider: React.FC<{ children: React.ReactNode }> = ({ child
         const startTime = new Date(new Date(endTime).getTime() - 60 * 60 * 1000).toISOString()
 
         const response = await getWithIfModifiedSince<Report[]>(
-            `/basics/inspectors?start=${startTime}&end=${endTime}`,
+            `/v0/basics/inspectors?start=${startTime}&end=${endTime}`,
             lastReceivedreportTime.current
         )
 
@@ -94,7 +94,7 @@ export const ReportsProvider: React.FC<{ children: React.ReactNode }> = ({ child
             const endTimeInRFC3339 = new Date(currentTime - 1000 * 60 * 60).toISOString()
 
             const response = await get<Report[]>(
-                `/basics/inspectors?start=${startTimeInRFC3339}&end=${endTimeInRFC3339}`
+                `/v0/basics/inspectors?start=${startTimeInRFC3339}&end=${endTimeInRFC3339}`
             )
 
             if (response.success && response.data) {

--- a/packages/frontend/src/contexts/RiskDataContext.tsx
+++ b/packages/frontend/src/contexts/RiskDataContext.tsx
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash'
-import React, { createContext, useCallback,useContext, useMemo,useState } from 'react'
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react'
 import { RiskData } from 'src/utils/types'
 
 const defaultRefreshRiskData = async (): Promise<void> => {
@@ -18,7 +18,7 @@ export const RiskDataProvider = ({ children }: { children: React.ReactNode }) =>
 
     const refreshRiskData = useCallback(async () => {
         try {
-            const results = await fetch(`${process.env.REACT_APP_API_URL}/risk-prediction/segment-colors`)
+            const results = await fetch(`${process.env.REACT_APP_API_URL}/v0/risk-prediction/segment-colors`)
 
             if (!results.ok) {
                 throw new Error('Failed to fetch risk data')
@@ -37,10 +37,7 @@ export const RiskDataProvider = ({ children }: { children: React.ReactNode }) =>
         }
     }, [segmentRiskData])
 
-    const value = useMemo(
-        () => ({ segmentRiskData, refreshRiskData }),
-        [segmentRiskData, refreshRiskData]
-    )
+    const value = useMemo(() => ({ segmentRiskData, refreshRiskData }), [segmentRiskData, refreshRiskData])
 
     return <RiskDataContext.Provider value={value}>{children}</RiskDataContext.Provider>
 }

--- a/packages/frontend/src/hooks/useStationReports.ts
+++ b/packages/frontend/src/hooks/useStationReports.ts
@@ -1,4 +1,4 @@
-import { useEffect,useRef,useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 type Statistics = {
     numberOfReports: number
@@ -27,7 +27,7 @@ export const useStationReports = (stationId: string): number => {
     useEffect(() => {
         if (stationId && !fetchingRef.current) {
             fetchingRef.current = true
-            fetch(`${process.env.REACT_APP_API_URL}/stations/${stationId}/statistics`)
+            fetch(`${process.env.REACT_APP_API_URL}/v0/stations/${stationId}/statistics`)
                 .then((response) => response.json())
                 .then((data: Statistics) => {
                     setNumberOfReports(data.numberOfReports)

--- a/packages/frontend/src/utils/databaseUtils.tsx
+++ b/packages/frontend/src/utils/databaseUtils.tsx
@@ -73,7 +73,7 @@ export const getAllStationsList = async (): Promise<StationList> => {
 
 export const getAllLinesList = async (): Promise<LinesList> => {
     try {
-        const response = await fetch(`${process.env.REACT_APP_API_URL}/lines`)
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/v0/lines`)
         const data = await response.json()
 
         return data
@@ -93,7 +93,7 @@ export const reportInspector = async (line: string, stationId: string, direction
         message: message || '',
     })
 
-    fetch(`${process.env.REACT_APP_API_URL}/basics/inspectors`, {
+    fetch(`${process.env.REACT_APP_API_URL}/v0/basics/inspectors`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -147,7 +147,7 @@ export const getNumberOfReportsInLast24Hours = async (): Promise<number> => {
         const startTime = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
 
         // Construct the URL with query parameters
-        const url = new URL(`${process.env.REACT_APP_API_URL}/basics/inspectors`)
+        const url = new URL(`${process.env.REACT_APP_API_URL}/v0/basics/inspectors`)
 
         url.searchParams.append('start', startTime)
         url.searchParams.append('end', endTime)

--- a/packages/instagram_bot/src/index.ts
+++ b/packages/instagram_bot/src/index.ts
@@ -15,7 +15,7 @@ const app = new Hono()
 app.use('/images/*', serveStatic({ root: './' }))
 
 async function fetchInspectorData() {
-    const response = await fetch(`${process.env.API_URL}/basics/inspectors`)
+    const response = await fetch(`${process.env.API_URL}/v0/basics/inspectors`)
     if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`)
     }

--- a/packages/nlp_service/FreiFahren_BE_NLP/db_utils.py
+++ b/packages/nlp_service/FreiFahren_BE_NLP/db_utils.py
@@ -49,7 +49,7 @@ def fetch_id(name, entity_type):
     if not name:
         return None
 
-    url = f"{BACKEND_URL}/stations/search?name={name}"
+    url = f"{BACKEND_URL}/v0/stations/search?name={name}"
 
     try:
         response = requests.get(url, timeout=10)

--- a/packages/nlp_service/FreiFahren_BE_NLP/process_message.py
+++ b/packages/nlp_service/FreiFahren_BE_NLP/process_message.py
@@ -37,7 +37,7 @@ def create_lines_with_station_names(lines_with_ids, stations):
 
 
 # Fetch lines data
-response = requests.get(f"{BACKEND_URL}/lines")
+response = requests.get(f"{BACKEND_URL}/v0/lines")
 lines_with_stations_as_ids = response.json()
 
 # Fetch stations data

--- a/scripts/segments.py
+++ b/scripts/segments.py
@@ -49,7 +49,7 @@ def cut_line(
 def fetch_api_data() -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
     """Fetch stations and lines data from the API."""
     stations_json = requests.get("https://api.freifahren.org/stations").json()
-    lines_json = requests.get("https://api.freifahren.org/lines").json()
+    lines_json = requests.get("https://api.freifahren.org/v0/lines").json()
     lines = [line for line in lines_json]
     return stations_json, lines
 


### PR DESCRIPTION
even though they would be routed to the latest version and thus not breaking anything it is better to be explicit about it as to avoid issues by forgetting to specify the version.

Every endpoint will have its own version to stay more modular that is why I did not create a global variable.
