### PR TITLE
feat: hint that the reports are synchronised with the telegram group

### DIFF
--- a/packages/frontend/public/locales/de.json
+++ b/packages/frontend/public/locales/de.json
@@ -45,7 +45,7 @@
         "description": "Beschreibung",
         "descriptionPlaceholder": "Beschreibung",
         "report": "Melden",
-        "syncText": "Meldungen mit @FreiFahren_BE synchronisiert"
+        "syncText": "Die Meldung wird mit @FreiFahren_BE synchronisiert"
     },
     "PrivacyCheckbox": {
         "privacy1": "Ich stimme der",
@@ -200,7 +200,8 @@
     "ReportSummaryModal": {
         "title": "Danke für deine Meldung!",
         "description": "Menschen schätzen deine Hilfe!",
-        "button": "Weiter"
+        "button": "Weiter",
+        "syncText": "Die Meldung wird mit @FreiFahren_BE synchronisiert"
     },
     "FeedbackButton": {
         "text": "Feedback"

--- a/packages/frontend/public/locales/de.json
+++ b/packages/frontend/public/locales/de.json
@@ -71,7 +71,8 @@
         "stations": "Stationen",
         "fromYou": "entfernt",
         "direction": "Richtung",
-        "inviteText": "Daten vielleicht ungenau."
+        "inviteText": "Daten vielleicht ungenau.",
+        "syncText": "Meldungen mit @FreiFahren_BE synchronisert"
     },
     "Share": {
         "title": "Schau dir mal diese App an.",

--- a/packages/frontend/public/locales/de.json
+++ b/packages/frontend/public/locales/de.json
@@ -44,7 +44,8 @@
         "direction": "Richtung",
         "description": "Beschreibung",
         "descriptionPlaceholder": "Beschreibung",
-        "report": "Melden"
+        "report": "Melden",
+        "syncText": "Meldungen mit @FreiFahren_BE synchronisiert"
     },
     "PrivacyCheckbox": {
         "privacy1": "Ich stimme der",

--- a/packages/frontend/public/locales/en.json
+++ b/packages/frontend/public/locales/en.json
@@ -203,7 +203,8 @@
     "ReportSummaryModal": {
         "title": "Thank you for your report!",
         "description": "People appreciate your help!",
-        "button": "Continue"
+        "button": "Continue",
+        "syncText": "Your report was synced with @FreiFahren_BE"
     },
     "FeedbackButton": {
         "text": "Feedback"

--- a/packages/frontend/public/locales/en.json
+++ b/packages/frontend/public/locales/en.json
@@ -74,7 +74,8 @@
         "stations": "stations",
         "fromYou": "away",
         "direction": "Direction",
-        "inviteText": "Data may be inaccurate."
+        "inviteText": "Data may be inaccurate.",
+        "syncText": "Reports synced with @FreiFahren_BE"
     },
     "Share": {
         "title": "Check out this app.",

--- a/packages/frontend/public/locales/en.json
+++ b/packages/frontend/public/locales/en.json
@@ -47,7 +47,8 @@
         "privacy1": "I agree to the",
         "privacy2": "Privacy policy",
         "privacy3": ".",
-        "report": "Submit"
+        "report": "Submit",
+        "syncText": "Reports synced with @FreiFahren_BE"
     },
     "PrivacyCheckbox": {
         "privacy1": "I agree to the",

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -484,20 +484,24 @@ const ReportForm: FC<ReportFormProps> = ({ closeModal, onNotifyParentAboutSubmis
                                 </SelectField>
                             </section>
                         ) : null}
-                        <section className="description-field">
-                            <h3>{t('ReportForm.description')}</h3>
-                            <textarea
-                                placeholder={t('ReportForm.descriptionPlaceholder')}
-                                onChange={(event) => setDescription(event.target.value)}
-                                value={description ?? ''}
-                            />
-                        </section>
+                        {currentStation !== null && (
+                            <section className="description-field">
+                                <h3>{t('ReportForm.description')}</h3>
+                                <textarea
+                                    placeholder={t('ReportForm.descriptionPlaceholder')}
+                                    onChange={(event) => setDescription(event.target.value)}
+                                    value={description ?? ''}
+                                />
+                            </section>
+                        )}
                         <section>
                             <div>
-                                <PrivacyCheckbox
-                                    isChecked={isPrivacyChecked}
-                                    onChange={() => setIsPrivacyChecked(!isPrivacyChecked)}
-                                />
+                                {currentStation !== null && (
+                                    <PrivacyCheckbox
+                                        isChecked={isPrivacyChecked}
+                                        onChange={() => setIsPrivacyChecked(!isPrivacyChecked)}
+                                    />
+                                )}
                             </div>
                             <div>
                                 <button
@@ -506,6 +510,7 @@ const ReportForm: FC<ReportFormProps> = ({ closeModal, onNotifyParentAboutSubmis
                                 >
                                     {t('ReportForm.report')}
                                 </button>
+                                <p className="disclaimer">{t('ReportForm.syncText')}</p>
                             </div>
                         </section>
                     </div>

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -1,6 +1,6 @@
 import './ReportForm.css'
 
-import React, { FC, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { ChangeEvent, FC, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import FeedbackButton from 'src/components/Buttons/FeedbackButton/FeedbackButton'
 
@@ -42,7 +42,7 @@ const ReportForm: FC<ReportFormProps> = ({ closeModal, onNotifyParentAboutSubmis
     const [currentLine, setCurrentLine] = useState<string | null>(null)
     const [currentStation, setCurrentStation] = useState<string | null>(null)
     const [currentDirection, setCurrentDirection] = useState<string | null>(null)
-    const [description, setDescription] = useState<string | null>(null)
+    const descriptionRef = useRef<HTMLTextAreaElement>(null)
 
     const [stationSearch, setStationSearch] = useState<string>('')
     const [searchUsed, setSearchUsed] = useState<boolean>(false)
@@ -302,7 +302,7 @@ const ReportForm: FC<ReportFormProps> = ({ closeModal, onNotifyParentAboutSubmis
 
         if (hasError) return // Abort submission if there are validation errors
 
-        await reportInspector(currentLine!, currentStation!, currentDirection!, description!)
+        await reportInspector(currentLine!, currentStation!, currentDirection!, descriptionRef.current?.value!)
 
         const endTime = new Date()
         const durationInSeconds = Math.round((endTime.getTime() - startTime.current.getTime()) / 1000)
@@ -322,7 +322,7 @@ const ReportForm: FC<ReportFormProps> = ({ closeModal, onNotifyParentAboutSubmis
                           coordinates: allStations[currentDirection!].coordinates,
                       }
                     : null,
-            message: description,
+            message: descriptionRef.current?.value ?? '',
             timestamp: endTime.toISOString(),
             isHistoric: false,
         }
@@ -487,11 +487,7 @@ const ReportForm: FC<ReportFormProps> = ({ closeModal, onNotifyParentAboutSubmis
                         {currentStation !== null && (
                             <section className="description-field">
                                 <h3>{t('ReportForm.description')}</h3>
-                                <textarea
-                                    placeholder={t('ReportForm.descriptionPlaceholder')}
-                                    onChange={(event) => setDescription(event.target.value)}
-                                    value={description ?? ''}
-                                />
+                                <textarea ref={descriptionRef} placeholder={t('ReportForm.descriptionPlaceholder')} />
                             </section>
                         )}
                         <section>

--- a/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
+++ b/packages/frontend/src/components/Form/ReportForm/ReportForm.tsx
@@ -1,6 +1,6 @@
 import './ReportForm.css'
 
-import React, { ChangeEvent, FC, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { FC, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import FeedbackButton from 'src/components/Buttons/FeedbackButton/FeedbackButton'
 
@@ -484,20 +484,20 @@ const ReportForm: FC<ReportFormProps> = ({ closeModal, onNotifyParentAboutSubmis
                                 </SelectField>
                             </section>
                         ) : null}
-                        {currentStation !== null && (
+                        {currentStation !== null ? (
                             <section className="description-field">
                                 <h3>{t('ReportForm.description')}</h3>
                                 <textarea ref={descriptionRef} placeholder={t('ReportForm.descriptionPlaceholder')} />
                             </section>
-                        )}
+                        ) : null}
                         <section>
                             <div>
-                                {currentStation !== null && (
+                                {currentStation !== null ? (
                                     <PrivacyCheckbox
                                         isChecked={isPrivacyChecked}
                                         onChange={() => setIsPrivacyChecked(!isPrivacyChecked)}
                                     />
-                                )}
+                                ) : null}
                             </div>
                             <div>
                                 <button

--- a/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.css
+++ b/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.css
@@ -42,8 +42,6 @@
 }
 
 .marker-modal.info-popup .disclaimer {
-    font-size: var(--font-xxs);
-    color: var(--color-primary);
     text-align: right;
 }
 

--- a/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.tsx
+++ b/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.tsx
@@ -10,7 +10,6 @@ import { useStationDistance } from '../../../hooks/useStationDistance'
 import { useStationReports } from '../../../hooks/useStationReports'
 import { Line } from '../../Miscellaneous/Line/Line'
 import { Skeleton, useSkeleton } from '../../Miscellaneous/LoadingPlaceholder/Skeleton'
-import { ShareButton } from '../../Miscellaneous/ShareButton/ShareButton'
 
 interface MarkerModalProps {
     selectedMarker: Report
@@ -24,7 +23,7 @@ const MarkerModal: React.FC<MarkerModalProps> = ({ className, children, selected
     const { t } = useTranslation()
 
     const { allStations } = useStationsAndLines()
-    const { timestamp, station, line, direction } = selectedMarker
+    const { timestamp, station, line, direction, message } = selectedMarker
 
     const numberOfReports = useStationReports(station.id)
     const {
@@ -42,7 +41,7 @@ const MarkerModal: React.FC<MarkerModalProps> = ({ className, children, selected
             {children}
             <h1>{station.name}</h1>
             <div className="align-child-on-line direction-line">
-                {line && <Line line={line} />}
+                {line !== null ? <Line line={line} /> : null}
                 {direction?.name !== undefined ? <h2>{direction.name}</h2> : null}
             </div>
             <div>
@@ -62,9 +61,7 @@ const MarkerModal: React.FC<MarkerModalProps> = ({ className, children, selected
                     <span className="disclaimer">{t('MarkerModal.inviteText')}</span>
                 </div>
                 <span className="disclaimer">{t('MarkerModal.syncText')}</span>
-                {selectedMarker.message !== null && selectedMarker.message !== undefined ? (
-                    <p className="description">{selectedMarker.message}</p>
-                ) : null}
+                {message !== null && message !== '' ? <p className="description">{message}</p> : null}
             </div>
         </div>
     )

--- a/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.tsx
+++ b/packages/frontend/src/components/Modals/MarkerModal/MarkerModal.tsx
@@ -42,28 +42,29 @@ const MarkerModal: React.FC<MarkerModalProps> = ({ className, children, selected
             {children}
             <h1>{station.name}</h1>
             <div className="align-child-on-line direction-line">
-                {/*  because no line should be shown
-                eslint-disable-next-line react/jsx-no-leaked-render */}
-                {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, react/jsx-no-leaked-render */}
                 {line && <Line line={line} />}
                 {direction?.name !== undefined ? <h2>{direction.name}</h2> : null}
             </div>
             <div>
                 <p>{elapsedTimeMessage}</p>
-                {numberOfReports > 0 ? <p className="reports-count">
+                {numberOfReports > 0 ? (
+                    <p className="reports-count">
                         <b>
                             {numberOfReports} {t('MarkerModal.reports')}
                         </b>{' '}
                         {t('MarkerModal.thisWeek')}
-                    </p> : null}
+                    </p>
+                ) : null}
                 <div className="footer">
-                    {userLat !== undefined && userLng !== undefined ? <span className="distance">{showSkeleton ? <Skeleton /> : stationDistanceMessage}</span> : null}
+                    {userLat !== undefined && userLng !== undefined ? (
+                        <span className="distance">{showSkeleton ? <Skeleton /> : stationDistanceMessage}</span>
+                    ) : null}
                     <span className="disclaimer">{t('MarkerModal.inviteText')}</span>
                 </div>
-                {/* description can be undefined */}
-                {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
-                {selectedMarker.message !== null && selectedMarker.message !== undefined ? <p className="description">{selectedMarker.message}</p> : null}
-                <ShareButton report={selectedMarker} />
+                <span className="disclaimer">{t('MarkerModal.syncText')}</span>
+                {selectedMarker.message !== null && selectedMarker.message !== undefined ? (
+                    <p className="description">{selectedMarker.message}</p>
+                ) : null}
             </div>
         </div>
     )

--- a/packages/frontend/src/components/Modals/ReportSummaryModal/ReportSummaryModal.css
+++ b/packages/frontend/src/components/Modals/ReportSummaryModal/ReportSummaryModal.css
@@ -35,5 +35,10 @@
 }
 
 .report-summary-modal-content > p {
+    margin: 0;
     font-size: var(--font-s);
+}
+
+.report-summary-modal-content .disclaimer {
+    margin-bottom: var(--margin-s);
 }

--- a/packages/frontend/src/components/Modals/ReportSummaryModal/ReportSummaryModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportSummaryModal/ReportSummaryModal.tsx
@@ -52,6 +52,7 @@ const ReportSummaryModal: React.FC<ReportSummaryModalProps> = ({
                     <h1>{animatedCount}</h1>
                 </span>
                 <p>{t('ReportSummaryModal.description')}</p>
+                <span className="disclaimer">{t('ReportSummaryModal.syncText')}</span>
                 <button className="action" onClick={handleCloseModal} type="button">
                     {t('ReportSummaryModal.button')}
                 </button>

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -320,6 +320,11 @@ textarea::placeholder {
     color: var(--color-white);
 }
 
+.disclaimer {
+    font-size: var(--font-xxs);
+    color: var(--color-primary);
+}
+
 .row {
     display: flex;
     gap: var(--margin-m);


### PR DESCRIPTION
## Describe the Issue:
Some users were making a report in FreiFahren and then reporting it again inside the Telegram group, even though the reports are shared automatically. This indicates that users believe there are two separate communities and that the Telegram group and the web app do not share data.

## Explain How You Solved the Issue:
I added some hints to the following important sections:
- Report form
- Report summary
- Marker modal
<img width="524" alt="Bildschirmfoto 2025-01-24 um 14 28 08" src="https://github.com/user-attachments/assets/a9fda975-15b6-439b-b027-d6a4c154431b" />

## Additional Notes or Considerations:
I decided not to add a link to the hint to avoid funneling people away from the web app.
