### PR TITLE
Do subpage routing instead of query

### DIFF
--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -45,6 +45,14 @@ root.render(
                                 </LocationProvider>
                             }
                         />
+                        <Route
+                            path="/station/:stationId"
+                            element={
+                                <LocationProvider>
+                                    <App />
+                                </LocationProvider>
+                            }
+                        />
                         <Route path="/datenschutz" element={<PrivacyPolicy />} />
                         <Route path="/support" element={<Support />} />
                     </Routes>

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -2,7 +2,7 @@ import './App.css'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSearchParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { ReportsModalButton } from 'src/components/Buttons/ReportsModalButton/ReportsModalButton'
 import NavigationModal from 'src/components/Modals/NavigationModal/NavigationModal'
 import { ReportsModal } from 'src/components/Modals/ReportsModal/ReportsModal'
@@ -50,8 +50,8 @@ const isTelegramWebApp = (): boolean =>
     typeof TelegramWebviewProxy !== 'undefined'
 
 const App = () => {
-    const [searchParams, setSearchParams] = useSearchParams();
-    const stationId = searchParams.get('stationId');
+    const { stationId } = useParams();
+    const navigate = useNavigate();
     const { t } = useTranslation()
 
     const [appUIState, setAppUIState] = useState<AppUIState>(initialAppUIState)
@@ -243,15 +243,17 @@ const App = () => {
         setSelectedStation(station)
         openInfoModal()
         setStationModalWasManuallyCloses(false)
+        // Navigate to the station URL
+        navigate(`/station/${station.name}`)
     }
 
     const onCloseInfoModal = () => {
         setStationModalWasManuallyCloses(true)
         closeInfoModal()
         
-        // If we're on a station URL with query parameter, remove the query parameter
-        if (stationId !== null) {
-            setSearchParams({});
+        // If we're on a station URL, navigate back to home
+        if (stationId !== undefined) {
+            navigate('/');
         }
     }
 
@@ -263,7 +265,7 @@ const App = () => {
         }
     }
 
-    // Handle direct navigation to a station via URL query parameter
+    // Handle direct navigation to a station via URL parameter
     useEffect(() => {
         const isValidStationId = typeof stationId === 'string' && stationId.trim() !== '';
 
@@ -303,7 +305,7 @@ const App = () => {
         onStationSelect(stationProperty);
             
      
-    }, [stationId, stations, isInfoModalOpen, appUIState.isFirstOpen, closeLegalDisclaimer, onStationSelect, stationModalWasManuallyCloses, setSearchParams]);
+    }, [stationId, stations, isInfoModalOpen, appUIState.isFirstOpen, closeLegalDisclaimer, onStationSelect, stationModalWasManuallyCloses, navigate]);
 
     useEffect(() => {
         if (indicatorTimeoutRef.current) {

--- a/packages/nlp_service/services/api_adapter.py
+++ b/packages/nlp_service/services/api_adapter.py
@@ -29,9 +29,9 @@ def report_inspector() -> tuple:
     if direction:
         telegram_message += f"\n<b>Richtung</b>: {direction}"
     if message:
-        telegram_message += f"\nBeschreibung hier einsehbar: <a href='app.freifahren.org/?stationId={stationId}'>app.freifahren.org</a>"
+        telegram_message += f"\nBeschreibung hier einsehbar: <a href='app.freifahren.org/station/{stationId}'>app.freifahren.org</a>"
     else:
-        telegram_message += f"\n\nMehr Informationen auf <a href='app.freifahren.org/?stationId={stationId}'>app.freifahren.org</a>"
+        telegram_message += f"\n\nMehr Informationen auf <a href='app.freifahren.org/station/{stationId}'>app.freifahren.org</a>"
 
     send_message(FREIFAHREN_CHAT_ID, telegram_message, nlp_bot)
 


### PR DESCRIPTION

- Added a new route for station pages using the path "/station/:stationId".
- Replaced useSearchParams with useParams for better handling of stationId.
- Updated navigation logic to redirect users to the station page and back to home when closing the info modal.
- Adjusted telegram message links to point directly to the new station URL format.
