### PR TITLE
fix: tram detection issues

### DIFF
--- a/packages/backend/integration_tests/PostProcessInspector_test.go
+++ b/packages/backend/integration_tests/PostProcessInspector_test.go
@@ -71,11 +71,11 @@ func TestPostProcessInspectorData(t *testing.T) {
 	// Define test cases
 	testCases := []TestCase{
 		// Tests for AssignLineIfSingleOption
-		createTestCase("Imply line from direction", "", "U-n270165592", "", "U1", "U-n2097818462", "U-n270165592"),
+		createTestCase("Imply line from direction", "", "U-n27586255", "", "U2", "SUM-n30731497", "U-n27586255"),
 		createTestCase("Imply line from station", "U-n29190890", "", "", "U8", "U-n29190890", ""),
 		createTestCase("Imply line from station and direction", "U-n29190890", "SU-BWIN", "", "U8", "U-n29190890", "SU-BWIN"),
 		createTestCase("Don't imply line if station and direction are missing", "", "", "", "", "", ""),
-		createTestCase("Dont imply line if it is already set", "UM-n243996833", "SUM-n27412648", "U5", "U5", "UM-n243996833", "U-n52684988"),
+		createTestCase("Dont imply line if it is already set", "UM-n243996833", "SUM-n27412648", "U5", "U5", "UM-n243996833", "SUM-n27412648"),
 		createTestCase("Don't imply line if there are multiple options", "U-n2097818462", "", "", "", "U-n2097818462", ""),
 		// Tests for guessStation
 		createTestCase("Don't guess the station when the line is not set", "", "SUM-n27412648", "", "", "", ""),

--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -34,6 +34,7 @@
       "react"
     ],
     "rules": {
+      "react/prop-types": "off",
       "eqeqeq": ["error", "always"],
       "no-console": "error",
       "no-continue": "off",

--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -37,7 +37,6 @@
         "@babel/preset-react": "^7.24.1",
         "@babel/preset-typescript": "^7.24.1",
         "@tanstack/eslint-plugin-query": "^5.65.0",
-        "@types/prop-types": "^15.7.14",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "babel-plugin-react-compiler": "^19.0.0-beta-37ed2a7-20241206",
@@ -4279,13 +4278,6 @@
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/q": {
       "version": "1.5.8",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -61,7 +61,6 @@
     "@babel/preset-react": "^7.24.1",
     "@babel/preset-typescript": "^7.24.1",
     "@tanstack/eslint-plugin-query": "^5.65.0",
-    "@types/prop-types": "^15.7.14",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "babel-plugin-react-compiler": "^19.0.0-beta-37ed2a7-20241206",

--- a/packages/frontend/src/components/Modals/NavigationModal/ItineraryDetail.tsx
+++ b/packages/frontend/src/components/Modals/NavigationModal/ItineraryDetail.tsx
@@ -9,18 +9,18 @@ interface ItineraryDetailProps {
     itinerary: Itinerary
     className?: string
     onBack?: () => void
-    onSaveRoute?: (route: Itinerary) => void
-    onRemoveRoute?: () => void
+    handleSaveRoute?: (route: Itinerary) => void
+    handleRemoveRoute?: () => void
     isSaved?: boolean
 }
 
-const ItineraryDetail: React.FC<ItineraryDetailProps> = ({ 
-    itinerary, 
-    className, 
+const ItineraryDetail: React.FC<ItineraryDetailProps> = ({
+    itinerary,
+    className,
     onBack,
-    onSaveRoute,
-    onRemoveRoute,
-    isSaved = false
+    handleSaveRoute,
+    handleRemoveRoute,
+    isSaved = false,
 }) => {
     const { t } = useTranslation()
     const durationMinutes = Math.round(itinerary.duration / 60)
@@ -148,24 +148,16 @@ const ItineraryDetail: React.FC<ItineraryDetailProps> = ({
                     </div>
                 </div>
             ) : null}
-            
+
             {/* Save/Remove Route buttons */}
             <div className="route-actions">
-                {!isSaved && onSaveRoute ? (
-                    <button 
-                        type="button" 
-                        className="button-gray" 
-                        onClick={() => onSaveRoute(itinerary)}
-                    >
+                {!isSaved && handleSaveRoute ? (
+                    <button type="button" className="button-gray" onClick={() => handleSaveRoute(itinerary)}>
                         <span>{t('NavigationModal.saveRoute')}</span>
                     </button>
                 ) : null}
-                {isSaved && onRemoveRoute ? (
-                    <button 
-                        type="button" 
-                        className="button-gray" 
-                        onClick={() => onRemoveRoute()}
-                    >
+                {isSaved && handleRemoveRoute ? (
+                    <button type="button" className="button-gray" onClick={() => handleRemoveRoute()}>
                         <span>{t('NavigationModal.removeRoute')}</span>
                     </button>
                 ) : null}

--- a/packages/frontend/src/components/Modals/NavigationModal/NavigationModal.tsx
+++ b/packages/frontend/src/components/Modals/NavigationModal/NavigationModal.tsx
@@ -1,6 +1,5 @@
 import './NavigationModal.css'
 
-import PropTypes from 'prop-types'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import FeedbackButton from 'src/components/Buttons/FeedbackButton/FeedbackButton'
@@ -28,13 +27,13 @@ interface NavigationModalProps {
 
 type ActiveInput = 'start' | 'end' | null
 
-const NavigationModal: React.FC<NavigationModalProps> = ({ 
-    className = '', 
+const NavigationModal: React.FC<NavigationModalProps> = ({
+    className = '',
     initialEndStation,
     initialRoute,
     savedRoute,
     onSaveRoute,
-    onRemoveRoute
+    onRemoveRoute,
 }) => {
     useTrackComponentView('navigation modal')
 
@@ -56,7 +55,7 @@ const NavigationModal: React.FC<NavigationModalProps> = ({
         }
         return null
     })
-    
+
     // If an initial route is provided, show it immediately
     const [selectedRoute, setSelectedRoute] = useState<Itinerary | null>(initialRoute || null)
 
@@ -231,7 +230,11 @@ const NavigationModal: React.FC<NavigationModalProps> = ({
                 }}
                 onSaveRoute={onSaveRoute}
                 onRemoveRoute={onRemoveRoute}
-                isSaved={!!savedRoute && savedRoute.startTime === selectedRoute.startTime ? savedRoute.endTime === selectedRoute.endTime : false}
+                isSaved={
+                    !!savedRoute && savedRoute.startTime === selectedRoute.startTime
+                        ? savedRoute.endTime === selectedRoute.endTime
+                        : false
+                }
             />
         )
     }
@@ -283,23 +286,6 @@ const NavigationModal: React.FC<NavigationModalProps> = ({
             {renderContent()}
         </div>
     )
-}
-
-// Add prop types validation
-NavigationModal.propTypes = {
-    className: PropTypes.string,
-    initialEndStation: PropTypes.shape({
-        name: PropTypes.string.isRequired,
-        lines: PropTypes.array,
-        coordinates: PropTypes.shape({
-            latitude: PropTypes.number.isRequired,
-            longitude: PropTypes.number.isRequired
-        }).isRequired
-    }),
-    initialRoute: PropTypes.object,
-    savedRoute: PropTypes.object,
-    onSaveRoute: PropTypes.func,
-    onRemoveRoute: PropTypes.func
 }
 
 export default NavigationModal

--- a/packages/frontend/src/components/Modals/NavigationModal/NavigationModal.tsx
+++ b/packages/frontend/src/components/Modals/NavigationModal/NavigationModal.tsx
@@ -57,7 +57,7 @@ const NavigationModal: React.FC<NavigationModalProps> = ({
     })
 
     // If an initial route is provided, show it immediately
-    const [selectedRoute, setSelectedRoute] = useState<Itinerary | null>(initialRoute || null)
+    const [selectedRoute, setSelectedRoute] = useState<Itinerary | null>(initialRoute ?? null)
 
     const { searchValue, setSearchValue, filteredStations: possibleStations } = useStationSearch()
 
@@ -228,8 +228,8 @@ const NavigationModal: React.FC<NavigationModalProps> = ({
                 onBack={() => {
                     setSelectedRoute(null)
                 }}
-                onSaveRoute={onSaveRoute}
-                onRemoveRoute={onRemoveRoute}
+                handleSaveRoute={onSaveRoute}
+                handleRemoveRoute={onRemoveRoute}
                 isSaved={
                     !!savedRoute && savedRoute.startTime === selectedRoute.startTime
                         ? savedRoute.endTime === selectedRoute.endTime

--- a/packages/frontend/src/components/Modals/ReportsModal/ReportItem.tsx
+++ b/packages/frontend/src/components/Modals/ReportsModal/ReportItem.tsx
@@ -24,6 +24,7 @@ const ReportItem: React.FC<ReportItemProps> = ({ report, currentTime }) => {
                 <h4>{report.station.name}</h4>
                 {displayMessage ? <p>{displayMessage}</p> : null}
             </div>
+            {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Don't listen to the compiler, it can be undefined */}
             {report.message !== undefined && report.message !== null && report.message.trim() !== '' ? (
                 <div className="report-message-container">
                     <p className="report-message">{report.message}</p>

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -9,7 +9,7 @@ import { ReportsModal } from 'src/components/Modals/ReportsModal/ReportsModal'
 import { ReportSummaryModal } from 'src/components/Modals/ReportSummaryModal/ReportSummaryModal'
 import { Itinerary, Report, StationProperty } from 'src/utils/types'
 
-import { useCurrentReports,useLast24HourReports, useStations } from '../../api/queries'
+import { useCurrentReports, useLast24HourReports, useStations } from '../../api/queries'
 import CloseButton from '../../components/Buttons/CloseButton/CloseButton'
 import { LayerSwitcher } from '../../components/Buttons/LayerSwitcher/LayerSwitcher'
 import { ReportButton } from '../../components/Buttons/ReportButton/ReportButton'
@@ -50,8 +50,8 @@ const isTelegramWebApp = (): boolean =>
     typeof TelegramWebviewProxy !== 'undefined'
 
 const App = () => {
-    const { stationId } = useParams();
-    const navigate = useNavigate();
+    const { stationId } = useParams()
+    const navigate = useNavigate()
     const { t } = useTranslation()
 
     const [appUIState, setAppUIState] = useState<AppUIState>(initialAppUIState)
@@ -194,10 +194,10 @@ const App = () => {
         return currentDate.getTime() - lastAcceptedDate.getTime() > oneWeek
     }
 
-    const closeLegalDisclaimer = () => {
+    const closeLegalDisclaimer = useCallback(() => {
         localStorage.setItem('legalDisclaimerAcceptedAt', new Date().toISOString())
-        setAppUIState({ ...appUIState, isFirstOpen: false, isStatsPopUpOpen: true })
-    }
+        setAppUIState((prevState) => ({ ...prevState, isFirstOpen: false, isStatsPopUpOpen: true }))
+    }, [])
 
     useEffect(() => {
         if (!shouldShowLegalDisclaimer()) {
@@ -231,7 +231,7 @@ const App = () => {
     const [selectedStation, setSelectedStation] = useState<StationProperty | null>(null)
     const [navigationEndStation, setNavigationEndStation] = useState<StationProperty | null>(null)
     const [stationModalWasManuallyCloses, setStationModalWasManuallyCloses] = useState(false)
-    
+
     // New state for saved route
     const [savedRoute, setSavedRoute] = useState<Itinerary | null>(null)
     const [showSavedRoute, setShowSavedRoute] = useState(false)
@@ -243,19 +243,22 @@ const App = () => {
         closeModal: closeInfoModal,
     } = useModalAnimation()
 
-    const onStationSelect = (station: StationProperty) => {
-        setSelectedStation(station)
-        openInfoModal()
-        setStationModalWasManuallyCloses(false)
-    }
+    const onStationSelect = useCallback(
+        (station: StationProperty) => {
+            setSelectedStation(station)
+            openInfoModal()
+            setStationModalWasManuallyCloses(false)
+        },
+        [openInfoModal]
+    )
 
     const onCloseInfoModal = () => {
         setStationModalWasManuallyCloses(true)
         closeInfoModal()
-        
+
         // If we're on a station URL, navigate back to home
         if (stationId !== undefined) {
-            navigate('/');
+            navigate('/')
         }
     }
 
@@ -269,45 +272,52 @@ const App = () => {
 
     // Handle direct navigation to a station via URL parameter
     useEffect(() => {
-        const isValidStationId = typeof stationId === 'string' && stationId.trim() !== '';
+        const isValidStationId = typeof stationId === 'string' && stationId.trim() !== ''
 
         if (!(isValidStationId && stations && !isInfoModalOpen && !stationModalWasManuallyCloses)) {
-            return;
+            return
         }
-        const station = stations[stationId];
-        
+        const station = stations[stationId]
+
         // station does have an overlap with undefined, when looking for stations[(RANDOM_STRING)], so we need to check for it
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (station === undefined) {
-            return;
+            return
         }
-        
+
         const hasValidName = typeof station.name === 'string' && station.name.trim() !== ''
         const hasValidCoordinates =
             typeof station.coordinates === 'object' &&
             typeof station.coordinates.longitude === 'number' &&
-            typeof station.coordinates.latitude === 'number';
-            
+            typeof station.coordinates.latitude === 'number'
+
         if (!(hasValidName && hasValidCoordinates)) {
-            return;
+            return
         }
 
         const stationProperty: StationProperty = {
             name: station.name,
             lines: Array.isArray(station.lines) ? station.lines : [],
             coordinates: {
-                        longitude: station.coordinates.longitude,
-                        latitude: station.coordinates.latitude
-                    }
-        };
+                longitude: station.coordinates.longitude,
+                latitude: station.coordinates.latitude,
+            },
+        }
         // Make sure legal disclaimer has to be accepted first, before the station view can be opened
         if (appUIState.isFirstOpen) {
-            return;
+            return
         }
-        onStationSelect(stationProperty);
-            
-     
-    }, [stationId, stations, isInfoModalOpen, appUIState.isFirstOpen, closeLegalDisclaimer, onStationSelect, stationModalWasManuallyCloses, navigate]);
+        onStationSelect(stationProperty)
+    }, [
+        stationId,
+        stations,
+        isInfoModalOpen,
+        appUIState.isFirstOpen,
+        closeLegalDisclaimer,
+        onStationSelect,
+        stationModalWasManuallyCloses,
+        navigate,
+    ])
 
     useEffect(() => {
         if (indicatorTimeoutRef.current) {
@@ -404,9 +414,9 @@ const App = () => {
             ) : null}
             {isNavigationModalOpen ? (
                 <>
-                    <NavigationModal 
-                        className="open center-animation" 
-                        initialEndStation={navigationEndStation} 
+                    <NavigationModal
+                        className="open center-animation"
+                        initialEndStation={navigationEndStation}
                         onSaveRoute={(route: Itinerary) => {
                             setSavedRoute(route)
                             setIsNavigationModalOpen(false)
@@ -422,7 +432,7 @@ const App = () => {
                     />
                 </>
             ) : null}
-            
+
             {/* Show Saved Route button - show only when a route is saved */}
             {savedRoute && !isNavigationModalOpen && !showSavedRoute ? (
                 <button
@@ -433,12 +443,12 @@ const App = () => {
                     <span>{t('NavigationModal.showSavedRoute')}</span>
                 </button>
             ) : null}
-            
+
             {/* Display saved route modal */}
             {showSavedRoute && savedRoute ? (
                 <>
-                    <NavigationModal 
-                        className="open center-animation" 
+                    <NavigationModal
+                        className="open center-animation"
                         initialRoute={savedRoute}
                         onRemoveRoute={() => {
                             setSavedRoute(null)
@@ -449,7 +459,7 @@ const App = () => {
                     <Backdrop handleClick={() => setShowSavedRoute(false)} />
                 </>
             ) : null}
-            
+
             <button
                 className="navigation-button small-button"
                 onClick={() => setIsNavigationModalOpen(true)}
@@ -457,14 +467,16 @@ const App = () => {
             >
                 <img src={`${process.env.PUBLIC_URL}/icons/route-svgrepo-com.svg`} alt="Navigation" />
             </button>
-            {showUpdateIndicator ? <div className="update-indicator">
+            {showUpdateIndicator ? (
+                <div className="update-indicator">
                     <img
                         src={`${process.env.PUBLIC_URL}/icons/refresh-svgrepo-com.svg`}
                         alt="Refresh"
                         className="update-indicator-icon"
                     />
                     <div className="update-indicator-text">{t('updateIndicator.text')}</div>
-                </div> : null}
+                </div>
+            ) : null}
             <ReportButton
                 handleOpenReportModal={() =>
                     setAppUIState({ ...appUIState, isReportFormOpen: !appUIState.isReportFormOpen })

--- a/packages/nlp_service/core/extractors/line_extractor.py
+++ b/packages/nlp_service/core/extractors/line_extractor.py
@@ -40,10 +40,6 @@ def format_text_for_line_search(text):
     return " ".join(formatted_words)
 
 
-"""
-Extraction functions
-"""
-
 def find_line(text, lines):
     logger.debug("finding the line")
 
@@ -57,7 +53,7 @@ def find_line(text, lines):
 
     for word in set(words):
         for line in sorted_lines:
-            if line.lower() in word.lower():
+            if line.lower() == word.lower():
                 matches_per_word.setdefault(word, []).append(line)
 
     return process_matches(matches_per_word)

--- a/packages/nlp_service/core/extractors/line_extractor.py
+++ b/packages/nlp_service/core/extractors/line_extractor.py
@@ -60,5 +60,7 @@ def find_line(text: str, lines: dict) -> str | None:
                     matches_per_word.setdefault(word, []).append(line)
             elif line.lower() == word.lower():
                 matches_per_word.setdefault(word, []).append(line)
+            elif word.lower() == "u12": # temporary fix for u12, which is not in the lines dict
+                matches_per_word.setdefault(word, []).append("U2")
 
     return process_matches(matches_per_word)

--- a/packages/nlp_service/core/extractors/line_extractor.py
+++ b/packages/nlp_service/core/extractors/line_extractor.py
@@ -1,4 +1,5 @@
 from nlp_service.utils.logger import setup_logger
+from typing import Union
 
 logger = setup_logger()
 
@@ -40,7 +41,7 @@ def format_text_for_line_search(text):
     return " ".join(formatted_words)
 
 
-def find_line(text: str, lines: dict) -> str | None:
+def find_line(text: str, lines: dict) -> Union[str, None]:
     logger.debug("finding the line")
 
     formatted_text = format_text_for_line_search(text)

--- a/packages/nlp_service/core/extractors/line_extractor.py
+++ b/packages/nlp_service/core/extractors/line_extractor.py
@@ -40,7 +40,7 @@ def format_text_for_line_search(text):
     return " ".join(formatted_words)
 
 
-def find_line(text, lines):
+def find_line(text: str, lines: dict) -> str | None:
     logger.debug("finding the line")
 
     formatted_text = format_text_for_line_search(text)
@@ -51,9 +51,14 @@ def find_line(text, lines):
     sorted_lines = sorted(lines.keys(), key=len, reverse=True)
     matches_per_word = {}
 
-    for word in set(words):
+    for i, word in enumerate(words):
         for line in sorted_lines:
-            if line.lower() == word.lower():
+            # For numeric-only lines, require "Tram" prefix
+            # as these lines are unlikely make sure the user is not referring to a number
+            if line.isdigit():
+                if i > 0 and words[i-1].lower() == "tram" and line == word:
+                    matches_per_word.setdefault(word, []).append(line)
+            elif line.lower() == word.lower():
                 matches_per_word.setdefault(word, []).append(line)
 
     return process_matches(matches_per_word)

--- a/packages/nlp_service/services/telegram_adapter.py
+++ b/packages/nlp_service/services/telegram_adapter.py
@@ -59,7 +59,6 @@ def get_info(message):
         if message.content_type == "text"
         else (message.caption or "Image without description")
     )
-    logger.info(f"Message received: {text} from chat id: {message.chat.id}")
 
     process_new_message(timestamp, text)
 


### PR DESCRIPTION
## Describe the Issue
Several issues arose due to the introduction of the new trams. Specifically, the logic was checking if a line was `in` a word rather than using `== word.lower()`. This led to cases where, for example, the M29 was incorrectly detected as the tram M2.  
Additionally, the U12 line was not being accounted for.

## How the Issue Was Resolved

- Ensured that a word must exactly match the line for detection.
- Numeric-only tram lines now require the previous word to be "tram" to avoid confusion with unrelated numbers.
- U12 is now detected as U2. I acknowledge that this is a suboptimal solution, as U12 can refer to either U1 or U2 depending on the station. However, since station detection currently depends on the line, this is a non-trivial issue. I'm open to suggestions for improving this logic.
