### PR TITLE
align with latest docker compose file spec

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   postgres:
     image: postgres:latest


### PR DESCRIPTION
As of Compose V2 the version tag is deprecated and the new recommended file name for the compose file is `compose.yaml`