### PR TITLE
fix: avoid resetting opacity for new reports

### DIFF
--- a/packages/frontend/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
+++ b/packages/frontend/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
@@ -36,7 +36,7 @@ export const OpacityMarker: React.FC<OpacityMarkerProps> = ({ markerData, index,
                 const calculateOpacity = () => {
                     const currentTime = new Date().getTime()
                     const elapsedTime = currentTime - adjustedTimestamp.getTime()
-                    const timeToFade = 60 * 60 * 1000
+                    const timeToFade = 5 * 60 * 1000
                     let newOpacity = Math.max(0, 1 - elapsedTime / timeToFade)
 
                     // When the opacity is too low the marker is not visible
@@ -81,7 +81,7 @@ export const OpacityMarker: React.FC<OpacityMarkerProps> = ({ markerData, index,
             className="inspector-marker"
             latitude={station.coordinates.latitude}
             longitude={station.coordinates.longitude}
-            style={{ opacity: opacity.toString() }}
+            opacity={opacity.toString()}
             onClick={handleMarkerClick}
         >
             <span className={`marker live ${shouldPulse ? 'pulse' : ''}`} />

--- a/packages/frontend/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
+++ b/packages/frontend/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
@@ -36,7 +36,7 @@ export const OpacityMarker: React.FC<OpacityMarkerProps> = ({ markerData, index,
                 const calculateOpacity = () => {
                     const currentTime = new Date().getTime()
                     const elapsedTime = currentTime - adjustedTimestamp.getTime()
-                    const timeToFade = 5 * 60 * 1000
+                    const timeToFade = 60 * 60 * 1000
                     let newOpacity = Math.max(0, 1 - elapsedTime / timeToFade)
 
                     // When the opacity is too low the marker is not visible

--- a/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
+++ b/packages/frontend/src/components/Map/Markers/MarkerContainer.tsx
@@ -50,7 +50,7 @@ const MarkerContainer: React.FC<MarkersProps> = ({ isFirstOpen, userPosition }) 
                     isFirstOpen={isFirstOpen}
                     markerData={ticketInspector}
                     index={index}
-                    key={ticketInspector.station.id}
+                    key={`${ticketInspector.station.id}-${ticketInspector.timestamp}`}
                     onMarkerClick={handleMarkerClick}
                 />
             ))}


### PR DESCRIPTION
We were trying to control the opacity using style, this had some consequences, controlling it over opacity is much more clear and gives us more control over the side effects.