### PR TITLE
feat: `POST` /feedback/

### DIFF
--- a/packages/hono-backend/drizzle/0001_new_squadron_supreme.sql
+++ b/packages/hono-backend/drizzle/0001_new_squadron_supreme.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "feedback" (
+	"feedback_id" serial PRIMARY KEY NOT NULL,
+	"email" varchar(255),
+	"feedback" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "line_stations" ADD CONSTRAINT "line_stations_line_id_station_id_pk" PRIMARY KEY("line_id","station_id");--> statement-breakpoint
+ALTER TABLE "lines" ADD COLUMN "is_circular" boolean DEFAULT false NOT NULL;

--- a/packages/hono-backend/drizzle/meta/0001_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,294 @@
+{
+  "id": "d60c232d-8b10-426c-94ed-52559f4ae1cd",
+  "prevId": "9ef619b2-9f68-49fb-984a-246dd7fc3ec5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_stations": {
+      "name": "line_stations",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_stations_line_id_lines_id_fk": {
+          "name": "line_stations_line_id_lines_id_fk",
+          "tableFrom": "line_stations",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "line_stations_station_id_stations_id_fk": {
+          "name": "line_stations_station_id_stations_id_fk",
+          "tableFrom": "line_stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_stations_line_id_station_id_pk": {
+          "name": "line_stations_line_id_station_id_pk",
+          "columns": [
+            "line_id",
+            "station_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lines": {
+      "name": "lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_circular": {
+          "name": "is_circular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "report_id": {
+          "name": "report_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction_id": {
+          "name": "direction_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_station_id_stations_id_fk": {
+          "name": "reports_station_id_stations_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_line_id_lines_id_fk": {
+          "name": "reports_line_id_lines_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_direction_id_lines_id_fk": {
+          "name": "reports_direction_id_lines_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "direction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.source": {
+      "name": "source",
+      "schema": "public",
+      "values": [
+        "mini_app",
+        "web_app",
+        "mobile_app",
+        "telegram"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/hono-backend/drizzle/meta/_journal.json
+++ b/packages/hono-backend/drizzle/meta/_journal.json
@@ -1,13 +1,20 @@
 {
-    "version": "7",
-    "dialect": "postgresql",
-    "entries": [
-        {
-            "idx": 0,
-            "version": "7",
-            "when": 1762526834081,
-            "tag": "0000_material_king_cobra",
-            "breakpoints": true
-        }
-    ]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1762526834081,
+      "tag": "0000_material_king_cobra",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1765116895295,
+      "tag": "0001_new_squadron_supreme",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/hono-backend/src/app-env.ts
+++ b/packages/hono-backend/src/app-env.ts
@@ -1,9 +1,11 @@
 import { Hono } from 'hono'
 
+import { FeedbackService } from './modules/feedback'
 import { ReportsService } from './modules/reports'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
 
 export type Services = {
+    feedbackService: FeedbackService
     reportsService: ReportsService
     transitNetworkDataService: TransitNetworkDataService
 }

--- a/packages/hono-backend/src/db/index.ts
+++ b/packages/hono-backend/src/db/index.ts
@@ -4,12 +4,13 @@ import postgres from 'postgres'
 import { lines, lineStations } from './schema/lines'
 import { reports } from './schema/reports'
 import { stations } from './schema/stations'
+import { feedback } from './schema/feedback'
 
 const connectionString = process.env.DATABASE_URL!
 
 export const client = postgres(connectionString, { prepare: false })
 export const db = drizzle(client, {
-    schema: { reports, stations, lines, lineStations },
+    schema: { reports, stations, lines, lineStations, feedback },
     casing: 'snake_case',
 })
 
@@ -18,3 +19,4 @@ export type DbConnection = typeof db
 export * from './schema/reports'
 export * from './schema/lines'
 export * from './schema/stations'
+export * from './schema/feedback'

--- a/packages/hono-backend/src/db/schema/feedback.ts
+++ b/packages/hono-backend/src/db/schema/feedback.ts
@@ -1,0 +1,17 @@
+import { createInsertSchema } from 'drizzle-zod'
+import { pgTable, serial, text, timestamp, varchar } from 'drizzle-orm/pg-core'
+import { z } from 'zod'
+
+export const feedback = pgTable('feedback', {
+    feedbackId: serial().primaryKey(),
+    email: varchar({ length: 255 }),
+    feedback: text().notNull(),
+    createdAt: timestamp().notNull().defaultNow(),
+})
+
+export const insertFeedbackSchema = createInsertSchema(feedback).pick({
+    email: true,
+    feedback: true,
+})
+
+export type InsertFeedback = z.infer<typeof insertFeedbackSchema>

--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import { registerServices, Services, type Env } from './app-env'
 import { registerRoutes } from './common/router'
 import { db, DbConnection } from './db'
+import { FeedbackService, postFeedback } from './modules/feedback'
 import { getReports, postReport, ReportsService } from './modules/reports/'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
 import { getLines, getStations } from './modules/transit/transit-routes'
@@ -13,12 +14,13 @@ const createServices = (db: DbConnection) => {
     const transitNetworkDataService = new TransitNetworkDataService(db)
 
     const reportsService = new ReportsService(db, transitNetworkDataService)
+    const feedbackService = new FeedbackService(db)
 
-    return { transitNetworkDataService, reportsService } satisfies Services
+    return { transitNetworkDataService, reportsService, feedbackService } satisfies Services
 }
 
 registerServices(app, createServices(db))
 
-registerRoutes(app, [getReports, postReport, getStations, getLines])
+registerRoutes(app, [getReports, postReport, postFeedback, getStations, getLines])
 
 export default app

--- a/packages/hono-backend/src/modules/feedback/feedback-routes.ts
+++ b/packages/hono-backend/src/modules/feedback/feedback-routes.ts
@@ -1,0 +1,27 @@
+import { defineRoute } from '../../common/router'
+import { Env } from '../../app-env'
+import { insertFeedbackSchema } from '../../db'
+
+export const postFeedback = defineRoute<Env>()({
+    method: 'post',
+    path: 'v0/feedback',
+    schemas: {
+        json: insertFeedbackSchema
+            .pick({
+                feedback: true,
+                email: true,
+            })
+            .extend({
+                feedback: insertFeedbackSchema.shape.feedback.trim().min(1),
+            }),
+    },
+    handler: async (c) => {
+        const feedbackService = c.get('feedbackService')
+
+        const body = c.req.valid('json')
+
+        await feedbackService.createFeedback(body)
+
+        return c.json({ success: true })
+    },
+})

--- a/packages/hono-backend/src/modules/feedback/feedback-service.ts
+++ b/packages/hono-backend/src/modules/feedback/feedback-service.ts
@@ -1,0 +1,9 @@
+import { DbConnection, InsertFeedback, feedback } from '../../db'
+
+export class FeedbackService {
+    constructor(private db: DbConnection) {}
+
+    async createFeedback(feedbackData: InsertFeedback) {
+        await this.db.insert(feedback).values(feedbackData)
+    }
+}

--- a/packages/hono-backend/src/modules/feedback/index.ts
+++ b/packages/hono-backend/src/modules/feedback/index.ts
@@ -1,0 +1,2 @@
+export * from './feedback-routes'
+export * from './feedback-service'


### PR DESCRIPTION
## Summary
- add a feedback table schema and migration
- wire a FeedbackService and POST /v0/feedback route to persist submissions
- validate incoming feedback payloads and expose the service through app wiring

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69358aa5fcbc832dac4c259e620d5a2b)