### PR TITLE
feat: post process report

### DIFF
--- a/packages/hono-backend/drizzle/0000_modern_runaways.sql
+++ b/packages/hono-backend/drizzle/0000_modern_runaways.sql
@@ -1,14 +1,15 @@
 CREATE TYPE "public"."source" AS ENUM('mini_app', 'web_app', 'mobile_app', 'telegram');--> statement-breakpoint
+CREATE TABLE "line_stations" (
+	"line_id" varchar(16) NOT NULL,
+	"station_id" varchar(16) NOT NULL,
+	"order" integer NOT NULL,
+	CONSTRAINT "line_stations_line_id_station_id_pk" PRIMARY KEY("line_id","station_id")
+);
+--> statement-breakpoint
 CREATE TABLE "lines" (
 	"id" varchar(16) PRIMARY KEY NOT NULL,
 	"name" varchar(255) NOT NULL,
-	"is_circular" boolean NOT NULL DEFAULT false
-);
---> statement-breakpoint
-CREATE TABLE "line_stations" (
-	"station_id" varchar(16) NOT NULL,
-	"line_id" varchar(16) NOT NULL,
-	"order" integer NOT NULL
+	"is_circular" boolean DEFAULT false NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "reports" (
@@ -27,8 +28,8 @@ CREATE TABLE "stations" (
 	"lng" double precision NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "line_stations" ADD CONSTRAINT "line_stations_station_id_stations_id_fk" FOREIGN KEY ("station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "line_stations" ADD CONSTRAINT "line_stations_line_id_lines_id_fk" FOREIGN KEY ("line_id") REFERENCES "public"."lines"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "line_stations" ADD CONSTRAINT "line_stations_station_id_stations_id_fk" FOREIGN KEY ("station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "reports" ADD CONSTRAINT "reports_station_id_stations_id_fk" FOREIGN KEY ("station_id") REFERENCES "public"."stations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "reports" ADD CONSTRAINT "reports_line_id_lines_id_fk" FOREIGN KEY ("line_id") REFERENCES "public"."lines"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "reports" ADD CONSTRAINT "reports_direction_id_lines_id_fk" FOREIGN KEY ("direction_id") REFERENCES "public"."lines"("id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "reports" ADD CONSTRAINT "reports_direction_id_stations_id_fk" FOREIGN KEY ("direction_id") REFERENCES "public"."stations"("id") ON DELETE no action ON UPDATE no action;

--- a/packages/hono-backend/drizzle/meta/0000_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0000_snapshot.json
@@ -1,216 +1,256 @@
 {
-    "id": "9ef619b2-9f68-49fb-984a-246dd7fc3ec5",
-    "prevId": "00000000-0000-0000-0000-000000000000",
-    "version": "7",
-    "dialect": "postgresql",
-    "tables": {
-        "public.lines": {
-            "name": "lines",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "varchar(16)",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "name": {
-                    "name": "name",
-                    "type": "varchar(255)",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {},
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+  "id": "16f44466-7915-4d16-881c-b5f8b3661843",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.line_stations": {
+      "name": "line_stations",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
         },
-        "public.line_stations": {
-            "name": "line_stations",
-            "schema": "",
-            "columns": {
-                "station_id": {
-                    "name": "station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "order": {
-                    "name": "order",
-                    "type": "integer",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "line_stations_station_id_stations_id_fk": {
-                    "name": "line_stations_station_id_stations_id_fk",
-                    "tableFrom": "line_stations",
-                    "tableTo": "stations",
-                    "columnsFrom": ["station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                },
-                "line_stations_line_id_lines_id_fk": {
-                    "name": "line_stations_line_id_lines_id_fk",
-                    "tableFrom": "line_stations",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+        "station_id": {
+          "name": "station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
         },
-        "public.reports": {
-            "name": "reports",
-            "schema": "",
-            "columns": {
-                "report_id": {
-                    "name": "report_id",
-                    "type": "serial",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "station_id": {
-                    "name": "station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": false
-                },
-                "direction_id": {
-                    "name": "direction_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": false
-                },
-                "timestamp": {
-                    "name": "timestamp",
-                    "type": "timestamp",
-                    "primaryKey": false,
-                    "notNull": true,
-                    "default": "now()"
-                },
-                "source": {
-                    "name": "source",
-                    "type": "source",
-                    "typeSchema": "public",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "reports_station_id_stations_id_fk": {
-                    "name": "reports_station_id_stations_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "stations",
-                    "columnsFrom": ["station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                },
-                "reports_line_id_lines_id_fk": {
-                    "name": "reports_line_id_lines_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                },
-                "reports_direction_id_lines_id_fk": {
-                    "name": "reports_direction_id_lines_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "lines",
-                    "columnsFrom": ["direction_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
-        },
-        "public.stations": {
-            "name": "stations",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "varchar(16)",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "name": {
-                    "name": "name",
-                    "type": "varchar(255)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "lat": {
-                    "name": "lat",
-                    "type": "double precision",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "lng": {
-                    "name": "lng",
-                    "type": "double precision",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {},
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
         }
-    },
-    "enums": {
-        "public.source": {
-            "name": "source",
-            "schema": "public",
-            "values": ["mini_app", "web_app", "mobile_app", "telegram"]
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_stations_line_id_lines_id_fk": {
+          "name": "line_stations_line_id_lines_id_fk",
+          "tableFrom": "line_stations",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "line_stations_station_id_stations_id_fk": {
+          "name": "line_stations_station_id_stations_id_fk",
+          "tableFrom": "line_stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
+      },
+      "compositePrimaryKeys": {
+        "line_stations_line_id_station_id_pk": {
+          "name": "line_stations_line_id_station_id_pk",
+          "columns": [
+            "line_id",
+            "station_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     },
-    "schemas": {},
-    "sequences": {},
-    "roles": {},
-    "policies": {},
-    "views": {},
-    "_meta": {
-        "columns": {},
-        "schemas": {},
-        "tables": {}
+    "public.lines": {
+      "name": "lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_circular": {
+          "name": "is_circular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "report_id": {
+          "name": "report_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction_id": {
+          "name": "direction_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_station_id_stations_id_fk": {
+          "name": "reports_station_id_stations_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_line_id_lines_id_fk": {
+          "name": "reports_line_id_lines_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_direction_id_stations_id_fk": {
+          "name": "reports_direction_id_stations_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "direction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     }
+  },
+  "enums": {
+    "public.source": {
+      "name": "source",
+      "schema": "public",
+      "values": [
+        "mini_app",
+        "web_app",
+        "mobile_app",
+        "telegram"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
 }

--- a/packages/hono-backend/drizzle/meta/0000_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0000_snapshot.json
@@ -1,256 +1,228 @@
 {
-  "id": "16f44466-7915-4d16-881c-b5f8b3661843",
-  "prevId": "00000000-0000-0000-0000-000000000000",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.line_stations": {
-      "name": "line_stations",
-      "schema": "",
-      "columns": {
-        "line_id": {
-          "name": "line_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
+    "id": "16f44466-7915-4d16-881c-b5f8b3661843",
+    "prevId": "00000000-0000-0000-0000-000000000000",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.line_stations": {
+            "name": "line_stations",
+            "schema": "",
+            "columns": {
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "order": {
+                    "name": "order",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "line_stations_line_id_lines_id_fk": {
+                    "name": "line_stations_line_id_lines_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "line_stations_station_id_stations_id_fk": {
+                    "name": "line_stations_station_id_stations_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "line_stations_line_id_station_id_pk": {
+                    "name": "line_stations_line_id_station_id_pk",
+                    "columns": ["line_id", "station_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "station_id": {
-          "name": "station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
+        "public.lines": {
+            "name": "lines",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "is_circular": {
+                    "name": "is_circular",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "order": {
-          "name": "order",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "line_stations_line_id_lines_id_fk": {
-          "name": "line_stations_line_id_lines_id_fk",
-          "tableFrom": "line_stations",
-          "tableTo": "lines",
-          "columnsFrom": [
-            "line_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+        "public.reports": {
+            "name": "reports",
+            "schema": "",
+            "columns": {
+                "report_id": {
+                    "name": "report_id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "direction_id": {
+                    "name": "direction_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "timestamp": {
+                    "name": "timestamp",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "source": {
+                    "name": "source",
+                    "type": "source",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "reports_station_id_stations_id_fk": {
+                    "name": "reports_station_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_line_id_lines_id_fk": {
+                    "name": "reports_line_id_lines_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_direction_id_stations_id_fk": {
+                    "name": "reports_direction_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["direction_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "line_stations_station_id_stations_id_fk": {
-          "name": "line_stations_station_id_stations_id_fk",
-          "tableFrom": "line_stations",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+        "public.stations": {
+            "name": "stations",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lat": {
+                    "name": "lat",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lng": {
+                    "name": "lng",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         }
-      },
-      "compositePrimaryKeys": {
-        "line_stations_line_id_station_id_pk": {
-          "name": "line_stations_line_id_station_id_pk",
-          "columns": [
-            "line_id",
-            "station_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     },
-    "public.lines": {
-      "name": "lines",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(16)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "is_circular": {
-          "name": "is_circular",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
+    "enums": {
+        "public.source": {
+            "name": "source",
+            "schema": "public",
+            "values": ["mini_app", "web_app", "mobile_app", "telegram"]
         }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     },
-    "public.reports": {
-      "name": "reports",
-      "schema": "",
-      "columns": {
-        "report_id": {
-          "name": "report_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "station_id": {
-          "name": "station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "line_id": {
-          "name": "line_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "direction_id": {
-          "name": "direction_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "source": {
-          "name": "source",
-          "type": "source",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "reports_station_id_stations_id_fk": {
-          "name": "reports_station_id_stations_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "reports_line_id_lines_id_fk": {
-          "name": "reports_line_id_lines_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "lines",
-          "columnsFrom": [
-            "line_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "reports_direction_id_stations_id_fk": {
-          "name": "reports_direction_id_stations_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "direction_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.stations": {
-      "name": "stations",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(16)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lat": {
-          "name": "lat",
-          "type": "double precision",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lng": {
-          "name": "lng",
-          "type": "double precision",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {
-    "public.source": {
-      "name": "source",
-      "schema": "public",
-      "values": [
-        "mini_app",
-        "web_app",
-        "mobile_app",
-        "telegram"
-      ]
-    }
-  },
-  "schemas": {},
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
     "schemas": {},
-    "tables": {}
-  }
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
 }

--- a/packages/hono-backend/drizzle/meta/_journal.json
+++ b/packages/hono-backend/drizzle/meta/_journal.json
@@ -1,13 +1,13 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1765472567170,
-      "tag": "0000_modern_runaways",
-      "breakpoints": true
-    }
-  ]
+    "version": "7",
+    "dialect": "postgresql",
+    "entries": [
+        {
+            "idx": 0,
+            "version": "7",
+            "when": 1765472567170,
+            "tag": "0000_modern_runaways",
+            "breakpoints": true
+        }
+    ]
 }

--- a/packages/hono-backend/drizzle/meta/_journal.json
+++ b/packages/hono-backend/drizzle/meta/_journal.json
@@ -1,13 +1,13 @@
 {
-    "version": "7",
-    "dialect": "postgresql",
-    "entries": [
-        {
-            "idx": 0,
-            "version": "7",
-            "when": 1762526834081,
-            "tag": "0000_material_king_cobra",
-            "breakpoints": true
-        }
-    ]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1765472567170,
+      "tag": "0000_modern_runaways",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/hono-backend/src/common/error-handler.ts
+++ b/packages/hono-backend/src/common/error-handler.ts
@@ -5,6 +5,14 @@ import { AppError } from './errors'
 
 export const handleError = (err: Error, c: Context) => {
     if (err instanceof AppError) {
+        c.get('logger').error(
+            {
+                internal_code: err.internalCode,
+                statusCode: err.statusCode,
+                description: err.description,
+            },
+            err.message
+        )
         return c.json(
             {
                 message: err.message,

--- a/packages/hono-backend/src/common/errors.ts
+++ b/packages/hono-backend/src/common/errors.ts
@@ -1,6 +1,6 @@
 import { ContentfulStatusCode } from 'hono/utils/http-status'
 
-export type InternalCode = 'TELEGRAM_NOTIFICATION_FAILED' | 'UNKNOWN_ERROR'
+export type InternalCode = 'TELEGRAM_NOTIFICATION_FAILED' | 'UNKNOWN_ERROR' | 'VALIDATION_FAILED'
 
 export interface AppErrorDetails {
     internal_code: InternalCode

--- a/packages/hono-backend/src/common/utils.ts
+++ b/packages/hono-backend/src/common/utils.ts
@@ -1,0 +1,12 @@
+import type { Stations, StationId } from '../modules/transit/types'
+
+const lookupStation = (
+    stations: Stations,
+    stationId: StationId | null | undefined
+): Stations[StationId] | undefined => {
+    if (stationId === null || stationId === undefined) return undefined
+    if (!Object.prototype.hasOwnProperty.call(stations, stationId)) return undefined
+    return stations[stationId]
+}
+
+export { lookupStation }

--- a/packages/hono-backend/src/db/schema/lines.ts
+++ b/packages/hono-backend/src/db/schema/lines.ts
@@ -8,6 +8,7 @@ export const lines = pgTable('lines', {
     isCircular: boolean().notNull().default(false),
 })
 
+// Todo: avoid deprecated syntax: #FRE-562
 export const lineStations = pgTable(
     'line_stations',
     {

--- a/packages/hono-backend/src/db/schema/reports.ts
+++ b/packages/hono-backend/src/db/schema/reports.ts
@@ -13,7 +13,7 @@ export const reports = pgTable('reports', {
         .notNull()
         .references(() => stations.id),
     lineId: varchar({ length: 16 }).references(() => lines.id),
-    directionId: varchar({ length: 16 }).references(() => lines.id),
+    directionId: varchar({ length: 16 }).references(() => stations.id),
     timestamp: timestamp().notNull().defaultNow(),
     source: sourceEnum().notNull(),
 })

--- a/packages/hono-backend/src/db/seed/index.ts
+++ b/packages/hono-backend/src/db/seed/index.ts
@@ -1,13 +1,12 @@
 /* eslint-disable no-console */
 import { db } from '../index'
 
-import { seedBaseData, seedReports } from './seed'
+import { seedBaseData } from './seed'
 
 const seed = async () => {
     console.log('Starting seed...')
 
     await seedBaseData(db)
-    await seedReports(db)
 
     console.log('Seed completed successfully!')
 }

--- a/packages/hono-backend/src/db/seed/index.ts
+++ b/packages/hono-backend/src/db/seed/index.ts
@@ -1,12 +1,13 @@
-/* eslint-disable no-console  */
+/* eslint-disable no-console */
 import { db } from '../index'
 
-import { seedBaseData } from './seed'
+import { seedBaseData, seedReports } from './seed'
 
 const seed = async () => {
     console.log('Starting seed...')
 
     await seedBaseData(db)
+    await seedReports(db)
 
     console.log('Seed completed successfully!')
 }

--- a/packages/hono-backend/src/db/seed/seed.ts
+++ b/packages/hono-backend/src/db/seed/seed.ts
@@ -1,5 +1,6 @@
 import type { DbConnection } from '../index'
 import { lines, lineStations } from '../schema/lines'
+import { reports } from '../schema/reports'
 import { stations } from '../schema/stations'
 
 import linesListJson from './LinesList.json'
@@ -20,6 +21,25 @@ interface StationsMap {
 
 interface LinesMap {
     [key: string]: string[]
+}
+
+const createDeterministicRandom = (seed: number) => {
+    // Deterministic pseudo random generator for repeatable seeds (Park–Miller LCG)
+    let state = Math.abs(Math.floor(seed)) % 2147483647
+    if (state === 0) state = 1
+    return () => {
+        state = (state * 48271) % 2147483647
+        return state / 2147483647
+    }
+}
+
+const pickOne = <T>(items: T[], randomFloat: () => number): T => {
+    const index = Math.floor(randomFloat() * items.length)
+    const item = items[index]
+    if (item === undefined) {
+        throw new Error('Cannot pick from an empty list')
+    }
+    return item
 }
 
 export const seedBaseData = async (db: DbConnection) => {
@@ -59,4 +79,87 @@ export const seedBaseData = async (db: DbConnection) => {
     }
 
     await db.insert(lineStations).values(stationLineRecords).onConflictDoNothing()
+}
+
+export const seedReports = async (
+    db: DbConnection,
+    {
+        count = 1000,
+        seed = 420,
+        clearExistingReports = true,
+    }: { count?: number; seed?: number; clearExistingReports?: boolean } = {}
+) => {
+    const stationsData = stationsListJson as StationsMap
+    const linesData = linesListJson as LinesMap
+
+    const randomFloat = createDeterministicRandom(seed)
+
+    const allStationIds = Object.keys(stationsData)
+    const allLineEntries = Object.entries(linesData)
+    const lineEntriesWithAtLeastThreeStations = allLineEntries.filter(([, stationIds]) => stationIds.length >= 3)
+
+    if (allStationIds.length === 0) throw new Error('No stations available for report seeding')
+    if (allLineEntries.length === 0) throw new Error('No lines available for report seeding')
+    if (lineEntriesWithAtLeastThreeStations.length === 0) {
+        throw new Error('No line with at least 3 stations available for report seeding')
+    }
+
+    const stationAndLineCount = Math.floor(count * 0.5)
+    const stationOnlyCount = Math.floor(count * 0.25)
+    const stationLineAndDirectionCount = count - stationAndLineCount - stationOnlyCount
+
+    const sources: Array<(typeof reports)['$inferInsert']['source']> = ['web_app', 'mobile_app', 'mini_app', 'telegram']
+
+    const makeRandomTimestamp = () => {
+        const daysBack = Math.floor(randomFloat() * 30)
+        const minutesBack = Math.floor(randomFloat() * 24 * 60)
+        return new Date(Date.now() - (daysBack * 24 * 60 + minutesBack) * 60 * 1000)
+    }
+
+    const reportRows: Array<(typeof reports)['$inferInsert']> = []
+
+    for (let i = 0; i < stationAndLineCount; i++) {
+        const [lineId, stationIds] = pickOne(allLineEntries, randomFloat)
+        reportRows.push({
+            stationId: pickOne(stationIds, randomFloat),
+            lineId,
+            source: pickOne(sources, randomFloat),
+            timestamp: makeRandomTimestamp(),
+        })
+    }
+
+    for (let i = 0; i < stationOnlyCount; i++) {
+        reportRows.push({
+            stationId: pickOne(allStationIds, randomFloat),
+            source: pickOne(sources, randomFloat),
+            timestamp: makeRandomTimestamp(),
+        })
+    }
+
+    for (let i = 0; i < stationLineAndDirectionCount; i++) {
+        const [lineId, stationIds] = pickOne(lineEntriesWithAtLeastThreeStations, randomFloat)
+
+        // Pick a non-terminal station so direction is always a terminal station and never equals stationId
+        const stationIndex = 1 + Math.floor(randomFloat() * (stationIds.length - 2))
+        const stationId = stationIds[stationIndex]!
+
+        const firstStationId = stationIds[0]!
+        const lastStationId = stationIds[stationIds.length - 1]!
+
+        const directionId = stationIndex < stationIds.length / 2 ? lastStationId : firstStationId
+
+        reportRows.push({
+            stationId,
+            lineId,
+            directionId,
+            source: pickOne(sources, randomFloat),
+            timestamp: makeRandomTimestamp(),
+        })
+    }
+
+    if (clearExistingReports) {
+        await db.delete(reports)
+    }
+
+    await db.insert(reports).values(reportRows)
 }

--- a/packages/hono-backend/src/db/seed/seed.ts
+++ b/packages/hono-backend/src/db/seed/seed.ts
@@ -1,6 +1,5 @@
 import type { DbConnection } from '../index'
 import { lines, lineStations } from '../schema/lines'
-import { reports } from '../schema/reports'
 import { stations } from '../schema/stations'
 
 import linesListJson from './LinesList.json'
@@ -21,25 +20,6 @@ interface StationsMap {
 
 interface LinesMap {
     [key: string]: string[]
-}
-
-const createDeterministicRandom = (seed: number) => {
-    // Deterministic pseudo random generator for repeatable seeds (Park–Miller LCG)
-    let state = Math.abs(Math.floor(seed)) % 2147483647
-    if (state === 0) state = 1
-    return () => {
-        state = (state * 48271) % 2147483647
-        return state / 2147483647
-    }
-}
-
-const pickOne = <T>(items: T[], randomFloat: () => number): T => {
-    const index = Math.floor(randomFloat() * items.length)
-    const item = items[index]
-    if (item === undefined) {
-        throw new Error('Cannot pick from an empty list')
-    }
-    return item
 }
 
 export const seedBaseData = async (db: DbConnection) => {
@@ -79,87 +59,4 @@ export const seedBaseData = async (db: DbConnection) => {
     }
 
     await db.insert(lineStations).values(stationLineRecords).onConflictDoNothing()
-}
-
-export const seedReports = async (
-    db: DbConnection,
-    {
-        count = 1000,
-        seed = 420,
-        clearExistingReports = true,
-    }: { count?: number; seed?: number; clearExistingReports?: boolean } = {}
-) => {
-    const stationsData = stationsListJson as StationsMap
-    const linesData = linesListJson as LinesMap
-
-    const randomFloat = createDeterministicRandom(seed)
-
-    const allStationIds = Object.keys(stationsData)
-    const allLineEntries = Object.entries(linesData)
-    const lineEntriesWithAtLeastThreeStations = allLineEntries.filter(([, stationIds]) => stationIds.length >= 3)
-
-    if (allStationIds.length === 0) throw new Error('No stations available for report seeding')
-    if (allLineEntries.length === 0) throw new Error('No lines available for report seeding')
-    if (lineEntriesWithAtLeastThreeStations.length === 0) {
-        throw new Error('No line with at least 3 stations available for report seeding')
-    }
-
-    const stationAndLineCount = Math.floor(count * 0.5)
-    const stationOnlyCount = Math.floor(count * 0.25)
-    const stationLineAndDirectionCount = count - stationAndLineCount - stationOnlyCount
-
-    const sources: Array<(typeof reports)['$inferInsert']['source']> = ['web_app', 'mobile_app', 'mini_app', 'telegram']
-
-    const makeRandomTimestamp = () => {
-        const daysBack = Math.floor(randomFloat() * 30)
-        const minutesBack = Math.floor(randomFloat() * 24 * 60)
-        return new Date(Date.now() - (daysBack * 24 * 60 + minutesBack) * 60 * 1000)
-    }
-
-    const reportRows: Array<(typeof reports)['$inferInsert']> = []
-
-    for (let i = 0; i < stationAndLineCount; i++) {
-        const [lineId, stationIds] = pickOne(allLineEntries, randomFloat)
-        reportRows.push({
-            stationId: pickOne(stationIds, randomFloat),
-            lineId,
-            source: pickOne(sources, randomFloat),
-            timestamp: makeRandomTimestamp(),
-        })
-    }
-
-    for (let i = 0; i < stationOnlyCount; i++) {
-        reportRows.push({
-            stationId: pickOne(allStationIds, randomFloat),
-            source: pickOne(sources, randomFloat),
-            timestamp: makeRandomTimestamp(),
-        })
-    }
-
-    for (let i = 0; i < stationLineAndDirectionCount; i++) {
-        const [lineId, stationIds] = pickOne(lineEntriesWithAtLeastThreeStations, randomFloat)
-
-        // Pick a non-terminal station so direction is always a terminal station and never equals stationId
-        const stationIndex = 1 + Math.floor(randomFloat() * (stationIds.length - 2))
-        const stationId = stationIds[stationIndex]!
-
-        const firstStationId = stationIds[0]!
-        const lastStationId = stationIds[stationIds.length - 1]!
-
-        const directionId = stationIndex < stationIds.length / 2 ? lastStationId : firstStationId
-
-        reportRows.push({
-            stationId,
-            lineId,
-            directionId,
-            source: pickOne(sources, randomFloat),
-            timestamp: makeRandomTimestamp(),
-        })
-    }
-
-    if (clearExistingReports) {
-        await db.delete(reports)
-    }
-
-    await db.insert(reports).values(reportRows)
 }

--- a/packages/hono-backend/src/modules/reports/post-process-report.ts
+++ b/packages/hono-backend/src/modules/reports/post-process-report.ts
@@ -145,7 +145,9 @@ const correctDirectionIfImplied =
         const stationIndex = stationsOnLine.indexOf(reportData.stationId)
         const directionIndex = stationsOnLine.indexOf(reportData.directionId)
 
+        // If the station or direction is not on the line, return the report data unchanged
         if (stationIndex === -1 || directionIndex === -1) return reportData
+        // If the station and direction are the same, return the report data unchanged
         if (stationIndex === directionIndex) return reportData
 
         const impliedTerminalDirectionId = stationIndex < directionIndex ? lastStationOnLine : firstStationOnLine

--- a/packages/hono-backend/src/modules/reports/post-process-report.ts
+++ b/packages/hono-backend/src/modules/reports/post-process-report.ts
@@ -97,6 +97,14 @@ const clearDirectionIfStationAndDirectionAreTheSame = (reportData: RawReport): R
     return reportData
 }
 
+const ifDirectionPresentWithoutLineClearDirection = (reportData: RawReport): RawReport => {
+    if (reportData.directionId !== null && reportData.directionId !== undefined && reportData.lineId === null) {
+        return { ...reportData, directionId: undefined }
+    }
+
+    return reportData
+}
+
 const clearStationReferenceIfNotOnLine =
     (stations: Stations, stationReferenceField: StationReferenceField) =>
     (reportData: RawReport): RawReport => {
@@ -137,6 +145,7 @@ export {
     clearStationReferenceIfNotOnLine,
     determineLineBasedOnStationAndDirection,
     correctDirectionIfImplied,
+    ifDirectionPresentWithoutLineClearDirection,
     guessStation,
     clearDirectionIfStationAndDirectionAreTheSame,
     isStationOnLine,

--- a/packages/hono-backend/src/modules/reports/post-process-report.ts
+++ b/packages/hono-backend/src/modules/reports/post-process-report.ts
@@ -16,6 +16,15 @@ type StationReferenceField = 'stationId' | 'directionId'
  */
 const pipe = <T>(value: T, ...fns: ((arg: T) => T)[]) => fns.reduce((acc, fn) => fn(acc), value)
 
+// TODO: Use a stochastic approach to guess the station
+const guessStation = (reportData: RawReport): RawReport => {
+    if (reportData.stationId === undefined) {
+        return { ...reportData, stationId: 'SUM-n30731497' }
+    }
+
+    return reportData
+}
+
 const isStationOnLine = (
     stations: Stations,
     lineId: LineId | null | undefined,
@@ -65,4 +74,4 @@ const assignLineIfSingleOption =
         return reportData
     }
 
-export { assignLineIfSingleOption, clearStationReferenceIfNotOnLine, isStationOnLine, pipe, RawReport }
+export { assignLineIfSingleOption, clearStationReferenceIfNotOnLine, guessStation, isStationOnLine, pipe, RawReport }

--- a/packages/hono-backend/src/modules/reports/post-process-report.ts
+++ b/packages/hono-backend/src/modules/reports/post-process-report.ts
@@ -89,6 +89,14 @@ const isStationOnLine = (
     return station.lines.includes(lineId)
 }
 
+const clearDirectionIfStationAndDirectionAreTheSame = (reportData: RawReport): RawReport => {
+    if (reportData.stationId === reportData.directionId) {
+        return { ...reportData, directionId: undefined }
+    }
+
+    return reportData
+}
+
 const clearStationReferenceIfNotOnLine =
     (stations: Stations, stationReferenceField: StationReferenceField) =>
     (reportData: RawReport): RawReport => {
@@ -130,6 +138,7 @@ export {
     determineLineBasedOnStationAndDirection,
     correctDirectionIfImplied,
     guessStation,
+    clearDirectionIfStationAndDirectionAreTheSame,
     isStationOnLine,
     pipe,
     RawReport,

--- a/packages/hono-backend/src/modules/reports/post-process-report.ts
+++ b/packages/hono-backend/src/modules/reports/post-process-report.ts
@@ -143,7 +143,7 @@ const correctDirectionIfImplied =
         if (reportData.directionId === null || reportData.directionId === undefined) return reportData
 
         const stationsOnLine = lines[reportData.lineId]
-        if (stationsOnLine.length < 2) return reportData
+        if (stationsOnLine === undefined || stationsOnLine.length < 2) return reportData
 
         const firstStationOnLine = stationsOnLine[0]
         const lastStationOnLine = stationsOnLine[stationsOnLine.length - 1]

--- a/packages/hono-backend/src/modules/reports/post-process-report.ts
+++ b/packages/hono-backend/src/modules/reports/post-process-report.ts
@@ -1,5 +1,9 @@
+import { eq } from 'drizzle-orm'
+import { DateTime } from 'luxon'
+
+import { AppError } from '../../common/errors'
 import { lookupStation } from '../../common/utils'
-import { InsertReport } from '../../db'
+import { DbConnection, InsertReport, reports } from '../../db'
 import { LineId, Lines, StationId, Stations } from '../transit/types'
 
 type RawReport = Omit<InsertReport, 'stationId'> & {
@@ -9,21 +13,143 @@ type RawReport = Omit<InsertReport, 'stationId'> & {
 type StationReferenceField = 'stationId' | 'directionId'
 
 /**
- * Pipe a value through a series of functions
+ * Pipe a value through a series of (a)synchronous functions
  * @param value - The value to pipe through the functions
  * @param fns - The functions to pipe through
- * @returns The final value
+ * @returns The final resolved value
  */
-const pipe = <T>(value: T, ...fns: ((arg: T) => T)[]) => fns.reduce((acc, fn) => fn(acc), value)
+const pipeAsync = async <T>(value: T, ...fns: Array<(arg: T) => T | Promise<T>>): Promise<T> => {
+    let result = value
+    for (const fn of fns) {
+        result = await fn(result)
+    }
+    return result
+}
 
-// TODO: Use a stochastic approach to guess the station
-const guessStation = (reportData: RawReport): RawReport => {
-    if (reportData.stationId === undefined) {
-        return { ...reportData, stationId: 'SUM-n30731497' }
+const normalizeDayOfWeek = (dayOfWeek: number): number => {
+    // Accept both JS-style (0-6, Sunday=0) and Luxon-style (1-7, Monday=1)
+    if (!Number.isFinite(dayOfWeek)) return 0
+    if (dayOfWeek >= 1 && dayOfWeek <= 7) return dayOfWeek
+    if (dayOfWeek >= 0 && dayOfWeek <= 6) return dayOfWeek === 0 ? 7 : dayOfWeek
+    return 0
+}
+
+const circularDistance = (a: number, b: number, modulus: number): number => {
+    const forward = (a - b + modulus) % modulus
+    const backward = (b - a + modulus) % modulus
+    return Math.min(forward, backward)
+}
+
+const getMostCommonStationId = (
+    rows: Array<{ stationId: StationId; timestamp: Date }>,
+    {
+        hour,
+        dayOfWeek,
+        hourWindow,
+        dayWindow,
+    }: { hour: number; dayOfWeek: number; hourWindow: number; dayWindow: number }
+): StationId | undefined => {
+    const normalizedDayOfWeek = normalizeDayOfWeek(dayOfWeek)
+    if (normalizedDayOfWeek === 0) return undefined
+    if (!Number.isInteger(hour) || hour < 0 || hour > 23) return undefined
+
+    const counts = new Map<StationId, number>()
+
+    for (const row of rows) {
+        const dateTime = DateTime.fromJSDate(row.timestamp, { zone: 'utc' })
+        const rowHour = dateTime.hour
+        const rowDayOfWeek = dateTime.weekday // 1-7
+
+        const hourDifference = circularDistance(rowHour, hour, 24)
+        const dayDifference = circularDistance(rowDayOfWeek, normalizedDayOfWeek, 7)
+
+        if (hourDifference > hourWindow) continue
+        if (dayDifference > dayWindow) continue
+
+        counts.set(row.stationId, (counts.get(row.stationId) ?? 0) + 1)
     }
 
-    return reportData
+    let bestStationId: StationId | undefined
+    let bestCount = -1
+
+    counts.forEach((count, stationId) => {
+        if (count > bestCount) {
+            bestStationId = stationId
+            bestCount = count
+            return
+        }
+
+        if (count === bestCount && bestStationId !== undefined && stationId < bestStationId) {
+            bestStationId = stationId
+        }
+    })
+
+    return bestStationId
 }
+
+const guessStation =
+    (db: DbConnection) =>
+    (lineId: LineId | null | undefined, hour: number, dayOfWeek: number) =>
+    async (reportData: RawReport): Promise<RawReport> => {
+        if (reportData.stationId !== undefined) return reportData
+
+        const normalizedDayOfWeek = normalizeDayOfWeek(dayOfWeek)
+        if (normalizedDayOfWeek === 0) {
+            throw new AppError({
+                message: 'Cannot infer station because day of week is invalid',
+                statusCode: 500,
+                internalCode: 'UNKNOWN_ERROR',
+                description: `Provided dayOfWeek=${String(dayOfWeek)}`,
+            })
+        }
+
+        const hourIsValid = Number.isInteger(hour) && hour >= 0 && hour <= 23
+        if (!hourIsValid) {
+            throw new AppError({
+                message: 'Cannot infer station because hour is invalid',
+                statusCode: 500,
+                internalCode: 'UNKNOWN_ERROR',
+                description: `Provided hour=${String(hour)}`,
+            })
+        }
+
+        const baseQuery = db.select({ stationId: reports.stationId, timestamp: reports.timestamp }).from(reports)
+
+        const rows =
+            lineId === null || lineId === undefined
+                ? await baseQuery
+                : await baseQuery.where(eq(reports.lineId, lineId))
+
+        // If there are no reports for the line yet, fall back to all reports
+        const candidateRows =
+            rows.length > 0
+                ? rows
+                : await db.select({ stationId: reports.stationId, timestamp: reports.timestamp }).from(reports)
+
+        // Expand search window until we find at least one matching station.
+        // Day window: 0..3 covers the full week (max distance is 3).
+        // Hour window: 0..12 covers the full day (max distance is 12).
+        for (let dayWindow = 0; dayWindow <= 3; dayWindow++) {
+            for (let hourWindow = 0; hourWindow <= 12; hourWindow++) {
+                const stationId = getMostCommonStationId(candidateRows, {
+                    hour,
+                    dayOfWeek: normalizedDayOfWeek,
+                    hourWindow,
+                    dayWindow,
+                })
+                if (stationId !== undefined) {
+                    return { ...reportData, stationId }
+                }
+            }
+        }
+
+        throw new AppError({
+            message: 'Could not infer station from historical reports',
+            statusCode: 422,
+            internalCode: 'UNKNOWN_ERROR',
+            description: `lineId=${String(lineId ?? 'null')}, hour=${hour}, dayOfWeek=${normalizedDayOfWeek}`,
+        })
+    }
 
 const correctDirectionIfImplied =
     (lines: Lines) =>
@@ -149,6 +275,6 @@ export {
     guessStation,
     clearDirectionIfStationAndDirectionAreTheSame,
     isStationOnLine,
-    pipe,
+    pipeAsync,
     RawReport,
 }

--- a/packages/hono-backend/src/modules/reports/post-process-report.ts
+++ b/packages/hono-backend/src/modules/reports/post-process-report.ts
@@ -25,6 +25,26 @@ const guessStation = (reportData: RawReport): RawReport => {
     return reportData
 }
 
+const determineLineBasedOnStationAndDirection =
+    (stations: Stations) =>
+    (reportData: RawReport): RawReport => {
+        if (reportData.lineId !== null && reportData.lineId !== undefined) return reportData
+
+        const station = lookupStation(stations, reportData.stationId)
+        const direction = lookupStation(stations, reportData.directionId)
+
+        if (station === undefined || direction === undefined) return reportData
+
+        const directionLines = new Set(direction.lines)
+        const sharedLines = station.lines.filter((lineId) => directionLines.has(lineId))
+
+        if (sharedLines.length === 1) {
+            return { ...reportData, lineId: sharedLines[0] }
+        }
+
+        return reportData
+    }
+
 const isStationOnLine = (
     stations: Stations,
     lineId: LineId | null | undefined,
@@ -74,4 +94,12 @@ const assignLineIfSingleOption =
         return reportData
     }
 
-export { assignLineIfSingleOption, clearStationReferenceIfNotOnLine, guessStation, isStationOnLine, pipe, RawReport }
+export {
+    assignLineIfSingleOption,
+    clearStationReferenceIfNotOnLine,
+    determineLineBasedOnStationAndDirection,
+    guessStation,
+    isStationOnLine,
+    pipe,
+    RawReport,
+}

--- a/packages/hono-backend/src/modules/reports/post-process-report.ts
+++ b/packages/hono-backend/src/modules/reports/post-process-report.ts
@@ -1,0 +1,38 @@
+import { InsertReport } from '../../db'
+import { StationId, Stations } from '../transit/types'
+
+type RawReport = Omit<InsertReport, 'stationId'> & {
+    stationId?: StationId | undefined
+}
+
+/**
+ * Pipe a value through a series of functions
+ * @param value - The value to pipe through the functions
+ * @param fns - The functions to pipe through
+ * @returns The final value
+ */
+const pipe = <T>(value: T, ...fns: ((arg: T) => T)[]) => fns.reduce((acc, fn) => fn(acc), value)
+
+// Todo: Unit test this function
+const assignLineIfSingleOption =
+    (stations: Stations) =>
+    (reportData: RawReport): RawReport => {
+        if (reportData.lineId !== null) return reportData
+
+        const getLineFromStation = (stations: Stations, stationId: StationId | null | undefined) => {
+            if (stationId === null || stationId === undefined) return undefined
+            const station = stations[stationId]
+            return station.lines.length === 1 ? station.lines[0] : undefined
+        }
+
+        const lineId =
+            getLineFromStation(stations, reportData.stationId) ?? getLineFromStation(stations, reportData.directionId)
+
+        if (lineId !== undefined) {
+            return { ...reportData, lineId }
+        }
+
+        return reportData
+    }
+
+export { assignLineIfSingleOption, pipe, RawReport }

--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -68,7 +68,7 @@ export const postReport = defineRoute<Env>()({
             source: reportData.source ?? 'telegram',
         })
 
-        const { telegramNotificationSuccess } = await reportsService.createReport({
+        const { telegramNotificationSuccess, report } = await reportsService.createReport({
             ...postProcessedReportData,
         })
 
@@ -77,11 +77,6 @@ export const postReport = defineRoute<Env>()({
             c.header('X-Telegram-Notification-Status', 'failed')
         }
 
-        return c.json(
-            await reportsService.getReports({
-                from: DateTime.now().minus({ hours: 1 }),
-                to: DateTime.now(),
-            })
-        )
+        return c.json(report)
     },
 })

--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -52,11 +52,7 @@ export const postReport = defineRoute<Env>()({
     method: 'post',
     path: 'v0/reports',
     schemas: {
-        json: insertReportSchema.extend({
-            source: insertReportSchema.shape.source.optional(),
-            // Since the Bot sometimes does not detect a station, we allow undefined
-            stationId: insertReportSchema.shape.stationId.optional(),
-        }),
+        json: insertReportSchema,
     },
     handler: async (c) => {
         const reportsService = c.get('reportsService')

--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -54,6 +54,8 @@ export const postReport = defineRoute<Env>()({
     schemas: {
         json: insertReportSchema.extend({
             source: insertReportSchema.shape.source.optional(),
+            // Since the Bot sometimes does not detect a station, we allow undefined
+            stationId: insertReportSchema.shape.stationId.optional(),
         }),
     },
     handler: async (c) => {
@@ -61,9 +63,13 @@ export const postReport = defineRoute<Env>()({
 
         const reportData = c.req.valid('json')
 
-        const { telegramNotificationSuccess } = await reportsService.createReport({
+        const postProcessedReportData = await reportsService.postProcessReport({
             ...reportData,
             source: reportData.source ?? 'telegram',
+        })
+
+        const { telegramNotificationSuccess } = await reportsService.createReport({
+            ...postProcessedReportData,
         })
 
         if (!telegramNotificationSuccess) {

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -15,6 +15,7 @@ import {
     guessStation,
     pipe,
     RawReport,
+    clearDirectionIfStationAndDirectionAreTheSame,
 } from './post-process-report'
 
 type TelegramNotificationPayload = {
@@ -110,6 +111,7 @@ export class ReportsService {
             assignLineIfSingleOption(stations),
             determineLineBasedOnStationAndDirection(stations),
             correctDirectionIfImplied(lines),
+            clearDirectionIfStationAndDirectionAreTheSame,
             guessStation
         )
 

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -6,6 +6,8 @@ import { DbConnection, InsertReport, reports } from '../../db/'
 import type { TransitNetworkDataService } from '../transit/transit-network-data-service'
 import type { Stations, StationId } from '../transit/types'
 
+import { assignLineIfSingleOption, pipe, RawReport } from './post-process-report'
+
 type TelegramNotificationPayload = {
     line: string | null
     station: string
@@ -13,40 +15,6 @@ type TelegramNotificationPayload = {
     message: string | null
     stationId: StationId
 }
-
-type RawReport = Omit<InsertReport, 'stationId'> & {
-    stationId?: StationId | undefined
-}
-
-/**
- * Pipe a value through a series of functions
- * @param value - The value to pipe through the functions
- * @param fns - The functions to pipe through
- * @returns The final value
- */
-const pipe = <T>(value: T, ...fns: ((arg: T) => T)[]) => fns.reduce((acc, fn) => fn(acc), value)
-
-// Todo: Unit test this function
-const assignLineIfSingleOption =
-    (stations: Stations) =>
-    (reportData: RawReport): RawReport => {
-        if (reportData.lineId !== null) return reportData
-
-        const getLineFromStation = (stations: Stations, stationId: StationId | null | undefined) => {
-            if (stationId === null || stationId === undefined) return undefined
-            const station = stations[stationId]
-            return station.lines.length === 1 ? station.lines[0] : undefined
-        }
-
-        const lineId =
-            getLineFromStation(stations, reportData.stationId) ?? getLineFromStation(stations, reportData.directionId)
-
-        if (lineId !== undefined) {
-            return { ...reportData, lineId }
-        }
-
-        return reportData
-    }
 
 export class ReportsService {
     constructor(

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -10,6 +10,7 @@ import type { StationId } from '../transit/types'
 import {
     assignLineIfSingleOption,
     clearStationReferenceIfNotOnLine,
+    correctDirectionIfImplied,
     determineLineBasedOnStationAndDirection,
     guessStation,
     pipe,
@@ -100,6 +101,7 @@ export class ReportsService {
 
     async postProcessReport(reportData: RawReport): Promise<InsertReport> {
         const stations = await this.transitNetworkDataService.getStations()
+        const lines = await this.transitNetworkDataService.getLines()
 
         const processed = pipe(
             reportData,
@@ -107,6 +109,7 @@ export class ReportsService {
             clearStationReferenceIfNotOnLine(stations, 'directionId'),
             assignLineIfSingleOption(stations),
             determineLineBasedOnStationAndDirection(stations),
+            correctDirectionIfImplied(lines),
             guessStation
         )
 

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -16,6 +16,7 @@ import {
     pipe,
     RawReport,
     clearDirectionIfStationAndDirectionAreTheSame,
+    ifDirectionPresentWithoutLineClearDirection,
 } from './post-process-report'
 
 type TelegramNotificationPayload = {
@@ -112,6 +113,7 @@ export class ReportsService {
             determineLineBasedOnStationAndDirection(stations),
             correctDirectionIfImplied(lines),
             clearDirectionIfStationAndDirectionAreTheSame,
+            ifDirectionPresentWithoutLineClearDirection,
             guessStation
         )
 

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -14,6 +14,40 @@ type TelegramNotificationPayload = {
     stationId: StationId
 }
 
+type RawReport = Omit<InsertReport, 'stationId'> & {
+    stationId?: StationId | undefined
+}
+
+/**
+ * Pipe a value through a series of functions
+ * @param value - The value to pipe through the functions
+ * @param fns - The functions to pipe through
+ * @returns The final value
+ */
+const pipe = <T>(value: T, ...fns: ((arg: T) => T)[]) => fns.reduce((acc, fn) => fn(acc), value)
+
+// Todo: Unit test this function
+const assignLineIfSingleOption =
+    (stations: Stations) =>
+    (reportData: RawReport): RawReport => {
+        if (reportData.lineId !== null) return reportData
+
+        const getLineFromStation = (stations: Stations, stationId: StationId | null | undefined) => {
+            if (stationId === null || stationId === undefined) return undefined
+            const station = stations[stationId]
+            return station.lines.length === 1 ? station.lines[0] : undefined
+        }
+
+        const lineId =
+            getLineFromStation(stations, reportData.stationId) ?? getLineFromStation(stations, reportData.directionId)
+
+        if (lineId !== undefined) {
+            return { ...reportData, lineId }
+        }
+
+        return reportData
+    }
+
 export class ReportsService {
     constructor(
         private db: DbConnection,
@@ -98,5 +132,13 @@ export class ReportsService {
         }
 
         return stations[stationId]
+    }
+
+    async postProcessReport(reportData: RawReport): Promise<InsertReport> {
+        const stations = await this.transitNetworkDataService.getStations()
+
+        const processed = pipe(reportData, assignLineIfSingleOption(stations))
+
+        return processed as InsertReport // TODO: remove this cast
     }
 }

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -122,8 +122,6 @@ export class ReportsService {
         const stations = await this.transitNetworkDataService.getStations()
         const lines = await this.transitNetworkDataService.getLines()
 
-        // Todo: if no line, station or direction fail early
-
         const now = DateTime.utc()
 
         const processed = await pipeAsync(

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -146,6 +146,6 @@ export class ReportsService {
             })
         }
 
-        return processed as InsertReport // TODO: remove this cast
+        return { ...processed, stationId: processed.stationId }
     }
 }

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -7,7 +7,13 @@ import { DbConnection, InsertReport, reports } from '../../db/'
 import type { TransitNetworkDataService } from '../transit/transit-network-data-service'
 import type { StationId } from '../transit/types'
 
-import { assignLineIfSingleOption, clearStationReferenceIfNotOnLine, pipe, RawReport } from './post-process-report'
+import {
+    assignLineIfSingleOption,
+    clearStationReferenceIfNotOnLine,
+    guessStation,
+    pipe,
+    RawReport,
+} from './post-process-report'
 
 type TelegramNotificationPayload = {
     line: string | null
@@ -98,7 +104,8 @@ export class ReportsService {
             reportData,
             clearStationReferenceIfNotOnLine(stations, 'stationId'),
             clearStationReferenceIfNotOnLine(stations, 'directionId'),
-            assignLineIfSingleOption(stations)
+            assignLineIfSingleOption(stations),
+            guessStation
         )
 
         return processed as InsertReport // TODO: remove this cast

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -10,6 +10,7 @@ import type { StationId } from '../transit/types'
 import {
     assignLineIfSingleOption,
     clearStationReferenceIfNotOnLine,
+    determineLineBasedOnStationAndDirection,
     guessStation,
     pipe,
     RawReport,
@@ -105,6 +106,7 @@ export class ReportsService {
             clearStationReferenceIfNotOnLine(stations, 'stationId'),
             clearStationReferenceIfNotOnLine(stations, 'directionId'),
             assignLineIfSingleOption(stations),
+            determineLineBasedOnStationAndDirection(stations),
             guessStation
         )
 

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -151,7 +151,9 @@ export class ReportsService {
                     .limit(1000)
 
                 return guessStation(candidateRows)(now.hour, now.weekday)(currentReport)
-            }
+            },
+            clearStationReferenceIfNotOnLine(stations, 'stationId'),
+            clearStationReferenceIfNotOnLine(stations, 'directionId')
         )
 
         if (processed.stationId === undefined) {

--- a/packages/hono-backend/src/modules/transit/types.ts
+++ b/packages/hono-backend/src/modules/transit/types.ts
@@ -16,6 +16,6 @@ type Station = {
 }
 
 type Stations = Record<StationId, Station>
-type Lines = Record<LineId, StationId[]>
+type Lines = Record<LineId, StationId[] | undefined>
 
 export type { Lines, Stations, StationId, LineId }

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -14,7 +14,7 @@ const createReport = async (timestamp: Date) => {
     await db.insert(reports).values({
         stationId: testStationId,
         lineId: testLineId,
-        directionId: testLineId,
+        directionId: testStationId,
         timestamp,
         source: 'telegram',
     })

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -129,6 +129,37 @@ describe('Report API contract', () => {
         app = mod.default
     })
 
+    it('returns only the created report', async () => {
+        const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
+
+        const response = await sendReportRequest({
+            stationId: station.id,
+            source: 'web_app',
+        })
+
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as unknown
+
+        expect(Array.isArray(body)).toBe(false)
+        expect(typeof body).toBe('object')
+        expect(body).not.toBeNull()
+
+        const createdReport = body as {
+            reportId: number
+            stationId: string
+            lineId: string | null
+            directionId: string | null
+            timestamp: string | Date
+            source?: unknown
+        }
+
+        expect(typeof createdReport.reportId).toBe('number')
+        expect(createdReport.stationId).toBe(station.id)
+        expect(createdReport).not.toHaveProperty('source')
+        expect(createdReport.timestamp).toBeTruthy()
+    })
+
     it('defaults to telegram source when source is missing in request', async () => {
         const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
 

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -15,6 +15,16 @@ type CapturedRequest = {
 
 const capturedRequests: CapturedRequest[] = []
 
+const sendReportRequest = async (payload: object) => {
+    return app.request('/v0/reports', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+    })
+}
+
 describe('Telegram notification', () => {
     let shouldFail: boolean
 
@@ -61,15 +71,9 @@ describe('Telegram notification', () => {
     it('sends a Telegram notification when source is not telegram and returns 200', async () => {
         const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
 
-        const response = await app.request('/v0/reports', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                stationId: station.id,
-                source: 'web_app',
-            }),
+        const response = await sendReportRequest({
+            stationId: station.id,
+            source: 'web_app',
         })
 
         expect(response.status).toBe(200)
@@ -93,15 +97,9 @@ describe('Telegram notification', () => {
 
         shouldFail = true
 
-        const response = await app.request('/v0/reports', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                stationId: station.id,
-                source: 'web_app',
-            }),
+        const response = await sendReportRequest({
+            stationId: station.id,
+            source: 'web_app',
         })
 
         expect(response.status).toBe(200)
@@ -112,15 +110,9 @@ describe('Telegram notification', () => {
     })
 
     it('does not send a Telegram notification if database insertion fails', async () => {
-        const response = await app.request('/v0/reports', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                stationId: 'invalid_id', // Triggers FK violation
-                source: 'web_app',
-            }),
+        const response = await sendReportRequest({
+            stationId: 'invalid_id', // Triggers FK violation
+            source: 'web_app',
         })
 
         expect(response.status).toBe(500)
@@ -138,15 +130,9 @@ describe('Report API contract', () => {
     it('defaults to telegram source when source is missing in request', async () => {
         const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
 
-        const response = await app.request('/v0/reports', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                stationId: station.id,
-                // source is omitted
-            }),
+        const response = await sendReportRequest({
+            stationId: station.id,
+            // source is omitted
         })
 
         expect(response.status).toBe(200)
@@ -182,17 +168,11 @@ describe('Report API contract', () => {
             .orderBy(desc(lineStations.order))
             .limit(1)
 
-        const response = await app.request('/v0/reports', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                stationId: entry.stationId,
-                lineId: entry.lineId,
-                directionId: finalStation.id,
-                source: 'web_app',
-            }),
+        const response = await sendReportRequest({
+            stationId: entry.stationId,
+            lineId: entry.lineId,
+            directionId: finalStation.id,
+            source: 'web_app',
         })
 
         expect(response.status).toBe(200)

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -380,6 +380,24 @@ describe('Report Post Processing', () => {
         expect(response.status).toBe(422)
     })
 
+    it('Accept a direction only payload when a line can be inferred', async () => {
+        const response = await sendReportRequest({
+            source: 'web_app',
+            directionId: directionWithOneLineId,
+        })
+
+        expect(response.status).toBe(200)
+
+        const [report] = await db
+            .select({ lineId: reports.lineId, stationId: reports.stationId, directionId: reports.directionId })
+            .from(reports)
+            .orderBy(desc(reports.timestamp))
+            .limit(1)
+
+        expect(report.lineId).toBe(lineIdForStationWithOneLine)
+        expect(report.directionId).toBe(directionWithOneLineId)
+    })
+
     it('if no line is present it will use the stations line', async () => {
         const response = await sendReportRequest({
             stationId: stationWithOneLineId,

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -129,6 +129,18 @@ describe('Report API contract', () => {
         app = mod.default
     })
 
+    it('rejects reports without station, line, and direction', async () => {
+        const response = await sendReportRequest({
+            source: 'web_app',
+            // stationId, lineId and directionId are omitted on purpose
+        })
+
+        expect(response.status).toBe(400)
+
+        const responseBody = await response.text()
+        expect(responseBody).toContain('At least one of stationId, lineId, or directionId must be provided')
+    })
+
     it('returns only the created report', async () => {
         const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
 

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -422,4 +422,23 @@ describe('Report Post Processing', () => {
 
         expect(report.directionId).toBe(firstStationOnLineId)
     })
+
+    it('clears direction when station and direction are the same', async () => {
+        const response = await sendReportRequest({
+            stationId: stationWithOneLineId,
+            lineId: lineIdForStationWithOneLine,
+            directionId: stationWithOneLineId,
+            source: 'web_app',
+        })
+
+        expect(response.status).toBe(200)
+
+        const [report] = await db
+            .select({ directionId: reports.directionId })
+            .from(reports)
+            .orderBy(desc(reports.timestamp))
+            .limit(1)
+
+        expect(report.directionId).toBeNull()
+    })
 })

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -337,6 +337,39 @@ describe('Report API contract', () => {
 
         expect(report.directionId).toBe(finalStation.id)
     })
+
+    it('rejects reports with an invalid lineId instead of crashing', async () => {
+        const response = await sendReportRequest({
+            lineId: 'NON_EXISTENT_LINE',
+            source: 'web_app',
+        })
+
+        expect(response.status).toBe(400)
+    })
+
+    it('rejects reports with an invalid stationId instead of crashing', async () => {
+        const response = await sendReportRequest({
+            stationId: 'NON_EXISTENT_STATION',
+            source: 'web_app',
+        })
+
+        expect(response.status).toBe(400)
+    })
+
+    it('rejects reports with an invalid directionId instead of crashing', async () => {
+        const response = await sendReportRequest({
+            directionId: 'NON_EXISTENT_DIRECTION',
+            source: 'web_app',
+        })
+        expect(response.status).toBe(400)
+    })
+
+    it('rejects reports with an invalid source instead of crashing', async () => {
+        const response = await sendReportRequest({
+            source: 'NON_EXISTENT_SOURCE',
+        })
+        expect(response.status).toBe(400)
+    })
 })
 
 describe('Report Post Processing', () => {
@@ -362,7 +395,9 @@ describe('Report Post Processing', () => {
         await seedBaseData(db)
         const transitService = new TransitNetworkDataService(db)
         stationsMap = await transitService.getStations()
-        linesMap = await transitService.getLines()
+        linesMap = Object.fromEntries(
+            Object.entries(await transitService.getLines()).map(([key, value]) => [key, value ?? []])
+        )
 
         const stationEntries = Object.entries(stationsMap)
 

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -371,6 +371,15 @@ describe('Report Post Processing', () => {
         stationAfterMiddleId = lineWithMiddleStation[1][2]!
     })
 
+    it('rejects direction only payload when no line can be inferred', async () => {
+        const response = await sendReportRequest({
+            source: 'web_app',
+            directionId: stationWithMultipleLinesId,
+        })
+
+        expect(response.status).toBe(422)
+    })
+
     it('if no line is present it will use the stations line', async () => {
         const response = await sendReportRequest({
             stationId: stationWithOneLineId,

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -441,4 +441,22 @@ describe('Report Post Processing', () => {
 
         expect(report.directionId).toBeNull()
     })
+
+    it('clears direction when direction is present without a line', async () => {
+        const response = await sendReportRequest({
+            stationId: stationWithOneLineId,
+            lineId: null,
+            directionId: stationWithOneLineId,
+            source: 'web_app',
+        })
+        expect(response.status).toBe(200)
+
+        const [report] = await db
+            .select({ directionId: reports.directionId })
+            .from(reports)
+            .orderBy(desc(reports.timestamp))
+            .limit(1)
+
+        expect(report.directionId).toBeNull()
+    })
 })


### PR DESCRIPTION
## Describe the issue:
Sometimes either users or the bot submit reports that are:
1. incomplete 
2. impossible
We need to validate those, to make sure that we only have valid and as complete as possible reports in the database.

## Explain how you solved the issue:
I defined a pipe that calls a couple of cross validation function on the report that was being sent by the user. 

## Additional notes or considerations:
A lot of this is coming from the extensive testing. If you have any ideas what we should also test in this context please let me know.
I also tried to write this as functional as possible so that we can reduce complexity.

### Important!!!
`guessStation` is not scaleable. It will fetch all of the reports for the line into memory and choose the most common in memory. This means as we get more reports the memory (and also CPU) usage of posting an inspector will increase. 
There are a couple of ways how we can solve this each with their own trade off and I would like some opinions on what we should do:
1. <del>Move the entire calculation to the DB. We can craft one drizzle query that will perform this all on the db side. The benefit of this is that this is as performant as it can possibly get since the brightest minds in computer science are working to optimize postgres and no matter how hard we try we will not be faster than Postgres. The downside of this is that the query would be quite complex, meaning difficult to write and even more difficult to read. </del>
2. <del>Create DB aggregates. We can create some aggregates that store the most common station for each line for each day of the week and each hour. We can then update this with a trigger every 24h at midnight or something like this. This would mean we have a O(1) lookup time but we also increase complexity of the db schema significantly. The benefit of this is that we can reuse the same logic for historic data, which means that the `POST /reports/` and the `GET /reports/` both benefit from this.</del>
3. Limit results: We can simply return the results of the last 30 or 90 days, with which we would have a very simple solution that is also very fast. The issue with this is that we loose significant accuracy especially if we would deploy in a city with a less active community.
4.<del> Do nothing. We currently have around 80k reports, even if all of them are loaded into memory it would not be that big of deal especially since we are not getting that many reports concurrently the server can probably handle it for now. So we could just note this down and solve the issue once it becomes an actual issue.  </del>

Also depending on the decision I can make `guessStation` be pure. 
