### PR TITLE
refactor: use pgTable array config for lineStations

### DIFF
--- a/packages/hono-backend/src/db/schema/lines.ts
+++ b/packages/hono-backend/src/db/schema/lines.ts
@@ -19,7 +19,5 @@ export const lineStations = pgTable(
             .references(() => stations.id, { onDelete: 'cascade' }),
         order: integer().notNull(),
     },
-    (table) => ({
-        pk: primaryKey({ columns: [table.lineId, table.stationId] }),
-    })
+    (table) => [primaryKey({ columns: [table.lineId, table.stationId] })]
 )


### PR DESCRIPTION
## Summary
- update the lineStations table schema to use the new pgTable array extra config API
- keep the composite primary key definition while avoiding the deprecated object config

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6946a56a56ec832db450151c51f99c46)