### PR TITLE
feat: check some secret info with `verifyRequest`

### DIFF
--- a/packages/hono-backend/compose-hono.test.yaml
+++ b/packages/hono-backend/compose-hono.test.yaml
@@ -26,6 +26,7 @@ services:
             DATABASE_URL: postgres://postgres:postgres@postgres:5432/freifahren
             NLP_SERVICE_URL: http://localhost:6000
             REPORT_PASSWORD: password
+            SECURITY_MICROSERVICE_URL: http://localhost:4000
         ports:
             - '80:3000'
         volumes:

--- a/packages/hono-backend/package.json
+++ b/packages/hono-backend/package.json
@@ -1,7 +1,8 @@
 {
     "name": "hono-backend",
     "scripts": {
-        "dev": "bun run --hot src/index.ts",
+        "dev": "NODE_ENV=development bun run --hot src/index.ts",
+        "start": "NODE_ENV=production bun run src/index.ts",
         "lint": "eslint . --ext .ts",
         "lint:fix": "eslint . --ext .ts --fix",
         "format": "prettier --write .",

--- a/packages/hono-backend/src/common/errors.ts
+++ b/packages/hono-backend/src/common/errors.ts
@@ -1,6 +1,6 @@
 import { ContentfulStatusCode } from 'hono/utils/http-status'
 
-export type InternalCode = 'TELEGRAM_NOTIFICATION_FAILED' | 'UNKNOWN_ERROR'
+export type InternalCode = 'TELEGRAM_NOTIFICATION_FAILED' | 'UNKNOWN_ERROR' | 'SPAM_REPORT_DETECTED'
 
 export interface AppErrorDetails {
     internal_code: InternalCode

--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { z } from 'zod'
 
 import { Env } from '../../app-env'
+import { AppError } from '../../common/errors'
 import { defineRoute } from '../../common/router'
 import { insertReportSchema } from '../../db'
 
@@ -58,6 +59,28 @@ export const postReport = defineRoute<Env>()({
     },
     handler: async (c) => {
         const reportsService = c.get('reportsService')
+        const logger = c.get('logger')
+
+        try {
+            await reportsService.verifyRequest(c.req.header())
+        } catch (err) {
+            if (err instanceof AppError && err.internalCode === 'SPAM_REPORT_DETECTED') {
+                logger.warn('Spam report blocked by security service')
+                return c.json(
+                    {
+                        message: err.message,
+                    },
+                    err.statusCode
+                )
+            }
+            logger.error(err, 'Error verifying request with security service')
+            return c.json(
+                {
+                    message: 'Failed to verify request',
+                },
+                500
+            )
+        }
 
         const reportData = c.req.valid('json')
 
@@ -67,7 +90,7 @@ export const postReport = defineRoute<Env>()({
         })
 
         if (!telegramNotificationSuccess) {
-            c.get('logger').error('Failed to notify Telegram bot about inspector report')
+            logger.error('Failed to notify Telegram bot about inspector report')
             c.header('X-Telegram-Notification-Status', 'failed')
         }
 

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -14,7 +14,7 @@ const createReport = async (timestamp: Date) => {
     await db.insert(reports).values({
         stationId: testStationId,
         lineId: testLineId,
-        directionId: testLineId,
+        directionId: testStationId, // Use stationId as directionId to avoid FK errors if lineId doesn't exist in stations
         timestamp,
         source: 'telegram',
     })

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -236,7 +236,12 @@ describe('Predicted reports', () => {
         // Create a real report for one station
         const realStationId = allStationIds[0]
 
-        await sendReportRequest({ stationId: realStationId, lineId: testLineId, directionId: realStationId, source: 'telegram' })
+        await sendReportRequest({
+            stationId: realStationId,
+            lineId: testLineId,
+            directionId: realStationId,
+            source: 'telegram',
+        })
 
         // Set 'to' after creating reports to ensure they're captured
         const to = DateTime.now().toUTC().plus({ seconds: 5 })

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -14,7 +14,7 @@ const createReport = async (timestamp: Date) => {
     await db.insert(reports).values({
         stationId: testStationId,
         lineId: testLineId,
-        directionId: testStationId, // Use stationId as directionId to avoid FK errors if lineId doesn't exist in stations
+        directionId: testStationId,
         timestamp,
         source: 'telegram',
     })

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -14,7 +14,7 @@ const createReport = async (timestamp: Date) => {
     await db.insert(reports).values({
         stationId: testStationId,
         lineId: testLineId,
-        directionId: testStationId,
+        directionId: testLineId,
         timestamp,
         source: 'telegram',
     })

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -20,7 +20,6 @@ type CapturedRequest = {
 const capturedRequests: CapturedRequest[] = []
 let securityValidResponse = true
 
-
 describe('Telegram notification', () => {
     let shouldFail: boolean
 


### PR DESCRIPTION
## Describe the issue:
Previously any person could automatically send POST report requests and thus would have spammed the database.

## Explain how you solved the issue:
Before the request is processed we are now sending a request with the headers to a secret microservice, which will decide if the request is valid or not. 

## Additional notes or considerations:
I also added a test case to test the X-Password exception. I am hesitant to add any other test cases since we could accidentally leak any implementation details of the secret microservice. 
