### PR TITLE
feat: server side cache for transit data

### DIFF
--- a/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
+++ b/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
@@ -47,7 +47,7 @@ export class TransitNetworkDataService {
 
         const result = joinedRows.reduce<Lines>((linesById, row) => {
             const base = Object.prototype.hasOwnProperty.call(linesById, row.lineId) ? linesById[row.lineId] : []
-            const stations = row.stationId !== null ? [...(base ?? []), row.stationId] : base
+            const stations = row.stationId !== null ? [...base, row.stationId] : base
             linesById[row.lineId] = stations
             return linesById
         }, {} as Lines)

--- a/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
+++ b/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
@@ -5,53 +5,68 @@ import { DbConnection, stations, lineStations, lines } from '../../db'
 import type { Lines, Stations } from './types'
 
 export class TransitNetworkDataService {
+    private stationsCache: Promise<Stations> | null = null
+    private linesCache: Promise<Lines> | null = null
+
     constructor(private db: DbConnection) {}
 
     async getStations(): Promise<Stations> {
-        const joinedRows = await this.db
-            .select({
-                id: stations.id,
-                name: stations.name,
-                lat: stations.lat,
-                lng: stations.lng,
-                lineId: lineStations.lineId,
-            })
-            .from(stations)
-            .leftJoin(lineStations, eq(lineStations.stationId, stations.id))
+        if (this.stationsCache) {
+            return this.stationsCache
+        }
 
-        const result = joinedRows.reduce<Stations>((stationsById, row) => {
-            const base = Object.prototype.hasOwnProperty.call(stationsById, row.id)
-                ? stationsById[row.id]
-                : {
-                      name: row.name,
-                      coordinates: { latitude: row.lat, longitude: row.lng },
-                      lines: [],
-                  }
-            const lines = row.lineId !== null ? [...base.lines, row.lineId] : base.lines
-            stationsById[row.id] = { ...base, lines }
-            return stationsById
-        }, {} as Stations)
+        this.stationsCache = (async () => {
+            const joinedRows = await this.db
+                .select({
+                    id: stations.id,
+                    name: stations.name,
+                    lat: stations.lat,
+                    lng: stations.lng,
+                    lineId: lineStations.lineId,
+                })
+                .from(stations)
+                .leftJoin(lineStations, eq(lineStations.stationId, stations.id))
 
-        return result
+            return joinedRows.reduce<Stations>((stationsById, row) => {
+                const base = Object.prototype.hasOwnProperty.call(stationsById, row.id)
+                    ? stationsById[row.id]
+                    : {
+                          name: row.name,
+                          coordinates: { latitude: row.lat, longitude: row.lng },
+                          lines: [],
+                      }
+                const lines = row.lineId !== null ? [...base.lines, row.lineId] : base.lines
+                stationsById[row.id] = { ...base, lines }
+                return stationsById
+            }, {} as Stations)
+        })()
+
+        return this.stationsCache
     }
 
     async getLines(): Promise<Lines> {
-        const joinedRows = await this.db
-            .select({
-                lineId: lines.id,
-                stationId: lineStations.stationId,
-            })
-            .from(lines)
-            .leftJoin(lineStations, eq(lineStations.lineId, lines.id))
-            .orderBy(asc(lines.id), asc(lineStations.order))
+        if (this.linesCache) {
+            return this.linesCache
+        }
 
-        const result = joinedRows.reduce<Lines>((linesById, row) => {
-            const base = Object.prototype.hasOwnProperty.call(linesById, row.lineId) ? linesById[row.lineId] : []
-            const stations = row.stationId !== null ? [...base, row.stationId] : base
-            linesById[row.lineId] = stations
-            return linesById
-        }, {} as Lines)
+        this.linesCache = (async () => {
+            const joinedRows = await this.db
+                .select({
+                    lineId: lines.id,
+                    stationId: lineStations.stationId,
+                })
+                .from(lines)
+                .leftJoin(lineStations, eq(lineStations.lineId, lines.id))
+                .orderBy(asc(lines.id), asc(lineStations.order))
 
-        return result
+            return joinedRows.reduce<Lines>((linesById, row) => {
+                const base = Object.prototype.hasOwnProperty.call(linesById, row.lineId) ? linesById[row.lineId] : []
+                const stations = row.stationId !== null ? [...base, row.stationId] : base
+                linesById[row.lineId] = stations
+                return linesById
+            }, {} as Lines)
+        })()
+
+        return this.linesCache
     }
 }

--- a/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
+++ b/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
@@ -47,7 +47,7 @@ export class TransitNetworkDataService {
 
         const result = joinedRows.reduce<Lines>((linesById, row) => {
             const base = Object.prototype.hasOwnProperty.call(linesById, row.lineId) ? linesById[row.lineId] : []
-            const stations = row.stationId !== null ? [...base, row.stationId] : base
+            const stations = row.stationId !== null ? [...(base ?? []), row.stationId] : base
             linesById[row.lineId] = stations
             return linesById
         }, {} as Lines)

--- a/packages/hono-backend/src/modules/transit/types.ts
+++ b/packages/hono-backend/src/modules/transit/types.ts
@@ -16,6 +16,6 @@ type Station = {
 }
 
 type Stations = Record<StationId, Station>
-type Lines = Record<LineId, StationId[] | undefined>
+type Lines = Record<LineId, StationId[]>
 
 export type { Lines, Stations, StationId, LineId }


### PR DESCRIPTION
## Describe the issue:
For every request to `/transit/lines` or `/transit/stations` we would do a database request. This is useless as the database content would only change when we restart the backend anyways.

## Explain how you solved the issue:
Instead we now keep the results of the first database query in memory and simply keep on returning this data. 
