### PR TITLE
feat: predicted reports 

### DIFF
--- a/packages/hono-backend/src/modules/reports/post-process-report.ts
+++ b/packages/hono-backend/src/modules/reports/post-process-report.ts
@@ -80,11 +80,8 @@ const getMostCommonStationId = (
 const guessStation =
     (candidateRows: Array<{ stationId: StationId; timestamp: Date }>) =>
     (hour: number, dayOfWeek: number) =>
-    (reportData: RawReport): RawReport => {
-        // We do not want to guess the station without a line
-        // Otherwise the guess would be too broad and we would end up with a lot of false positives
-        if (reportData.stationId !== undefined || reportData.lineId === null || reportData.lineId === undefined)
-            return reportData
+    <T extends { stationId?: StationId }>(reportData: T): T => {
+        if (reportData.stationId !== undefined) return reportData
 
         if (!Number.isFinite(dayOfWeek) || dayOfWeek < 1 || dayOfWeek > 7) {
             throw new AppError({

--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -44,7 +44,7 @@ export const getReports = defineRoute<Env>()({
             to: query.to ?? defaultRange.to,
         }
 
-        return c.json(await reportsService.getReports(range))
+        return c.json(await reportsService.getReports({ ...range, currentTime: DateTime.now() })) // Intentionally pass in local time
     },
 })
 

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -57,10 +57,6 @@ const calculateBasePredictedReportsThreshold = (currentTime: DateTime): number =
     return 7
 }
 
-/**
- * Applies the legacy weekend reduction. The reduction is computed from the *truncated* base value,
- * which is important for matching the previous behavior.
- */
 const calculateWeekendAdjustment = (currentTime: DateTime, baseThreshold: number): number => {
     if (!isWeekend(currentTime.weekday as LuxonWeekday)) return 0
 
@@ -86,7 +82,6 @@ export class ReportsService {
         private transitNetworkDataService: TransitNetworkDataService
     ) {}
 
-    // Todo: Test that getReports returns not only unique stationIds
     async getReports({
         from,
         to,
@@ -120,10 +115,7 @@ export class ReportsService {
         return result
     }
 
-    /*
-    Returns the integer threshold that controls how many predicted/historic reports we should show.
-    */
-    // TODO: Write integration tests for this
+    // Returns the integer threshold that controls how many predicted/historic reports we should show.
     private calculatePredictedReportsThreshold(currentTime: DateTime): number {
         const base = calculateBasePredictedReportsThreshold(currentTime)
         const adjustment = calculateWeekendAdjustment(currentTime, base)

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -36,12 +36,12 @@ const calculateBasePredictedReportsThreshold = (currentTime: DateTime): number =
 
     if (minutesPastMidnight >= 18 * 60 && isSaturday && minutesPastMidnight < 24 * 60) {
         // On Saturdays, decrease linearly from 18:00 to 24:00
-        return 7 - (minutesPastMidnight - 18 * 60) * (9.0 / (6 * 60))
+        return 7 - (minutesPastMidnight - 18 * 60) * (6.0 / (6 * 60))
     }
 
     if (minutesPastMidnight >= 18 * 60 && minutesPastMidnight < 21 * 60) {
         // On other days, decrease linearly from 18:00 to 21:00
-        return 7 - (minutesPastMidnight - 18 * 60) * (9.0 / (3 * 60))
+        return 7 - (minutesPastMidnight - 18 * 60) * (6.0 / (3 * 60))
     }
 
     if (minutesPastMidnight >= 21 * 60 || minutesPastMidnight < 7 * 60) {
@@ -51,7 +51,7 @@ const calculateBasePredictedReportsThreshold = (currentTime: DateTime): number =
 
     if (minutesPastMidnight >= 7 * 60 && minutesPastMidnight < 9 * 60) {
         // Increase linearly from 7:00 to 9:00
-        return 1 + (minutesPastMidnight - 7 * 60) * (9.0 / (2 * 60))
+        return 1 + (minutesPastMidnight - 7 * 60) * (6.0 / (2 * 60))
     }
 
     return 7

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -307,7 +307,11 @@ describe('Predicted reports', () => {
 
         // Create 2 reports for station B
         for (let i = 0; i < 2; i++) {
-            await createReportWithTimestamp(historicalMonday.minus({ minutes: i + 10 }).toJSDate(), stationB, testLineId)
+            await createReportWithTimestamp(
+                historicalMonday.minus({ minutes: i + 10 }).toJSDate(),
+                stationB,
+                testLineId
+            )
         }
 
         // Now query for current Monday at 3pm (should trigger predictions based on historical data)
@@ -437,7 +441,11 @@ describe('Predicted reports threshold', () => {
             for (let dayOffset = 0; dayOffset < 7; dayOffset++) {
                 for (const hour of [7, 9, 12, 15, 18, 21]) {
                     for (let stationIdx = 0; stationIdx < Math.min(testStations.length, 7); stationIdx++) {
-                        const historicalTime = DateTime.utc(2024, 1, 1, hour, 0).minus({ weeks: weeksAgo, days: dayOffset, minutes: stationIdx * 2 })
+                        const historicalTime = DateTime.utc(2024, 1, 1, hour, 0).minus({
+                            weeks: weeksAgo,
+                            days: dayOffset,
+                            minutes: stationIdx * 2,
+                        })
                         await createReportWithTimestamp(historicalTime.toJSDate(), testStations[stationIdx], testLineId)
                     }
                 }

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { eq } from 'drizzle-orm'
 import { DateTime } from 'luxon'
 
-import { db, lines, reports, stations } from '../src/db'
+import { db, lineStations, lines, reports, stations } from '../src/db'
 import { seedBaseData } from '../src/db/seed/seed'
 import app from '../src/index'
 
@@ -10,13 +11,31 @@ import { getDefaultReportsRange, MAX_REPORTS_TIMEFRAME } from '../src/modules/re
 let testStationId: string
 let testLineId: string
 
-const createReport = async (timestamp: Date) => {
+// Note: this function is primarily used for timeframe filtering tests
+// It is better to use the `createReportViaAPI` function for testing business logic and API behavior.
+// Since this function bypasses the API validation and post-processing pipeline, it is not a good fit for testing the API.
+const createReportWithTimestamp = async (timestamp: Date) => {
     await db.insert(reports).values({
         stationId: testStationId,
         lineId: testLineId,
         directionId: testStationId,
         timestamp,
         source: 'telegram',
+    })
+}
+
+const createReportViaAPI = async (stationId: string, lineId: string) => {
+    await app.request('/v0/reports', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            stationId,
+            lineId,
+            directionId: stationId,
+            source: 'telegram',
+        }),
     })
 }
 
@@ -45,9 +64,9 @@ describe('Timeframe filtering', () => {
         const insideTwo = now.minus({ minutes: 10 })
         const outside = now.minus({ hours: 2 })
 
-        await createReport(outside.toJSDate())
-        await createReport(insideOne.toJSDate())
-        await createReport(insideTwo.toJSDate())
+        await createReportWithTimestamp(outside.toJSDate())
+        await createReportWithTimestamp(insideOne.toJSDate())
+        await createReportWithTimestamp(insideTwo.toJSDate())
 
         const from = now.minus({ minutes: 45 }).toISO()
         const to = now.minus({ minutes: 5 }).toISO()
@@ -77,8 +96,8 @@ describe('Timeframe filtering', () => {
         const older = from.minus({ minutes: 10 })
         const inside = from.plus({ minutes: 10 })
 
-        await createReport(older.toJSDate())
-        await createReport(inside.toJSDate())
+        await createReportWithTimestamp(older.toJSDate())
+        await createReportWithTimestamp(inside.toJSDate())
 
         const response = await app.request('/v0/reports')
 
@@ -116,5 +135,151 @@ describe('Timeframe filtering', () => {
         )
 
         expect(response.status).toBe(400)
+    })
+})
+
+describe('Predicted reports', () => {
+    let allStationIds: string[]
+
+    beforeAll(async () => {
+        await seedBaseData(db)
+
+        const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
+        testLineId = line.id
+
+        // Get stations that are actually on this line
+        const stationsOnLine = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, testLineId))
+
+        allStationIds = stationsOnLine.map((s) => s.stationId)
+    })
+
+    beforeEach(async () => {
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        await db.delete(reports)
+    })
+
+    it('ensures predicted reports have unique station IDs and do not overlap with real reports', async () => {
+        const from = DateTime.now().toUTC().minus({ hours: 1 })
+
+        // Create 2 real reports for specific stations (this will trigger predicted reports since threshold is higher)
+        const realStationIds = [allStationIds[0], allStationIds[1]]
+
+        for (const stationId of realStationIds) {
+            await createReportViaAPI(stationId, testLineId)
+        }
+
+        // Set 'to' after creating reports to ensure they're captured
+        const to = DateTime.now().toUTC().plus({ seconds: 5 })
+
+        const response = await app.request(
+            `/v0/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        )
+
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as Array<{
+            stationId: string
+            isPredicted: boolean
+        }>
+
+        const predictedReports = body.filter((r) => r.isPredicted)
+        const nonPredictedReports = body.filter((r) => !r.isPredicted)
+
+        // Test 1: Predicted reports exclude station IDs of non-predicted reports
+        const nonPredictedStationIds = new Set(nonPredictedReports.map((r) => r.stationId))
+        const predictedStationIds = predictedReports.map((r) => r.stationId)
+
+        for (const predictedStationId of predictedStationIds) {
+            expect(nonPredictedStationIds.has(predictedStationId)).toBe(false)
+        }
+
+        // Test 2: Predicted reports have unique station IDs (no duplicates)
+        const uniquePredictedStationIds = new Set(predictedStationIds)
+        expect(uniquePredictedStationIds.size).toBe(predictedStationIds.length)
+    })
+
+    it('allows non-predicted reports to have duplicate station IDs', async () => {
+        const from = DateTime.now().toUTC().minus({ hours: 1 })
+
+        // Create multiple reports for the same station at different times
+        const stationId = allStationIds[0]
+
+        for (let i = 0; i < 3; i++) {
+            await createReportViaAPI(stationId, testLineId)
+        }
+
+        // Set 'to' after creating reports to ensure they're captured
+        const to = DateTime.now().toUTC().plus({ seconds: 5 })
+
+        const response = await app.request(
+            `/v0/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        )
+
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as Array<{
+            stationId: string
+            isPredicted: boolean
+        }>
+
+        const nonPredictedReports = body.filter((r) => !r.isPredicted)
+
+        // Test 3: Non-predicted reports can have duplicate station IDs
+        const nonPredictedStationIds = nonPredictedReports.map((r) => r.stationId)
+        const uniqueNonPredictedStationIds = new Set(nonPredictedStationIds)
+
+        // Should have duplicates (more reports than unique station IDs)
+        expect(nonPredictedStationIds.length).toBeGreaterThan(uniqueNonPredictedStationIds.size)
+        expect(nonPredictedStationIds.filter((id) => id === stationId).length).toBe(3)
+    })
+
+    it('prevents same station from appearing as both predicted and non-predicted', async () => {
+        const from = DateTime.now().toUTC().minus({ hours: 1 })
+
+        // Create a real report for one station
+        const realStationId = allStationIds[0]
+
+        await createReportViaAPI(realStationId, testLineId)
+
+        // Set 'to' after creating reports to ensure they're captured
+        const to = DateTime.now().toUTC().plus({ seconds: 5 })
+
+        const response = await app.request(
+            `/v0/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        )
+
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as Array<{
+            stationId: string
+            isPredicted: boolean
+        }>
+
+        // Group reports by station ID
+        const stationReports = body.reduce(
+            (acc, report) => {
+                if (!acc[report.stationId]) {
+                    acc[report.stationId] = []
+                }
+                acc[report.stationId].push(report)
+                return acc
+            },
+            {} as Record<string, Array<{ stationId: string; isPredicted: boolean }>>
+        )
+
+        // For each station, all reports must be either all predicted or all non-predicted
+        // (no mixing of predicted and non-predicted for the same station)
+        Object.entries(stationReports).forEach(([, reportsForStation]) => {
+            const isPredictedValues = reportsForStation.map((r) => r.isPredicted)
+            const allSame = isPredictedValues.every((val) => val === isPredictedValues[0])
+
+            expect(allSame).toBe(true)
+        })
     })
 })


### PR DESCRIPTION
## Describe the issue:
Sometimes we don't have enough report coverage to inform users. In these cases, we predict where inspectors could be located to display at least some data.

## Explain how you solved the issue:
I reused the existing guessStation function, which we already use to predict the station when a report is submitted without a stationId. We now calculate a threshold—if current reports fall below it, we use guessStation to predict stations within a given timeframe. If no predictions are found, we expand the timeframe iteratively.
I also added extensive tests for this functionality.

## Additional notes or considerations:
We now call them "predicted reports" instead of "historic reports" to reduce confusion about terminology. This breaks the API contract with the mobile and web apps.
