### PR TITLE
fix: improve ludicity in telegram chat group

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -30,7 +30,6 @@
             property="og:description"
             content="Sieh Ticketkontrollen auf der Karte und melde neue Kontrollen in Echtzeit."
         />
-        <meta property="og:image" content="https://app.freifahren.org/logo-with-text.png" />
         <meta
             name="description"
             content="Freifahren ist eine Webapp, die es Nutzern ermöglicht Ticketkontrollen zu melden und sich vor Kontrollen zu warnen."


### PR DESCRIPTION
## Describe the issue:
Fixes #442 Disable link preview for lucidity
`Frequent messages from the Telegram bot make the group chat very crowded. Please consider disabling the link preview to make the messages smaller and enable users to see more messages without scolling.`

## Explain how you solved the issue:
This issue is caused by some `<meta>` tags inside the `index.html` of the frontend package. Altough these tags are helpful displaying previews of shared links inside chats like telegram they tend to make a group chat look chaotic if there are lots of messages on a regular basis. 
To tackle this issue a removed the `<meta property"og:image">` to make the bot messages shorter.

## Additional notes or considerations:
This is just suggestion as I agree with the creator of this issue.