### PR TITLE
refactor: version routes

### DIFF
--- a/packages/hono-backend/src/common/router.ts
+++ b/packages/hono-backend/src/common/router.ts
@@ -73,6 +73,21 @@ export const registerVersionedRoutes = <E extends Env>(
         app.route(`/${version}/${basePath}`, subApp)
     }
 
+    // Return 404 with available versions for unknown version prefixes (e.g. /v99/reports)
+    const availableVersions = Object.keys(versions)
+    const unknownVersion = (c: Context) => {
+        const requestedVersion = c.req.param('version')
+        return c.json(
+            {
+                error: `Version ${requestedVersion} not found for ${basePath}`,
+                availableVersions,
+            },
+            404
+        )
+    }
+    app.all(`/:version{v\\d+}/${basePath}/*`, unknownVersion)
+    app.all(`/:version{v\\d+}/${basePath}`, unknownVersion)
+
     // Redirect unversioned requests to the latest version.
     // 307 preserves the original HTTP method and body
     const redirect = (c: Context) => {

--- a/packages/hono-backend/src/common/router.ts
+++ b/packages/hono-backend/src/common/router.ts
@@ -70,6 +70,7 @@ export const registerVersionedRoutes = <E extends Env>(
         }
 
         registerRoutes(subApp, routes)
+        // We define version in the route so that it is easy to identify and debug potential version mismatches
         app.route(`/${version}/${basePath}`, subApp)
     }
 

--- a/packages/hono-backend/src/common/router.ts
+++ b/packages/hono-backend/src/common/router.ts
@@ -60,6 +60,15 @@ export const registerVersionedRoutes = <E extends Env>(
     // And app.route() prefixes them so they resolve to the full URL (e.g. /v0/transit/stations).
     for (const [version, routes] of Object.entries(versions)) {
         const subApp = new Hono<E>()
+
+        if (version !== latestVersion) {
+            subApp.use('*', async (c, next) => {
+                await next()
+                c.header('Deprecation', 'true')
+                c.header('X-Latest-Api-Version', latestVersion)
+            })
+        }
+
         registerRoutes(subApp, routes)
         app.route(`/${version}/${basePath}`, subApp)
     }

--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -5,7 +5,7 @@ import pino from 'pino'
 
 import { registerServices, Services, type Env } from './app-env'
 import { handleError } from './common/error-handler'
-import { registerRoutes } from './common/router'
+import { registerVersionedRoutes } from './common/router'
 import { db, DbConnection } from './db'
 import { getReports, postReport, ReportsService } from './modules/reports/'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
@@ -55,6 +55,12 @@ const createServices = (db: DbConnection) => {
 
 registerServices(app, createServices(db))
 
-registerRoutes(app, [getReports, postReport, getStations, getLines])
+registerVersionedRoutes(app, 'reports', 'v0', {
+    v0: [getReports, postReport],
+})
+
+registerVersionedRoutes(app, 'transit', 'v0', {
+    v0: [getStations, getLines],
+})
 
 export default app

--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -11,7 +11,7 @@ import { getDefaultReportsRange, MAX_REPORTS_TIMEFRAME } from './constants'
 
 export const getReports = defineRoute<Env>()({
     method: 'get',
-    path: 'v0/reports',
+    path: '/',
     schemas: {
         query: z
             .object({
@@ -51,7 +51,7 @@ export const getReports = defineRoute<Env>()({
 
 export const postReport = defineRoute<Env>()({
     method: 'post',
-    path: 'v0/reports',
+    path: '/',
     schemas: {
         json: insertReportSchema,
     },

--- a/packages/hono-backend/src/modules/transit/transit-routes.ts
+++ b/packages/hono-backend/src/modules/transit/transit-routes.ts
@@ -3,7 +3,7 @@ import { defineRoute } from '../../common/router'
 
 export const getStations = defineRoute<Env>()({
     method: 'get' as const,
-    path: 'v0/transit/stations',
+    path: '/stations',
     handler: async (c) => {
         const transitNetworkDataService = c.get('transitNetworkDataService')
         return c.json(await transitNetworkDataService.getStations())
@@ -12,7 +12,7 @@ export const getStations = defineRoute<Env>()({
 
 export const getLines = defineRoute<Env>()({
     method: 'get' as const,
-    path: 'v0/transit/lines',
+    path: '/lines',
     handler: async (c) => {
         const transitNetworkDataService = c.get('transitNetworkDataService')
         return c.json(await transitNetworkDataService.getLines())

--- a/packages/hono-backend/tests/generalAPI.test.ts
+++ b/packages/hono-backend/tests/generalAPI.test.ts
@@ -35,4 +35,11 @@ describe('Versioning', () => {
         expect(location.searchParams.get('from')).toBe('2024-01-01T00:00:00Z')
         expect(location.searchParams.get('to')).toBe('2024-01-02T00:00:00Z')
     })
+
+    it('does not set deprecation headers on the latest version', async () => {
+        const response = await app.request('/v0/reports')
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Deprecation')).toBeNull()
+        expect(response.headers.get('X-Latest-Api-Version')).toBeNull()
+    })
 })

--- a/packages/hono-backend/tests/generalAPI.test.ts
+++ b/packages/hono-backend/tests/generalAPI.test.ts
@@ -1,0 +1,38 @@
+import { beforeAll, describe, expect, it } from 'bun:test'
+
+import { seedBaseData } from '../src/db/seed/seed'
+import { db } from '../src/db'
+import app from '../src/index'
+
+beforeAll(async () => {
+    await seedBaseData(db)
+})
+
+describe('Versioning', () => {
+    it('serves GET /v0/reports directly', async () => {
+        const response = await app.request('/v0/reports')
+        expect(response.status).toBe(200)
+    })
+
+    it('redirects GET /reports to /v0/reports with 307', async () => {
+        const response = await app.request('/reports')
+        expect(response.status).toBe(307)
+        expect(new URL(response.headers.get('Location')!).pathname).toBe('/v0/reports')
+    })
+
+    it('redirects POST /reports to /v0/reports with 307', async () => {
+        const response = await app.request('/reports', { method: 'POST' })
+        expect(response.status).toBe(307)
+        expect(new URL(response.headers.get('Location')!).pathname).toBe('/v0/reports')
+    })
+
+    it('preserves query params through redirects', async () => {
+        const response = await app.request('/reports?from=2024-01-01T00:00:00Z&to=2024-01-02T00:00:00Z')
+        expect(response.status).toBe(307)
+
+        const location = new URL(response.headers.get('Location')!)
+        expect(location.pathname).toBe('/v0/reports')
+        expect(location.searchParams.get('from')).toBe('2024-01-01T00:00:00Z')
+        expect(location.searchParams.get('to')).toBe('2024-01-02T00:00:00Z')
+    })
+})

--- a/packages/hono-backend/tests/generalAPI.test.ts
+++ b/packages/hono-backend/tests/generalAPI.test.ts
@@ -42,4 +42,13 @@ describe('Versioning', () => {
         expect(response.headers.get('Deprecation')).toBeNull()
         expect(response.headers.get('X-Latest-Api-Version')).toBeNull()
     })
+
+    it('returns 404 with available versions for unknown version', async () => {
+        const response = await app.request('/v99/reports')
+        expect(response.status).toBe(404)
+
+        const body = (await response.json()) as { error: string; availableVersions: string[] }
+        expect(body.error).toBe('Version v99 not found for reports')
+        expect(body.availableVersions).toContain('v0')
+    })
 })

--- a/packages/hono-backend/tests/generalAPI.test.ts
+++ b/packages/hono-backend/tests/generalAPI.test.ts
@@ -51,4 +51,12 @@ describe('Versioning', () => {
         expect(body.error).toBe('Version v99 not found for reports')
         expect(body.availableVersions).toContain('v0')
     })
+
+    it('does not return version error for valid version with unmatched method', async () => {
+        const response = await app.request('/v0/reports', { method: 'PUT' })
+        expect(response.status).toBe(404)
+
+        const body = await response.text()
+        expect(body).not.toContain('availableVersions')
+    })
 })

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -4,10 +4,9 @@ import { DateTime, Settings } from 'luxon'
 
 import { db, lineStations, lines, reports, stations } from '../src/db'
 import { seedBaseData } from '../src/db/seed/seed'
-import app from '../src/index'
 
 import { getDefaultReportsRange, MAX_REPORTS_TIMEFRAME } from '../src/modules/reports/constants'
-import { sendReportRequest } from './test-utils'
+import { appRequest, sendReportRequest } from './test-utils'
 
 let testStationId: string
 let testLineId: string
@@ -61,9 +60,7 @@ describe('Timeframe filtering', () => {
         const from = now.minus({ minutes: 45 }).toISO()
         const to = now.minus({ minutes: 5 }).toISO()
 
-        const response = await app.request(
-            `/v0/reports?from=${encodeURIComponent(from!)}&to=${encodeURIComponent(to!)}`
-        )
+        const response = await appRequest(`/reports?from=${encodeURIComponent(from!)}&to=${encodeURIComponent(to!)}`)
 
         expect(response.status).toBe(200)
 
@@ -89,7 +86,7 @@ describe('Timeframe filtering', () => {
         await createReportWithTimestamp(older.toJSDate())
         await createReportWithTimestamp(inside.toJSDate())
 
-        const response = await app.request('/v0/reports')
+        const response = await appRequest('/reports')
 
         expect(response.status).toBe(200)
 
@@ -108,8 +105,8 @@ describe('Timeframe filtering', () => {
         const from = now
         const to = now.minus({ hours: 1 })
 
-        const response = await app.request(
-            `/v0/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        const response = await appRequest(
+            `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
         )
 
         expect(response.status).toBe(400)
@@ -120,9 +117,7 @@ describe('Timeframe filtering', () => {
         const from = now.minus({ days: MAX_REPORTS_TIMEFRAME + 1 }).toISO()
         const to = now.toISO()
 
-        const response = await app.request(
-            `/v0/reports?from=${encodeURIComponent(from!)}&to=${encodeURIComponent(to!)}`
-        )
+        const response = await appRequest(`/reports?from=${encodeURIComponent(from!)}&to=${encodeURIComponent(to!)}`)
 
         expect(response.status).toBe(400)
     })
@@ -168,8 +163,8 @@ describe('Predicted reports', () => {
         // Set 'to' after creating reports to ensure they're captured
         const to = DateTime.now().toUTC().plus({ seconds: 5 })
 
-        const response = await app.request(
-            `/v0/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        const response = await appRequest(
+            `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
         )
 
         expect(response.status).toBe(200)
@@ -208,8 +203,8 @@ describe('Predicted reports', () => {
         // Set 'to' after creating reports to ensure they're captured
         const to = DateTime.now().toUTC().plus({ seconds: 5 })
 
-        const response = await app.request(
-            `/v0/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        const response = await appRequest(
+            `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
         )
 
         expect(response.status).toBe(200)
@@ -246,8 +241,8 @@ describe('Predicted reports', () => {
         // Set 'to' after creating reports to ensure they're captured
         const to = DateTime.now().toUTC().plus({ seconds: 5 })
 
-        const response = await app.request(
-            `/v0/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        const response = await appRequest(
+            `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
         )
 
         expect(response.status).toBe(200)
@@ -311,8 +306,8 @@ describe('Predicted reports', () => {
         const from = currentMonday.minus({ minutes: 30 })
         const to = currentMonday.plus({ minutes: 30 })
 
-        const response = await app.request(
-            `/v0/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        const response = await appRequest(
+            `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
         )
 
         expect(response.status).toBe(200)
@@ -353,8 +348,8 @@ describe('Predicted reports', () => {
         const from = currentThursday.minus({ minutes: 30 })
         const to = currentThursday.plus({ minutes: 30 })
 
-        const response = await app.request(
-            `/v0/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        const response = await appRequest(
+            `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
         )
 
         expect(response.status).toBe(200)
@@ -427,8 +422,8 @@ describe('Predicted reports threshold', () => {
         const fromPeak = mondayAfternoon.minus({ hours: 1 })
         const toPeak = mondayAfternoon.plus({ hours: 1 })
 
-        const responsePeak = await app.request(
-            `/v0/reports?from=${encodeURIComponent(fromPeak.toISO()!)}&to=${encodeURIComponent(toPeak.toISO()!)}`
+        const responsePeak = await appRequest(
+            `/reports?from=${encodeURIComponent(fromPeak.toISO()!)}&to=${encodeURIComponent(toPeak.toISO()!)}`
         )
 
         expect(responsePeak.status).toBe(200)
@@ -442,8 +437,8 @@ describe('Predicted reports threshold', () => {
         const fromNight = tuesdayNight.minus({ hours: 1 })
         const toNight = tuesdayNight.plus({ hours: 1 })
 
-        const responseNight = await app.request(
-            `/v0/reports?from=${encodeURIComponent(fromNight.toISO()!)}&to=${encodeURIComponent(toNight.toISO()!)}`
+        const responseNight = await appRequest(
+            `/reports?from=${encodeURIComponent(fromNight.toISO()!)}&to=${encodeURIComponent(toNight.toISO()!)}`
         )
 
         expect(responseNight.status).toBe(200)
@@ -469,8 +464,8 @@ describe('Predicted reports threshold', () => {
             const from = time.minus({ hours: 1 })
             const to = time.plus({ hours: 1 })
 
-            const response = await app.request(
-                `/v0/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+            const response = await appRequest(
+                `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
             )
 
             expect(response.status).toBe(200)
@@ -491,8 +486,8 @@ describe('Predicted reports threshold', () => {
         const from7 = morning7.minus({ hours: 1 })
         const to7 = morning7.plus({ hours: 1 })
 
-        const response7 = await app.request(
-            `/v0/reports?from=${encodeURIComponent(from7.toISO()!)}&to=${encodeURIComponent(to7.toISO()!)}`
+        const response7 = await appRequest(
+            `/reports?from=${encodeURIComponent(from7.toISO()!)}&to=${encodeURIComponent(to7.toISO()!)}`
         )
 
         const body7 = (await response7.json()) as Array<{ isPredicted: boolean }>
@@ -505,8 +500,8 @@ describe('Predicted reports threshold', () => {
         const fromNoon = noon.minus({ hours: 1 })
         const toNoon = noon.plus({ hours: 1 })
 
-        const responseNoon = await app.request(
-            `/v0/reports?from=${encodeURIComponent(fromNoon.toISO()!)}&to=${encodeURIComponent(toNoon.toISO()!)}`
+        const responseNoon = await appRequest(
+            `/reports?from=${encodeURIComponent(fromNoon.toISO()!)}&to=${encodeURIComponent(toNoon.toISO()!)}`
         )
 
         const bodyNoon = (await responseNoon.json()) as Array<{ isPredicted: boolean }>
@@ -527,8 +522,8 @@ describe('Predicted reports threshold', () => {
         const fromLate = weekdayLateEvening.minus({ hours: 1 })
         const toLate = weekdayLateEvening.plus({ hours: 1 })
 
-        const responseLate = await app.request(
-            `/v0/reports?from=${encodeURIComponent(fromLate.toISO()!)}&to=${encodeURIComponent(toLate.toISO()!)}`
+        const responseLate = await appRequest(
+            `/reports?from=${encodeURIComponent(fromLate.toISO()!)}&to=${encodeURIComponent(toLate.toISO()!)}`
         )
 
         expect(responseLate.status).toBe(200)
@@ -542,8 +537,8 @@ describe('Predicted reports threshold', () => {
         const fromNight = weekdayNight.minus({ hours: 1 })
         const toNight = weekdayNight.plus({ hours: 1 })
 
-        const responseNight = await app.request(
-            `/v0/reports?from=${encodeURIComponent(fromNight.toISO()!)}&to=${encodeURIComponent(toNight.toISO()!)}`
+        const responseNight = await appRequest(
+            `/reports?from=${encodeURIComponent(fromNight.toISO()!)}&to=${encodeURIComponent(toNight.toISO()!)}`
         )
 
         expect(responseNight.status).toBe(200)
@@ -564,8 +559,8 @@ describe('Predicted reports threshold', () => {
         const from = mondayNoon.minus({ hours: 1 })
         const to = mondayNoon.plus({ hours: 1 })
 
-        const response = await app.request(
-            `/v0/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        const response = await appRequest(
+            `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
         )
 
         expect(response.status).toBe(200)

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -6,9 +6,8 @@ import { TransitNetworkDataService } from '../src/modules/transit/transit-networ
 import { db, lineStations, reports, stations } from '../src/db'
 import { seedBaseData } from '../src/db/seed/seed'
 import { and, desc, eq } from 'drizzle-orm'
-import { sendReportRequest } from './test-utils'
+import { appRequest, sendReportRequest } from './test-utils'
 
-let app: (typeof import('../src/index'))['default']
 let fakeNlpServer: ReturnType<typeof Bun.serve> | null = null
 let fakeSecurityServer: ReturnType<typeof Bun.serve> | null = null
 
@@ -60,9 +59,6 @@ describe('Telegram notification', () => {
         process.env.SECURITY_MICROSERVICE_URL = `http://127.0.0.1:${fakeSecurityServer.port}`
         process.env.REPORT_PASSWORD = 'test-password'
         process.env.NODE_ENV = 'production'
-
-        const mod = await import('../src/index')
-        app = mod.default
     })
 
     afterAll(() => {
@@ -133,7 +129,7 @@ describe('Security Verification', () => {
         const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
         securityValidResponse = false // Even if security would have blocked it
 
-        const response = await app.request('/v0/reports', {
+        const response = await appRequest('/reports', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -152,9 +148,6 @@ describe('Security Verification', () => {
 describe('Report API contract', () => {
     beforeAll(async () => {
         await seedBaseData(db)
-        const mod = await import('../src/index')
-        app = mod.default
-
         process.env.NODE_ENV = 'production'
         process.env.REPORT_PASSWORD = 'test-password' // To pass the security check
     })

--- a/packages/hono-backend/tests/test-utils.ts
+++ b/packages/hono-backend/tests/test-utils.ts
@@ -1,7 +1,19 @@
 import app from '../src/index'
 
+export const appRequest = async (path: string, init?: RequestInit) => {
+    const response = await app.request(path, init)
+    if (response.status === 307) {
+        const location = response.headers.get('Location')
+        if (location) {
+            const url = new URL(location)
+            return app.request(url.pathname + url.search, init)
+        }
+    }
+    return response
+}
+
 export const sendReportRequest = async (payload: object) => {
-    return app.request('/v0/reports', {
+    return appRequest('/reports', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Describe the issue:
We need to version routes to maintain backward compatibility with the mobile app. Previously we only had a single route and poorly done versioning.

## Explain how you solved the issue:
When a user requests a route without a version specified e.g. `GET /reports` we are now returning a `307` which tells the client to redirect to the latest version. When a user requests an outdated version we set a deprecation header to notify them that they are using a deprecated version and when they request an unknown version we return a `404` with some helpful info about which versions are available. 

## Additional notes or considerations:
- Each group of endpoints has its own version, this means that the transit routes can be on v0 while the reports route is on v1. This will make it easier to iterate, otherwise we would have to deprecate the entire API if we update the contract of a single Endpoint.
- Versions are specified in the route, we could also specify this in the header, but I prefer to have it in the route, this makes it explicit and harder to get stuck on issues that are caused by a version mismatch 
