### PR TITLE
feat: post users feedback

### DIFF
--- a/packages/hono-backend/drizzle/0001_tearful_slayback.sql
+++ b/packages/hono-backend/drizzle/0001_tearful_slayback.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "feedback" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"feedback" text NOT NULL,
+	"user_agent" varchar(512),
+	"timestamp" timestamp DEFAULT now() NOT NULL
+);

--- a/packages/hono-backend/drizzle/meta/0001_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0001_snapshot.json
@@ -1,294 +1,266 @@
 {
-  "id": "15295229-7ecd-4e98-891c-8f630e47de7c",
-  "prevId": "16f44466-7915-4d16-881c-b5f8b3661843",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.feedback": {
-      "name": "feedback",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
+    "id": "15295229-7ecd-4e98-891c-8f630e47de7c",
+    "prevId": "16f44466-7915-4d16-881c-b5f8b3661843",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.feedback": {
+            "name": "feedback",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "feedback": {
+                    "name": "feedback",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_agent": {
+                    "name": "user_agent",
+                    "type": "varchar(512)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "timestamp": {
+                    "name": "timestamp",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "feedback": {
-          "name": "feedback",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
+        "public.line_stations": {
+            "name": "line_stations",
+            "schema": "",
+            "columns": {
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "order": {
+                    "name": "order",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "line_stations_line_id_lines_id_fk": {
+                    "name": "line_stations_line_id_lines_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "line_stations_station_id_stations_id_fk": {
+                    "name": "line_stations_station_id_stations_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "line_stations_line_id_station_id_pk": {
+                    "name": "line_stations_line_id_station_id_pk",
+                    "columns": ["line_id", "station_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "varchar(512)",
-          "primaryKey": false,
-          "notNull": false
+        "public.lines": {
+            "name": "lines",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "is_circular": {
+                    "name": "is_circular",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
+        "public.reports": {
+            "name": "reports",
+            "schema": "",
+            "columns": {
+                "report_id": {
+                    "name": "report_id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "direction_id": {
+                    "name": "direction_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "timestamp": {
+                    "name": "timestamp",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "source": {
+                    "name": "source",
+                    "type": "source",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "reports_station_id_stations_id_fk": {
+                    "name": "reports_station_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_line_id_lines_id_fk": {
+                    "name": "reports_line_id_lines_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_direction_id_stations_id_fk": {
+                    "name": "reports_direction_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["direction_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.stations": {
+            "name": "stations",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lat": {
+                    "name": "lat",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lng": {
+                    "name": "lng",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     },
-    "public.line_stations": {
-      "name": "line_stations",
-      "schema": "",
-      "columns": {
-        "line_id": {
-          "name": "line_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "station_id": {
-          "name": "station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "order": {
-          "name": "order",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
+    "enums": {
+        "public.source": {
+            "name": "source",
+            "schema": "public",
+            "values": ["mini_app", "web_app", "mobile_app", "telegram"]
         }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "line_stations_line_id_lines_id_fk": {
-          "name": "line_stations_line_id_lines_id_fk",
-          "tableFrom": "line_stations",
-          "tableTo": "lines",
-          "columnsFrom": [
-            "line_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "line_stations_station_id_stations_id_fk": {
-          "name": "line_stations_station_id_stations_id_fk",
-          "tableFrom": "line_stations",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "line_stations_line_id_station_id_pk": {
-          "name": "line_stations_line_id_station_id_pk",
-          "columns": [
-            "line_id",
-            "station_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     },
-    "public.lines": {
-      "name": "lines",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(16)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "is_circular": {
-          "name": "is_circular",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.reports": {
-      "name": "reports",
-      "schema": "",
-      "columns": {
-        "report_id": {
-          "name": "report_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "station_id": {
-          "name": "station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "line_id": {
-          "name": "line_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "direction_id": {
-          "name": "direction_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "source": {
-          "name": "source",
-          "type": "source",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "reports_station_id_stations_id_fk": {
-          "name": "reports_station_id_stations_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "reports_line_id_lines_id_fk": {
-          "name": "reports_line_id_lines_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "lines",
-          "columnsFrom": [
-            "line_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "reports_direction_id_stations_id_fk": {
-          "name": "reports_direction_id_stations_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "direction_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.stations": {
-      "name": "stations",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(16)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lat": {
-          "name": "lat",
-          "type": "double precision",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lng": {
-          "name": "lng",
-          "type": "double precision",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {
-    "public.source": {
-      "name": "source",
-      "schema": "public",
-      "values": [
-        "mini_app",
-        "web_app",
-        "mobile_app",
-        "telegram"
-      ]
-    }
-  },
-  "schemas": {},
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
     "schemas": {},
-    "tables": {}
-  }
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
 }

--- a/packages/hono-backend/drizzle/meta/0001_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,294 @@
+{
+  "id": "15295229-7ecd-4e98-891c-8f630e47de7c",
+  "prevId": "16f44466-7915-4d16-881c-b5f8b3661843",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_stations": {
+      "name": "line_stations",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_stations_line_id_lines_id_fk": {
+          "name": "line_stations_line_id_lines_id_fk",
+          "tableFrom": "line_stations",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "line_stations_station_id_stations_id_fk": {
+          "name": "line_stations_station_id_stations_id_fk",
+          "tableFrom": "line_stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_stations_line_id_station_id_pk": {
+          "name": "line_stations_line_id_station_id_pk",
+          "columns": [
+            "line_id",
+            "station_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lines": {
+      "name": "lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_circular": {
+          "name": "is_circular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "report_id": {
+          "name": "report_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction_id": {
+          "name": "direction_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_station_id_stations_id_fk": {
+          "name": "reports_station_id_stations_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_line_id_lines_id_fk": {
+          "name": "reports_line_id_lines_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_direction_id_stations_id_fk": {
+          "name": "reports_direction_id_stations_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "direction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.source": {
+      "name": "source",
+      "schema": "public",
+      "values": [
+        "mini_app",
+        "web_app",
+        "mobile_app",
+        "telegram"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/hono-backend/drizzle/meta/_journal.json
+++ b/packages/hono-backend/drizzle/meta/_journal.json
@@ -1,20 +1,20 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1765472567170,
-      "tag": "0000_modern_runaways",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1770824145557,
-      "tag": "0001_tearful_slayback",
-      "breakpoints": true
-    }
-  ]
+    "version": "7",
+    "dialect": "postgresql",
+    "entries": [
+        {
+            "idx": 0,
+            "version": "7",
+            "when": 1765472567170,
+            "tag": "0000_modern_runaways",
+            "breakpoints": true
+        },
+        {
+            "idx": 1,
+            "version": "7",
+            "when": 1770824145557,
+            "tag": "0001_tearful_slayback",
+            "breakpoints": true
+        }
+    ]
 }

--- a/packages/hono-backend/drizzle/meta/_journal.json
+++ b/packages/hono-backend/drizzle/meta/_journal.json
@@ -1,13 +1,20 @@
 {
-    "version": "7",
-    "dialect": "postgresql",
-    "entries": [
-        {
-            "idx": 0,
-            "version": "7",
-            "when": 1765472567170,
-            "tag": "0000_modern_runaways",
-            "breakpoints": true
-        }
-    ]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1765472567170,
+      "tag": "0000_modern_runaways",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1770824145557,
+      "tag": "0001_tearful_slayback",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/hono-backend/src/db/index.ts
+++ b/packages/hono-backend/src/db/index.ts
@@ -1,6 +1,7 @@
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 
+import { feedback } from './schema/feedback'
 import { lines, lineStations } from './schema/lines'
 import { reports } from './schema/reports'
 import { stations } from './schema/stations'
@@ -9,12 +10,13 @@ const connectionString = process.env.DATABASE_URL!
 
 export const client = postgres(connectionString, { prepare: false })
 export const db = drizzle(client, {
-    schema: { reports, stations, lines, lineStations },
+    schema: { reports, stations, lines, lineStations, feedback },
     casing: 'snake_case',
 })
 
 export type DbConnection = typeof db
 
+export * from './schema/feedback'
 export * from './schema/reports'
 export * from './schema/lines'
 export * from './schema/stations'

--- a/packages/hono-backend/src/db/schema/feedback.ts
+++ b/packages/hono-backend/src/db/schema/feedback.ts
@@ -1,0 +1,13 @@
+import { pgTable, serial, text, timestamp, varchar } from 'drizzle-orm/pg-core'
+import { createInsertSchema } from 'drizzle-zod'
+
+export const feedback = pgTable('feedback', {
+    id: serial().primaryKey(),
+    feedback: text().notNull(),
+    userAgent: varchar({ length: 512 }),
+    timestamp: timestamp().notNull().defaultNow(),
+})
+
+export const insertFeedbackSchema = createInsertSchema(feedback).pick({
+    feedback: true,
+})

--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -7,6 +7,7 @@ import { registerServices, Services, type Env } from './app-env'
 import { handleError } from './common/error-handler'
 import { registerRoutes } from './common/router'
 import { db, DbConnection } from './db'
+import { postFeedback } from './modules/feedback/feedback-routes'
 import { getReports, postReport, ReportsService } from './modules/reports/'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
 import { getLines, getStations } from './modules/transit/transit-routes'
@@ -55,6 +56,6 @@ const createServices = (db: DbConnection) => {
 
 registerServices(app, createServices(db))
 
-registerRoutes(app, [getReports, postReport, getStations, getLines])
+registerRoutes(app, [getReports, postReport, getStations, getLines, postFeedback])
 
 export default app

--- a/packages/hono-backend/src/modules/feedback/feedback-routes.ts
+++ b/packages/hono-backend/src/modules/feedback/feedback-routes.ts
@@ -12,8 +12,8 @@ export const postFeedback = defineRoute<Env>()({
         const { feedback: feedbackText } = c.req.valid('json')
         const userAgent = c.req.header('user-agent') ?? null
 
-        const [inserted] = await db.insert(feedback).values({ feedback: feedbackText, userAgent }).returning()
+        await db.insert(feedback).values({ feedback: feedbackText, userAgent })
 
-        return c.json(inserted, 201)
+        return c.body(null, 201)
     },
 })

--- a/packages/hono-backend/src/modules/feedback/feedback-routes.ts
+++ b/packages/hono-backend/src/modules/feedback/feedback-routes.ts
@@ -1,0 +1,19 @@
+import { Env } from '../../app-env'
+import { defineRoute } from '../../common/router'
+import { db, feedback, insertFeedbackSchema } from '../../db'
+
+export const postFeedback = defineRoute<Env>()({
+    method: 'post',
+    path: 'v0/feedback',
+    schemas: {
+        json: insertFeedbackSchema,
+    },
+    handler: async (c) => {
+        const { feedback: feedbackText } = c.req.valid('json')
+        const userAgent = c.req.header('user-agent') ?? null
+
+        const [inserted] = await db.insert(feedback).values({ feedback: feedbackText, userAgent }).returning()
+
+        return c.json(inserted, 201)
+    },
+})

--- a/packages/hono-backend/tests/postFeedback.test.ts
+++ b/packages/hono-backend/tests/postFeedback.test.ts
@@ -1,0 +1,83 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+
+import { db, feedback } from '../src/db'
+
+let app: (typeof import('../src/index'))['default']
+
+const sendFeedbackRequest = (payload: object, headers?: Record<string, string>) => {
+    return app.request('/v0/feedback', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            ...headers,
+        },
+        body: JSON.stringify(payload),
+    })
+}
+
+describe('Feedback endpoint', () => {
+    beforeAll(async () => {
+        const mod = await import('../src/index')
+        app = mod.default
+    })
+
+    beforeEach(async () => {
+        await db.delete(feedback)
+    })
+
+    it('creates feedback and returns 201', async () => {
+        const response = await sendFeedbackRequest({ feedback: 'Great app!' })
+
+        expect(response.status).toBe(201)
+
+        const body = (await response.json()) as {
+            id: number
+            feedback: string
+            userAgent: string | null
+            timestamp: string
+        }
+
+        expect(body.feedback).toBe('Great app!')
+        expect(typeof body.id).toBe('number')
+        expect(body.timestamp).toBeTruthy()
+    })
+
+    it('stores the user agent from the request', async () => {
+        const response = await sendFeedbackRequest({ feedback: 'Test feedback' }, { 'User-Agent': 'TestAgent/1.0' })
+
+        expect(response.status).toBe(201)
+
+        const body = (await response.json()) as { id: number; userAgent: string | null }
+
+        expect(body.userAgent).toBe('TestAgent/1.0')
+    })
+
+    it('stores null user agent when header is missing', async () => {
+        const response = await app.request('/v0/feedback', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ feedback: 'No UA' }),
+        })
+
+        expect(response.status).toBe(201)
+
+        const body = (await response.json()) as { userAgent: string | null }
+
+        expect(body.userAgent).toBeNull()
+    })
+
+    it('persists feedback in the database', async () => {
+        await sendFeedbackRequest({ feedback: 'Persisted feedback' })
+
+        const rows = await db.select().from(feedback)
+
+        expect(rows.length).toBe(1)
+        expect(rows[0].feedback).toBe('Persisted feedback')
+    })
+
+    it('rejects request with missing feedback field', async () => {
+        const response = await sendFeedbackRequest({})
+
+        expect(response.status).toBe(400)
+    })
+})


### PR DESCRIPTION
## Describe the issue:
We need a way to accept users feedback that is coming from the web app.

## Explain how you solved the issue:
I added a new `/feedback` endpoint which accepts a `POST` request with a `feedback: {...}` body. It returns a `201` when successful. 
We store: feedback, timestamp and user agent.

## Additional notes or considerations:
I added a new migration for the new table. For the other new tables we just modified the default migration for now. For this I felt like a migration is appropriate, let me know if I should include it in the default one.
