### PR TITLE
style: suppress logs tests

### DIFF
--- a/packages/hono-backend/bunfig.toml
+++ b/packages/hono-backend/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/preload.ts"]

--- a/packages/hono-backend/compose-hono.test.yaml
+++ b/packages/hono-backend/compose-hono.test.yaml
@@ -31,6 +31,7 @@ services:
             - '80:3000'
         volumes:
             - ./src:/app/src:ro
+            - ./bunfig.toml:/app/bunfig.toml:ro
             - ./tests:/app/tests:ro
             - ./drizzle.config.ts:/app/drizzle.config.ts:ro
             - ./drizzle:/app/drizzle

--- a/packages/hono-backend/tests/preload.ts
+++ b/packages/hono-backend/tests/preload.ts
@@ -1,0 +1,3 @@
+// We suppress logging in tests to avoid cluttering the output.
+// But to debug a test failure, you can run `TEST_LOG_LEVEL=info bun test` to enable logging.
+process.env.LOG_LEVEL = process.env.TEST_LOG_LEVEL ?? 'error'


### PR DESCRIPTION
I was getting annoyed, since the test output would be spammed with all of the logs that are coming from successful HTTP requests.

Instead we are now suppressing the INFO logs and giving the user the option to enable it again when running the tests
