### PR TITLE
feat: `GET /reports/:stationId`

### DIFF
--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -7,7 +7,7 @@ import { registerServices, Services, type Env } from './app-env'
 import { handleError } from './common/error-handler'
 import { registerRoutes } from './common/router'
 import { db, DbConnection } from './db'
-import { getReports, postReport, ReportsService } from './modules/reports/'
+import { getReports, getReportsByStation, postReport, ReportsService } from './modules/reports/'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
 import { getLines, getStations } from './modules/transit/transit-routes'
 
@@ -55,6 +55,6 @@ const createServices = (db: DbConnection) => {
 
 registerServices(app, createServices(db))
 
-registerRoutes(app, [getReports, postReport, getStations, getLines])
+registerRoutes(app, [getReports, getReportsByStation, postReport, getStations, getLines])
 
 export default app

--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -11,17 +11,18 @@ import { getDefaultReportsRange, MAX_REPORTS_TIMEFRAME } from './constants'
 
 const reportsQuerySchema = z
     .object({
-        from: z.iso.datetime().transform((str) => DateTime.fromISO(str)),
-        to: z.iso.datetime().transform((str) => DateTime.fromISO(str)),
+        from: z.iso
+            .datetime()
+            .transform((str) => DateTime.fromISO(str))
+            .optional(),
+        to: z.iso
+            .datetime()
+            .transform((str) => DateTime.fromISO(str))
+            .optional(),
     })
-    .or(
-        z.object({
-            from: z.undefined(),
-            to: z.undefined(),
-        })
-    )
     .refine(({ to, from }) => {
-        if (isNil(to) || isNil(from)) return true
+        if (isNil(to) && isNil(from)) return true
+        if (isNil(to) || isNil(from)) return false
 
         if (!from.isValid || !to.isValid) return false
 
@@ -29,21 +30,16 @@ const reportsQuerySchema = z
 
         return range.toMillis() > 0 && range.as('days') <= MAX_REPORTS_TIMEFRAME
     })
+    .transform((query) => {
+        if (!isNil(query.from) && !isNil(query.to)) {
+            return {
+                from: query.from,
+                to: query.to,
+            }
+        }
 
-const getReportRange = (
-    query: {
-        from?: DateTime
-        to?: DateTime
-    },
-    now = DateTime.now()
-) => {
-    const defaultRange = getDefaultReportsRange(now)
-
-    return {
-        from: query.from ?? defaultRange.from,
-        to: query.to ?? defaultRange.to,
-    }
-}
+        return getDefaultReportsRange(DateTime.now())
+    })
 
 export const getReports = defineRoute<Env>()({
     method: 'get',
@@ -55,9 +51,10 @@ export const getReports = defineRoute<Env>()({
         const reportsService = c.get('reportsService')
 
         const query = c.req.valid('query')
-        const range = getReportRange(query)
 
-        return c.json(await reportsService.getReports({ ...range, currentTime: DateTime.now() })) // Intentionally pass in local time
+        return c.json(
+            await reportsService.getReports({ from: query.from!, to: query.to!, currentTime: DateTime.now() })
+        ) // Intentionally pass in local time
     },
 })
 
@@ -75,9 +72,15 @@ export const getReportsByStation = defineRoute<Env>()({
 
         const query = c.req.valid('query')
         const { stationId } = c.req.valid('param')
-        const range = getReportRange(query)
 
-        return c.json(await reportsService.getReports({ ...range, stationId, currentTime: DateTime.now() })) // Intentionally pass in local time
+        return c.json(
+            await reportsService.getReports({
+                from: query.from!,
+                to: query.to!,
+                stationId,
+                currentTime: DateTime.now(),
+            })
+        ) // Intentionally pass in local time
     },
 })
 

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -127,10 +127,12 @@ export class ReportsService {
     async getReports({
         from,
         to,
+        stationId,
         currentTime,
     }: {
         from: DateTime
         to: DateTime
+        stationId?: StationId
         currentTime: DateTime
     }): Promise<ReportSummary[]> {
         const dbResults = await this.db
@@ -141,7 +143,13 @@ export class ReportsService {
                 lineId: reports.lineId,
             })
             .from(reports)
-            .where(and(gte(reports.timestamp, from.toJSDate()), lte(reports.timestamp, to.toJSDate())))
+            .where(
+                and(
+                    gte(reports.timestamp, from.toJSDate()),
+                    lte(reports.timestamp, to.toJSDate()),
+                    stationId !== undefined ? eq(reports.stationId, stationId) : undefined
+                )
+            )
 
         const result: ReportSummary[] = dbResults.map((r) => ({ ...r, isPredicted: false }))
 

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -634,6 +634,7 @@ describe('Reports by station route', () => {
 
     afterEach(async () => {
         await db.delete(reports)
+        Settings.now = () => Date.now()
     })
 
     it('returns only reports for the requested station in the given timeframe', async () => {
@@ -655,5 +656,42 @@ describe('Reports by station route', () => {
 
         expect(body.length).toBe(2)
         expect(body.every((report) => report.stationId === stationOneId)).toBe(true)
+    })
+
+    it('fills up with predicted reports when there are not enough real reports for the requested station', async () => {
+        // Mock time to peak hours so the threshold is high (7 reports)
+        const mondayNoon = DateTime.utc(2024, 1, 15, 12, 0)
+        Settings.now = () => mondayNoon.toMillis()
+
+        // Seed historical data for stationOneId at matching time patterns (Monday noon, past weeks)
+        // so the prediction algorithm guesses stationOneId for the query timeframe
+        for (let weeksAgo = 1; weeksAgo <= 2; weeksAgo++) {
+            const historicalTime = mondayNoon.minus({ weeks: weeksAgo })
+            await createReportWithTimestamp(historicalTime.toJSDate(), stationOneId, lineId)
+            await createReportWithTimestamp(historicalTime.minus({ minutes: 5 }).toJSDate(), stationOneId, lineId)
+            await createReportWithTimestamp(historicalTime.minus({ minutes: 10 }).toJSDate(), stationOneId, lineId)
+        }
+
+        // No real reports for stationOneId exist in the query timeframe
+        const from = mondayNoon.minus({ hours: 1 })
+        const to = mondayNoon.plus({ hours: 1 })
+
+        const response = await app.request(
+            `/v0/reports/${stationOneId}?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        )
+
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as Array<{
+            stationId: string
+            isPredicted: boolean
+        }>
+
+        // The response should contain predicted reports to fill up toward the threshold
+        const predictedReports = body.filter((r) => r.isPredicted)
+        expect(predictedReports.length).toBeGreaterThan(0)
+
+        // All predicted reports must be for the requested station
+        expect(predictedReports.every((r) => r.stationId === stationOneId)).toBe(true)
     })
 })


### PR DESCRIPTION
## Describe the issue:
When a user clicks on a station they will see all of the reports for this station. In order to show them efficiently we need an endpoint that can return them filtered for a station. 

## Explain how you solved the issue:
Added a `GET /reports/:stationId` endpoint which returns only stations for this endpoint. 

