### PR TITLE
feat: `/v0/transit/segments` endpoint

### DIFF
--- a/packages/hono-backend/README.md
+++ b/packages/hono-backend/README.md
@@ -1,5 +1,15 @@
 # New Freifahren backend using Hono + Drizzle
 
+## .env
+
+The .env file contains the following variables:
+
+- `DATABASE_URL`: The URL of the database to use.
+- `DATABASE_URL_TEST`: The URL of the test database to use.
+- `NLP_SERVICE_URL`: The URL of the NLP service to use.
+- `REPORT_PASSWORD`: The password to use for the report API.
+- `SECURITY_MICROSERVICE_URL`: The URL of the security microservice to use.
+
 ## Start containers
 
 You can start the DB and bun container like so:

--- a/packages/hono-backend/drizzle/0000_modern_runaways.sql
+++ b/packages/hono-backend/drizzle/0000_modern_runaways.sql
@@ -45,4 +45,5 @@ CREATE TABLE "segments" (
 --> statement-breakpoint
 ALTER TABLE "segments" ADD CONSTRAINT "segments_line_id_lines_id_fk" FOREIGN KEY ("line_id") REFERENCES "public"."lines"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "segments" ADD CONSTRAINT "segments_from_station_id_stations_id_fk" FOREIGN KEY ("from_station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "segments" ADD CONSTRAINT "segments_to_station_id_stations_id_fk" FOREIGN KEY ("to_station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "segments" ADD CONSTRAINT "segments_to_station_id_stations_id_fk" FOREIGN KEY ("to_station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "segments_line_from_to_idx" ON "segments" USING btree ("line_id","from_station_id","to_station_id");

--- a/packages/hono-backend/drizzle/0000_modern_runaways.sql
+++ b/packages/hono-backend/drizzle/0000_modern_runaways.sql
@@ -33,3 +33,16 @@ ALTER TABLE "line_stations" ADD CONSTRAINT "line_stations_station_id_stations_id
 ALTER TABLE "reports" ADD CONSTRAINT "reports_station_id_stations_id_fk" FOREIGN KEY ("station_id") REFERENCES "public"."stations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "reports" ADD CONSTRAINT "reports_line_id_lines_id_fk" FOREIGN KEY ("line_id") REFERENCES "public"."lines"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "reports" ADD CONSTRAINT "reports_direction_id_stations_id_fk" FOREIGN KEY ("direction_id") REFERENCES "public"."stations"("id") ON DELETE no action ON UPDATE no action;
+
+CREATE TABLE "segments" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"line_id" varchar(16) NOT NULL,
+	"from_station_id" varchar(16) NOT NULL,
+	"to_station_id" varchar(16) NOT NULL,
+	"color" varchar(7) NOT NULL,
+	"coordinates" jsonb NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "segments" ADD CONSTRAINT "segments_line_id_lines_id_fk" FOREIGN KEY ("line_id") REFERENCES "public"."lines"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "segments" ADD CONSTRAINT "segments_from_station_id_stations_id_fk" FOREIGN KEY ("from_station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "segments" ADD CONSTRAINT "segments_to_station_id_stations_id_fk" FOREIGN KEY ("to_station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/hono-backend/drizzle/meta/0000_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0000_snapshot.json
@@ -1,219 +1,336 @@
 {
-    "id": "16f44466-7915-4d16-881c-b5f8b3661843",
-    "prevId": "00000000-0000-0000-0000-000000000000",
+    "id": "565c8c91-131e-4a5d-8082-770a5a594eda",
+    "prevId": "16f44466-7915-4d16-881c-b5f8b3661843",
     "version": "7",
     "dialect": "postgresql",
     "tables": {
-        "public.line_stations": {
-            "name": "line_stations",
-            "schema": "",
-            "columns": {
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "station_id": {
-                    "name": "station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "order": {
-                    "name": "order",
-                    "type": "integer",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "line_stations_line_id_lines_id_fk": {
-                    "name": "line_stations_line_id_lines_id_fk",
-                    "tableFrom": "line_stations",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                },
-                "line_stations_station_id_stations_id_fk": {
-                    "name": "line_stations_station_id_stations_id_fk",
-                    "tableFrom": "line_stations",
-                    "tableTo": "stations",
-                    "columnsFrom": ["station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {
-                "line_stations_line_id_station_id_pk": {
-                    "name": "line_stations_line_id_station_id_pk",
-                    "columns": ["line_id", "station_id"]
-                }
-            },
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+      "public.line_stations": {
+        "name": "line_stations",
+        "schema": "",
+        "columns": {
+          "line_id": {
+            "name": "line_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "station_id": {
+            "name": "station_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "order": {
+            "name": "order",
+            "type": "integer",
+            "primaryKey": false,
+            "notNull": true
+          }
         },
-        "public.lines": {
-            "name": "lines",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "varchar(16)",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "name": {
-                    "name": "name",
-                    "type": "varchar(255)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "is_circular": {
-                    "name": "is_circular",
-                    "type": "boolean",
-                    "primaryKey": false,
-                    "notNull": true,
-                    "default": false
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {},
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+        "indexes": {},
+        "foreignKeys": {
+          "line_stations_line_id_lines_id_fk": {
+            "name": "line_stations_line_id_lines_id_fk",
+            "tableFrom": "line_stations",
+            "tableTo": "lines",
+            "columnsFrom": [
+              "line_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "cascade",
+            "onUpdate": "no action"
+          },
+          "line_stations_station_id_stations_id_fk": {
+            "name": "line_stations_station_id_stations_id_fk",
+            "tableFrom": "line_stations",
+            "tableTo": "stations",
+            "columnsFrom": [
+              "station_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "cascade",
+            "onUpdate": "no action"
+          }
         },
-        "public.reports": {
-            "name": "reports",
-            "schema": "",
-            "columns": {
-                "report_id": {
-                    "name": "report_id",
-                    "type": "serial",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "station_id": {
-                    "name": "station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": false
-                },
-                "direction_id": {
-                    "name": "direction_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": false
-                },
-                "timestamp": {
-                    "name": "timestamp",
-                    "type": "timestamp",
-                    "primaryKey": false,
-                    "notNull": true,
-                    "default": "now()"
-                },
-                "source": {
-                    "name": "source",
-                    "type": "source",
-                    "typeSchema": "public",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "reports_station_id_stations_id_fk": {
-                    "name": "reports_station_id_stations_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "stations",
-                    "columnsFrom": ["station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                },
-                "reports_line_id_lines_id_fk": {
-                    "name": "reports_line_id_lines_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                },
-                "reports_direction_id_stations_id_fk": {
-                    "name": "reports_direction_id_stations_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "stations",
-                    "columnsFrom": ["direction_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+        "compositePrimaryKeys": {
+          "line_stations_line_id_station_id_pk": {
+            "name": "line_stations_line_id_station_id_pk",
+            "columns": [
+              "line_id",
+              "station_id"
+            ]
+          }
         },
-        "public.stations": {
-            "name": "stations",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "varchar(16)",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "name": {
-                    "name": "name",
-                    "type": "varchar(255)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "lat": {
-                    "name": "lat",
-                    "type": "double precision",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "lng": {
-                    "name": "lng",
-                    "type": "double precision",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {},
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
-        }
+        "uniqueConstraints": {},
+        "policies": {},
+        "checkConstraints": {},
+        "isRLSEnabled": false
+      },
+      "public.lines": {
+        "name": "lines",
+        "schema": "",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "varchar(16)",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "name": {
+            "name": "name",
+            "type": "varchar(255)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "is_circular": {
+            "name": "is_circular",
+            "type": "boolean",
+            "primaryKey": false,
+            "notNull": true,
+            "default": false
+          }
+        },
+        "indexes": {},
+        "foreignKeys": {},
+        "compositePrimaryKeys": {},
+        "uniqueConstraints": {},
+        "policies": {},
+        "checkConstraints": {},
+        "isRLSEnabled": false
+      },
+      "public.reports": {
+        "name": "reports",
+        "schema": "",
+        "columns": {
+          "report_id": {
+            "name": "report_id",
+            "type": "serial",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "station_id": {
+            "name": "station_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "line_id": {
+            "name": "line_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": false
+          },
+          "direction_id": {
+            "name": "direction_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": false
+          },
+          "timestamp": {
+            "name": "timestamp",
+            "type": "timestamp",
+            "primaryKey": false,
+            "notNull": true,
+            "default": "now()"
+          },
+          "source": {
+            "name": "source",
+            "type": "source",
+            "typeSchema": "public",
+            "primaryKey": false,
+            "notNull": true
+          }
+        },
+        "indexes": {},
+        "foreignKeys": {
+          "reports_station_id_stations_id_fk": {
+            "name": "reports_station_id_stations_id_fk",
+            "tableFrom": "reports",
+            "tableTo": "stations",
+            "columnsFrom": [
+              "station_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "no action",
+            "onUpdate": "no action"
+          },
+          "reports_line_id_lines_id_fk": {
+            "name": "reports_line_id_lines_id_fk",
+            "tableFrom": "reports",
+            "tableTo": "lines",
+            "columnsFrom": [
+              "line_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "no action",
+            "onUpdate": "no action"
+          },
+          "reports_direction_id_stations_id_fk": {
+            "name": "reports_direction_id_stations_id_fk",
+            "tableFrom": "reports",
+            "tableTo": "stations",
+            "columnsFrom": [
+              "direction_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "no action",
+            "onUpdate": "no action"
+          }
+        },
+        "compositePrimaryKeys": {},
+        "uniqueConstraints": {},
+        "policies": {},
+        "checkConstraints": {},
+        "isRLSEnabled": false
+      },
+      "public.segments": {
+        "name": "segments",
+        "schema": "",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "serial",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "line_id": {
+            "name": "line_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "from_station_id": {
+            "name": "from_station_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "to_station_id": {
+            "name": "to_station_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "color": {
+            "name": "color",
+            "type": "varchar(7)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "coordinates": {
+            "name": "coordinates",
+            "type": "jsonb",
+            "primaryKey": false,
+            "notNull": true
+          }
+        },
+        "indexes": {},
+        "foreignKeys": {
+          "segments_line_id_lines_id_fk": {
+            "name": "segments_line_id_lines_id_fk",
+            "tableFrom": "segments",
+            "tableTo": "lines",
+            "columnsFrom": [
+              "line_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "cascade",
+            "onUpdate": "no action"
+          },
+          "segments_from_station_id_stations_id_fk": {
+            "name": "segments_from_station_id_stations_id_fk",
+            "tableFrom": "segments",
+            "tableTo": "stations",
+            "columnsFrom": [
+              "from_station_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "cascade",
+            "onUpdate": "no action"
+          },
+          "segments_to_station_id_stations_id_fk": {
+            "name": "segments_to_station_id_stations_id_fk",
+            "tableFrom": "segments",
+            "tableTo": "stations",
+            "columnsFrom": [
+              "to_station_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "cascade",
+            "onUpdate": "no action"
+          }
+        },
+        "compositePrimaryKeys": {},
+        "uniqueConstraints": {},
+        "policies": {},
+        "checkConstraints": {},
+        "isRLSEnabled": false
+      },
+      "public.stations": {
+        "name": "stations",
+        "schema": "",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "varchar(16)",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "name": {
+            "name": "name",
+            "type": "varchar(255)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "lat": {
+            "name": "lat",
+            "type": "double precision",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "lng": {
+            "name": "lng",
+            "type": "double precision",
+            "primaryKey": false,
+            "notNull": true
+          }
+        },
+        "indexes": {},
+        "foreignKeys": {},
+        "compositePrimaryKeys": {},
+        "uniqueConstraints": {},
+        "policies": {},
+        "checkConstraints": {},
+        "isRLSEnabled": false
+      }
     },
     "enums": {
-        "public.source": {
-            "name": "source",
-            "schema": "public",
-            "values": ["mini_app", "web_app", "mobile_app", "telegram"]
-        }
+      "public.source": {
+        "name": "source",
+        "schema": "public",
+        "values": [
+          "mini_app",
+          "web_app",
+          "mobile_app",
+          "telegram"
+        ]
+      }
     },
     "schemas": {},
     "sequences": {},
@@ -221,8 +338,8 @@
     "policies": {},
     "views": {},
     "_meta": {
-        "columns": {},
-        "schemas": {},
-        "tables": {}
+      "columns": {},
+      "schemas": {},
+      "tables": {}
     }
-}
+  }

--- a/packages/hono-backend/drizzle/meta/0000_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0000_snapshot.json
@@ -1,305 +1,373 @@
 {
-    "id": "565c8c91-131e-4a5d-8082-770a5a594eda",
-    "prevId": "16f44466-7915-4d16-881c-b5f8b3661843",
-    "version": "7",
-    "dialect": "postgresql",
-    "tables": {
-        "public.line_stations": {
-            "name": "line_stations",
-            "schema": "",
-            "columns": {
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "station_id": {
-                    "name": "station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "order": {
-                    "name": "order",
-                    "type": "integer",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "line_stations_line_id_lines_id_fk": {
-                    "name": "line_stations_line_id_lines_id_fk",
-                    "tableFrom": "line_stations",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                },
-                "line_stations_station_id_stations_id_fk": {
-                    "name": "line_stations_station_id_stations_id_fk",
-                    "tableFrom": "line_stations",
-                    "tableTo": "stations",
-                    "columnsFrom": ["station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {
-                "line_stations_line_id_station_id_pk": {
-                    "name": "line_stations_line_id_station_id_pk",
-                    "columns": ["line_id", "station_id"]
-                }
-            },
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+  "id": "c74cdf83-4a0d-4ed9-85c9-74fc979c3567",
+  "prevId": "565c8c91-131e-4a5d-8082-770a5a594eda",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.line_stations": {
+      "name": "line_stations",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
         },
-        "public.lines": {
-            "name": "lines",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "varchar(16)",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "name": {
-                    "name": "name",
-                    "type": "varchar(255)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "is_circular": {
-                    "name": "is_circular",
-                    "type": "boolean",
-                    "primaryKey": false,
-                    "notNull": true,
-                    "default": false
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {},
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+        "station_id": {
+          "name": "station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
         },
-        "public.reports": {
-            "name": "reports",
-            "schema": "",
-            "columns": {
-                "report_id": {
-                    "name": "report_id",
-                    "type": "serial",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "station_id": {
-                    "name": "station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": false
-                },
-                "direction_id": {
-                    "name": "direction_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": false
-                },
-                "timestamp": {
-                    "name": "timestamp",
-                    "type": "timestamp",
-                    "primaryKey": false,
-                    "notNull": true,
-                    "default": "now()"
-                },
-                "source": {
-                    "name": "source",
-                    "type": "source",
-                    "typeSchema": "public",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "reports_station_id_stations_id_fk": {
-                    "name": "reports_station_id_stations_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "stations",
-                    "columnsFrom": ["station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                },
-                "reports_line_id_lines_id_fk": {
-                    "name": "reports_line_id_lines_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                },
-                "reports_direction_id_stations_id_fk": {
-                    "name": "reports_direction_id_stations_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "stations",
-                    "columnsFrom": ["direction_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
-        },
-        "public.segments": {
-            "name": "segments",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "serial",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "from_station_id": {
-                    "name": "from_station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "to_station_id": {
-                    "name": "to_station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "color": {
-                    "name": "color",
-                    "type": "varchar(7)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "coordinates": {
-                    "name": "coordinates",
-                    "type": "jsonb",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "segments_line_id_lines_id_fk": {
-                    "name": "segments_line_id_lines_id_fk",
-                    "tableFrom": "segments",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                },
-                "segments_from_station_id_stations_id_fk": {
-                    "name": "segments_from_station_id_stations_id_fk",
-                    "tableFrom": "segments",
-                    "tableTo": "stations",
-                    "columnsFrom": ["from_station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                },
-                "segments_to_station_id_stations_id_fk": {
-                    "name": "segments_to_station_id_stations_id_fk",
-                    "tableFrom": "segments",
-                    "tableTo": "stations",
-                    "columnsFrom": ["to_station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
-        },
-        "public.stations": {
-            "name": "stations",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "varchar(16)",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "name": {
-                    "name": "name",
-                    "type": "varchar(255)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "lat": {
-                    "name": "lat",
-                    "type": "double precision",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "lng": {
-                    "name": "lng",
-                    "type": "double precision",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {},
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
         }
-    },
-    "enums": {
-        "public.source": {
-            "name": "source",
-            "schema": "public",
-            "values": ["mini_app", "web_app", "mobile_app", "telegram"]
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_stations_line_id_lines_id_fk": {
+          "name": "line_stations_line_id_lines_id_fk",
+          "tableFrom": "line_stations",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "line_stations_station_id_stations_id_fk": {
+          "name": "line_stations_station_id_stations_id_fk",
+          "tableFrom": "line_stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
+      },
+      "compositePrimaryKeys": {
+        "line_stations_line_id_station_id_pk": {
+          "name": "line_stations_line_id_station_id_pk",
+          "columns": [
+            "line_id",
+            "station_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     },
-    "schemas": {},
-    "sequences": {},
-    "roles": {},
-    "policies": {},
-    "views": {},
-    "_meta": {
-        "columns": {},
-        "schemas": {},
-        "tables": {}
+    "public.lines": {
+      "name": "lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_circular": {
+          "name": "is_circular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "report_id": {
+          "name": "report_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction_id": {
+          "name": "direction_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_station_id_stations_id_fk": {
+          "name": "reports_station_id_stations_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_line_id_lines_id_fk": {
+          "name": "reports_line_id_lines_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_direction_id_stations_id_fk": {
+          "name": "reports_direction_id_stations_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "direction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_station_id": {
+          "name": "from_station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_station_id": {
+          "name": "to_station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coordinates": {
+          "name": "coordinates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "segments_line_from_to_idx": {
+          "name": "segments_line_from_to_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "segments_line_id_lines_id_fk": {
+          "name": "segments_line_id_lines_id_fk",
+          "tableFrom": "segments",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segments_from_station_id_stations_id_fk": {
+          "name": "segments_from_station_id_stations_id_fk",
+          "tableFrom": "segments",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "from_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segments_to_station_id_stations_id_fk": {
+          "name": "segments_to_station_id_stations_id_fk",
+          "tableFrom": "segments",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "to_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     }
+  },
+  "enums": {
+    "public.source": {
+      "name": "source",
+      "schema": "public",
+      "values": [
+        "mini_app",
+        "web_app",
+        "mobile_app",
+        "telegram"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
 }

--- a/packages/hono-backend/drizzle/meta/0000_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0000_snapshot.json
@@ -1,373 +1,333 @@
 {
-  "id": "c74cdf83-4a0d-4ed9-85c9-74fc979c3567",
-  "prevId": "565c8c91-131e-4a5d-8082-770a5a594eda",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.line_stations": {
-      "name": "line_stations",
-      "schema": "",
-      "columns": {
-        "line_id": {
-          "name": "line_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "station_id": {
-          "name": "station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "order": {
-          "name": "order",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "line_stations_line_id_lines_id_fk": {
-          "name": "line_stations_line_id_lines_id_fk",
-          "tableFrom": "line_stations",
-          "tableTo": "lines",
-          "columnsFrom": [
-            "line_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "line_stations_station_id_stations_id_fk": {
-          "name": "line_stations_station_id_stations_id_fk",
-          "tableFrom": "line_stations",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "line_stations_line_id_station_id_pk": {
-          "name": "line_stations_line_id_station_id_pk",
-          "columns": [
-            "line_id",
-            "station_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.lines": {
-      "name": "lines",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(16)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "is_circular": {
-          "name": "is_circular",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.reports": {
-      "name": "reports",
-      "schema": "",
-      "columns": {
-        "report_id": {
-          "name": "report_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "station_id": {
-          "name": "station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "line_id": {
-          "name": "line_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "direction_id": {
-          "name": "direction_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "source": {
-          "name": "source",
-          "type": "source",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "reports_station_id_stations_id_fk": {
-          "name": "reports_station_id_stations_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "reports_line_id_lines_id_fk": {
-          "name": "reports_line_id_lines_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "lines",
-          "columnsFrom": [
-            "line_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "reports_direction_id_stations_id_fk": {
-          "name": "reports_direction_id_stations_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "direction_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.segments": {
-      "name": "segments",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "line_id": {
-          "name": "line_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "from_station_id": {
-          "name": "from_station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "to_station_id": {
-          "name": "to_station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "color": {
-          "name": "color",
-          "type": "varchar(7)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "coordinates": {
-          "name": "coordinates",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "segments_line_from_to_idx": {
-          "name": "segments_line_from_to_idx",
-          "columns": [
-            {
-              "expression": "line_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
+    "id": "c74cdf83-4a0d-4ed9-85c9-74fc979c3567",
+    "prevId": "565c8c91-131e-4a5d-8082-770a5a594eda",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.line_stations": {
+            "name": "line_stations",
+            "schema": "",
+            "columns": {
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "order": {
+                    "name": "order",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                }
             },
-            {
-              "expression": "from_station_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
+            "indexes": {},
+            "foreignKeys": {
+                "line_stations_line_id_lines_id_fk": {
+                    "name": "line_stations_line_id_lines_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "line_stations_station_id_stations_id_fk": {
+                    "name": "line_stations_station_id_stations_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
             },
-            {
-              "expression": "to_station_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "segments_line_id_lines_id_fk": {
-          "name": "segments_line_id_lines_id_fk",
-          "tableFrom": "segments",
-          "tableTo": "lines",
-          "columnsFrom": [
-            "line_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+            "compositePrimaryKeys": {
+                "line_stations_line_id_station_id_pk": {
+                    "name": "line_stations_line_id_station_id_pk",
+                    "columns": ["line_id", "station_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "segments_from_station_id_stations_id_fk": {
-          "name": "segments_from_station_id_stations_id_fk",
-          "tableFrom": "segments",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "from_station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+        "public.lines": {
+            "name": "lines",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "is_circular": {
+                    "name": "is_circular",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "segments_to_station_id_stations_id_fk": {
-          "name": "segments_to_station_id_stations_id_fk",
-          "tableFrom": "segments",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "to_station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+        "public.reports": {
+            "name": "reports",
+            "schema": "",
+            "columns": {
+                "report_id": {
+                    "name": "report_id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "direction_id": {
+                    "name": "direction_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "timestamp": {
+                    "name": "timestamp",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "source": {
+                    "name": "source",
+                    "type": "source",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "reports_station_id_stations_id_fk": {
+                    "name": "reports_station_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_line_id_lines_id_fk": {
+                    "name": "reports_line_id_lines_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_direction_id_stations_id_fk": {
+                    "name": "reports_direction_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["direction_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.segments": {
+            "name": "segments",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "from_station_id": {
+                    "name": "from_station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "to_station_id": {
+                    "name": "to_station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "color": {
+                    "name": "color",
+                    "type": "varchar(7)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "coordinates": {
+                    "name": "coordinates",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "segments_line_from_to_idx": {
+                    "name": "segments_line_from_to_idx",
+                    "columns": [
+                        {
+                            "expression": "line_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "from_station_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "to_station_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "segments_line_id_lines_id_fk": {
+                    "name": "segments_line_id_lines_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "segments_from_station_id_stations_id_fk": {
+                    "name": "segments_from_station_id_stations_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "stations",
+                    "columnsFrom": ["from_station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "segments_to_station_id_stations_id_fk": {
+                    "name": "segments_to_station_id_stations_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "stations",
+                    "columnsFrom": ["to_station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.stations": {
+            "name": "stations",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lat": {
+                    "name": "lat",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lng": {
+                    "name": "lng",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     },
-    "public.stations": {
-      "name": "stations",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(16)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lat": {
-          "name": "lat",
-          "type": "double precision",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lng": {
-          "name": "lng",
-          "type": "double precision",
-          "primaryKey": false,
-          "notNull": true
+    "enums": {
+        "public.source": {
+            "name": "source",
+            "schema": "public",
+            "values": ["mini_app", "web_app", "mobile_app", "telegram"]
         }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {
-    "public.source": {
-      "name": "source",
-      "schema": "public",
-      "values": [
-        "mini_app",
-        "web_app",
-        "mobile_app",
-        "telegram"
-      ]
-    }
-  },
-  "schemas": {},
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
+    },
     "schemas": {},
-    "tables": {}
-  }
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
 }

--- a/packages/hono-backend/drizzle/meta/0000_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0000_snapshot.json
@@ -4,333 +4,293 @@
     "version": "7",
     "dialect": "postgresql",
     "tables": {
-      "public.line_stations": {
-        "name": "line_stations",
-        "schema": "",
-        "columns": {
-          "line_id": {
-            "name": "line_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "station_id": {
-            "name": "station_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "order": {
-            "name": "order",
-            "type": "integer",
-            "primaryKey": false,
-            "notNull": true
-          }
+        "public.line_stations": {
+            "name": "line_stations",
+            "schema": "",
+            "columns": {
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "order": {
+                    "name": "order",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "line_stations_line_id_lines_id_fk": {
+                    "name": "line_stations_line_id_lines_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "line_stations_station_id_stations_id_fk": {
+                    "name": "line_stations_station_id_stations_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "line_stations_line_id_station_id_pk": {
+                    "name": "line_stations_line_id_station_id_pk",
+                    "columns": ["line_id", "station_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "indexes": {},
-        "foreignKeys": {
-          "line_stations_line_id_lines_id_fk": {
-            "name": "line_stations_line_id_lines_id_fk",
-            "tableFrom": "line_stations",
-            "tableTo": "lines",
-            "columnsFrom": [
-              "line_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "cascade",
-            "onUpdate": "no action"
-          },
-          "line_stations_station_id_stations_id_fk": {
-            "name": "line_stations_station_id_stations_id_fk",
-            "tableFrom": "line_stations",
-            "tableTo": "stations",
-            "columnsFrom": [
-              "station_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "cascade",
-            "onUpdate": "no action"
-          }
+        "public.lines": {
+            "name": "lines",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "is_circular": {
+                    "name": "is_circular",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "compositePrimaryKeys": {
-          "line_stations_line_id_station_id_pk": {
-            "name": "line_stations_line_id_station_id_pk",
-            "columns": [
-              "line_id",
-              "station_id"
-            ]
-          }
+        "public.reports": {
+            "name": "reports",
+            "schema": "",
+            "columns": {
+                "report_id": {
+                    "name": "report_id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "direction_id": {
+                    "name": "direction_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "timestamp": {
+                    "name": "timestamp",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "source": {
+                    "name": "source",
+                    "type": "source",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "reports_station_id_stations_id_fk": {
+                    "name": "reports_station_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_line_id_lines_id_fk": {
+                    "name": "reports_line_id_lines_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_direction_id_stations_id_fk": {
+                    "name": "reports_direction_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["direction_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "uniqueConstraints": {},
-        "policies": {},
-        "checkConstraints": {},
-        "isRLSEnabled": false
-      },
-      "public.lines": {
-        "name": "lines",
-        "schema": "",
-        "columns": {
-          "id": {
-            "name": "id",
-            "type": "varchar(16)",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "name": {
-            "name": "name",
-            "type": "varchar(255)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "is_circular": {
-            "name": "is_circular",
-            "type": "boolean",
-            "primaryKey": false,
-            "notNull": true,
-            "default": false
-          }
+        "public.segments": {
+            "name": "segments",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "from_station_id": {
+                    "name": "from_station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "to_station_id": {
+                    "name": "to_station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "color": {
+                    "name": "color",
+                    "type": "varchar(7)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "coordinates": {
+                    "name": "coordinates",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "segments_line_id_lines_id_fk": {
+                    "name": "segments_line_id_lines_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "segments_from_station_id_stations_id_fk": {
+                    "name": "segments_from_station_id_stations_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "stations",
+                    "columnsFrom": ["from_station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "segments_to_station_id_stations_id_fk": {
+                    "name": "segments_to_station_id_stations_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "stations",
+                    "columnsFrom": ["to_station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "indexes": {},
-        "foreignKeys": {},
-        "compositePrimaryKeys": {},
-        "uniqueConstraints": {},
-        "policies": {},
-        "checkConstraints": {},
-        "isRLSEnabled": false
-      },
-      "public.reports": {
-        "name": "reports",
-        "schema": "",
-        "columns": {
-          "report_id": {
-            "name": "report_id",
-            "type": "serial",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "station_id": {
-            "name": "station_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "line_id": {
-            "name": "line_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": false
-          },
-          "direction_id": {
-            "name": "direction_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": false
-          },
-          "timestamp": {
-            "name": "timestamp",
-            "type": "timestamp",
-            "primaryKey": false,
-            "notNull": true,
-            "default": "now()"
-          },
-          "source": {
-            "name": "source",
-            "type": "source",
-            "typeSchema": "public",
-            "primaryKey": false,
-            "notNull": true
-          }
-        },
-        "indexes": {},
-        "foreignKeys": {
-          "reports_station_id_stations_id_fk": {
-            "name": "reports_station_id_stations_id_fk",
-            "tableFrom": "reports",
-            "tableTo": "stations",
-            "columnsFrom": [
-              "station_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "no action",
-            "onUpdate": "no action"
-          },
-          "reports_line_id_lines_id_fk": {
-            "name": "reports_line_id_lines_id_fk",
-            "tableFrom": "reports",
-            "tableTo": "lines",
-            "columnsFrom": [
-              "line_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "no action",
-            "onUpdate": "no action"
-          },
-          "reports_direction_id_stations_id_fk": {
-            "name": "reports_direction_id_stations_id_fk",
-            "tableFrom": "reports",
-            "tableTo": "stations",
-            "columnsFrom": [
-              "direction_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "no action",
-            "onUpdate": "no action"
-          }
-        },
-        "compositePrimaryKeys": {},
-        "uniqueConstraints": {},
-        "policies": {},
-        "checkConstraints": {},
-        "isRLSEnabled": false
-      },
-      "public.segments": {
-        "name": "segments",
-        "schema": "",
-        "columns": {
-          "id": {
-            "name": "id",
-            "type": "serial",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "line_id": {
-            "name": "line_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "from_station_id": {
-            "name": "from_station_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "to_station_id": {
-            "name": "to_station_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "color": {
-            "name": "color",
-            "type": "varchar(7)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "coordinates": {
-            "name": "coordinates",
-            "type": "jsonb",
-            "primaryKey": false,
-            "notNull": true
-          }
-        },
-        "indexes": {},
-        "foreignKeys": {
-          "segments_line_id_lines_id_fk": {
-            "name": "segments_line_id_lines_id_fk",
-            "tableFrom": "segments",
-            "tableTo": "lines",
-            "columnsFrom": [
-              "line_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "cascade",
-            "onUpdate": "no action"
-          },
-          "segments_from_station_id_stations_id_fk": {
-            "name": "segments_from_station_id_stations_id_fk",
-            "tableFrom": "segments",
-            "tableTo": "stations",
-            "columnsFrom": [
-              "from_station_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "cascade",
-            "onUpdate": "no action"
-          },
-          "segments_to_station_id_stations_id_fk": {
-            "name": "segments_to_station_id_stations_id_fk",
-            "tableFrom": "segments",
-            "tableTo": "stations",
-            "columnsFrom": [
-              "to_station_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "cascade",
-            "onUpdate": "no action"
-          }
-        },
-        "compositePrimaryKeys": {},
-        "uniqueConstraints": {},
-        "policies": {},
-        "checkConstraints": {},
-        "isRLSEnabled": false
-      },
-      "public.stations": {
-        "name": "stations",
-        "schema": "",
-        "columns": {
-          "id": {
-            "name": "id",
-            "type": "varchar(16)",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "name": {
-            "name": "name",
-            "type": "varchar(255)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "lat": {
-            "name": "lat",
-            "type": "double precision",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "lng": {
-            "name": "lng",
-            "type": "double precision",
-            "primaryKey": false,
-            "notNull": true
-          }
-        },
-        "indexes": {},
-        "foreignKeys": {},
-        "compositePrimaryKeys": {},
-        "uniqueConstraints": {},
-        "policies": {},
-        "checkConstraints": {},
-        "isRLSEnabled": false
-      }
+        "public.stations": {
+            "name": "stations",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lat": {
+                    "name": "lat",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lng": {
+                    "name": "lng",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
     },
     "enums": {
-      "public.source": {
-        "name": "source",
-        "schema": "public",
-        "values": [
-          "mini_app",
-          "web_app",
-          "mobile_app",
-          "telegram"
-        ]
-      }
+        "public.source": {
+            "name": "source",
+            "schema": "public",
+            "values": ["mini_app", "web_app", "mobile_app", "telegram"]
+        }
     },
     "schemas": {},
     "sequences": {},
@@ -338,8 +298,8 @@
     "policies": {},
     "views": {},
     "_meta": {
-      "columns": {},
-      "schemas": {},
-      "tables": {}
+        "columns": {},
+        "schemas": {},
+        "tables": {}
     }
-  }
+}

--- a/packages/hono-backend/drizzle/meta/_journal.json
+++ b/packages/hono-backend/drizzle/meta/_journal.json
@@ -1,13 +1,13 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1765472567170,
-      "tag": "0000_modern_runaways",
-      "breakpoints": true
-    }
-  ]
+    "version": "7",
+    "dialect": "postgresql",
+    "entries": [
+        {
+            "idx": 0,
+            "version": "7",
+            "when": 1765472567170,
+            "tag": "0000_modern_runaways",
+            "breakpoints": true
+        }
+    ]
 }

--- a/packages/hono-backend/drizzle/meta/_journal.json
+++ b/packages/hono-backend/drizzle/meta/_journal.json
@@ -1,13 +1,13 @@
 {
-    "version": "7",
-    "dialect": "postgresql",
-    "entries": [
-        {
-            "idx": 0,
-            "version": "7",
-            "when": 1765472567170,
-            "tag": "0000_modern_runaways",
-            "breakpoints": true
-        }
-    ]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1765472567170,
+      "tag": "0000_modern_runaways",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/hono-backend/justfile
+++ b/packages/hono-backend/justfile
@@ -12,6 +12,13 @@ db-generate:
 db-migrate:
     docker compose -f {{compose_file}} exec {{service}} bun run db:migrate
 
+db-migrate-test:
+    docker compose -f {{compose_file}} exec -e DATABASE_URL=postgres://postgres:postgres@postgres:5432/freifahren_test {{service}} bun run db:migrate
+
+db-migrate-all:
+    just db-migrate
+    just db-migrate-test
+
 db-studio:
     DATABASE_URL={{db_url}} bun run db:studio
 

--- a/packages/hono-backend/package.json
+++ b/packages/hono-backend/package.json
@@ -12,7 +12,8 @@
         "db:push": "drizzle-kit push",
         "db:studio": "drizzle-kit studio",
         "db:drop": "drizzle-kit drop",
-        "db:seed": "bun run src/db/seed/index.ts"
+        "db:seed": "bun run src/db/seed/index.ts",
+        "db:reset": "psql $DATABASE_URL -c 'DROP SCHEMA public CASCADE; DROP SCHEMA drizzle CASCADE; CREATE SCHEMA public;' && drizzle-kit migrate && bun run src/db/seed/index.ts"
     },
     "dependencies": {
         "@types/lodash": "^4.17.20",

--- a/packages/hono-backend/src/db/index.ts
+++ b/packages/hono-backend/src/db/index.ts
@@ -3,13 +3,14 @@ import postgres from 'postgres'
 
 import { lines, lineStations } from './schema/lines'
 import { reports } from './schema/reports'
+import { segments } from './schema/segments'
 import { stations } from './schema/stations'
 
 const connectionString = process.env.DATABASE_URL!
 
 export const client = postgres(connectionString, { prepare: false })
 export const db = drizzle(client, {
-    schema: { reports, stations, lines, lineStations },
+    schema: { reports, stations, lines, lineStations, segments },
     casing: 'snake_case',
 })
 
@@ -18,3 +19,4 @@ export type DbConnection = typeof db
 export * from './schema/reports'
 export * from './schema/lines'
 export * from './schema/stations'
+export * from './schema/segments'

--- a/packages/hono-backend/src/db/schema/segments.ts
+++ b/packages/hono-backend/src/db/schema/segments.ts
@@ -1,19 +1,23 @@
-import { jsonb, pgTable, serial, varchar } from 'drizzle-orm/pg-core'
+import { jsonb, pgTable, serial, uniqueIndex, varchar } from 'drizzle-orm/pg-core'
 
 import { lines } from './lines'
 import { stations } from './stations'
 
-export const segments = pgTable('segments', {
-    id: serial().primaryKey(),
-    lineId: varchar({ length: 16 })
-        .notNull()
-        .references(() => lines.id, { onDelete: 'cascade' }),
-    fromStationId: varchar({ length: 16 })
-        .notNull()
-        .references(() => stations.id, { onDelete: 'cascade' }),
-    toStationId: varchar({ length: 16 })
-        .notNull()
-        .references(() => stations.id, { onDelete: 'cascade' }),
-    color: varchar({ length: 7 }).notNull(),
-    coordinates: jsonb().notNull().$type<[number, number][]>(),
-})
+export const segments = pgTable(
+    'segments',
+    {
+        id: serial().primaryKey(),
+        lineId: varchar({ length: 16 })
+            .notNull()
+            .references(() => lines.id, { onDelete: 'cascade' }),
+        fromStationId: varchar({ length: 16 })
+            .notNull()
+            .references(() => stations.id, { onDelete: 'cascade' }),
+        toStationId: varchar({ length: 16 })
+            .notNull()
+            .references(() => stations.id, { onDelete: 'cascade' }),
+        color: varchar({ length: 7 }).notNull(),
+        coordinates: jsonb().notNull().$type<[number, number][]>(),
+    },
+    (table) => [uniqueIndex('segments_line_from_to_idx').on(table.lineId, table.fromStationId, table.toStationId)]
+)

--- a/packages/hono-backend/src/db/schema/segments.ts
+++ b/packages/hono-backend/src/db/schema/segments.ts
@@ -1,0 +1,19 @@
+import { jsonb, pgTable, serial, varchar } from 'drizzle-orm/pg-core'
+
+import { lines } from './lines'
+import { stations } from './stations'
+
+export const segments = pgTable('segments', {
+    id: serial().primaryKey(),
+    lineId: varchar({ length: 16 })
+        .notNull()
+        .references(() => lines.id, { onDelete: 'cascade' }),
+    fromStationId: varchar({ length: 16 })
+        .notNull()
+        .references(() => stations.id, { onDelete: 'cascade' }),
+    toStationId: varchar({ length: 16 })
+        .notNull()
+        .references(() => stations.id, { onDelete: 'cascade' }),
+    color: varchar({ length: 7 }).notNull(),
+    coordinates: jsonb().notNull().$type<[number, number][]>(),
+})

--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -9,7 +9,7 @@ import { registerRoutes } from './common/router'
 import { db, DbConnection } from './db'
 import { getReports, postReport, ReportsService } from './modules/reports/'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
-import { getLines, getStations } from './modules/transit/transit-routes'
+import { getLines, getSegments, getStations } from './modules/transit/transit-routes'
 
 const app = new Hono<Env>()
 
@@ -55,6 +55,6 @@ const createServices = (db: DbConnection) => {
 
 registerServices(app, createServices(db))
 
-registerRoutes(app, [getReports, postReport, getStations, getLines])
+registerRoutes(app, [getReports, postReport, getStations, getLines, getSegments])
 
 export default app

--- a/packages/hono-backend/src/modules/transit/transit-routes.ts
+++ b/packages/hono-backend/src/modules/transit/transit-routes.ts
@@ -18,3 +18,12 @@ export const getLines = defineRoute<Env>()({
         return c.json(await transitNetworkDataService.getLines())
     },
 })
+
+export const getSegments = defineRoute<Env>()({
+    method: 'get' as const,
+    path: 'v0/transit/segments',
+    handler: async (c) => {
+        const transitNetworkDataService = c.get('transitNetworkDataService')
+        return c.json(await transitNetworkDataService.getSegments())
+    },
+})

--- a/packages/hono-backend/src/modules/transit/transit-routes.ts
+++ b/packages/hono-backend/src/modules/transit/transit-routes.ts
@@ -46,6 +46,29 @@ export const getLines = defineRoute<Env>()({
 export const getSegments = defineRoute<Env>()({
     method: 'get' as const,
     path: 'v0/transit/segments',
+    docs: {
+        summary: 'List segments',
+        description: 'Returns all transit line segments as GeoJSON features.',
+        tags: ['transit'],
+        responseSchema: z.object({
+            type: z.literal('FeatureCollection'),
+            features: z.array(
+                z.object({
+                    type: z.literal('Feature'),
+                    properties: z.object({
+                        line: z.string(),
+                        from: z.string(),
+                        to: z.string(),
+                        color: z.string(),
+                    }),
+                    geometry: z.object({
+                        type: z.literal('LineString'),
+                        coordinates: z.array(z.tuple([z.number(), z.number()])),
+                    }),
+                })
+            ),
+        }),
+    },
     handler: async (c) => {
         const transitNetworkDataService = c.get('transitNetworkDataService')
         return c.json(await transitNetworkDataService.getSegments())

--- a/packages/hono-backend/src/modules/transit/types.ts
+++ b/packages/hono-backend/src/modules/transit/types.ts
@@ -1,10 +1,12 @@
 import { InferSelectModel } from 'drizzle-orm'
 
 import { lines } from '../../db/schema/lines'
+import { segments } from '../../db/schema/segments'
 import { stations } from '../../db/schema/stations'
 
 type StationRow = InferSelectModel<typeof stations>
 type LineRow = InferSelectModel<typeof lines>
+type SegmentRow = InferSelectModel<typeof segments>
 
 type StationId = StationRow['id']
 type LineId = LineRow['id']
@@ -15,7 +17,28 @@ type Station = {
     lines: LineId[]
 }
 
+type SegmentProperties = {
+    line: SegmentRow['lineId']
+    from: SegmentRow['fromStationId']
+    to: SegmentRow['toStationId']
+    color: SegmentRow['color']
+}
+
+type SegmentFeature = {
+    type: 'Feature'
+    properties: SegmentProperties
+    geometry: {
+        type: 'LineString'
+        coordinates: SegmentRow['coordinates']
+    }
+}
+
+type SegmentsFeatureCollection = {
+    type: 'FeatureCollection'
+    features: SegmentFeature[]
+}
+
 type Stations = Record<StationId, Station>
 type Lines = Record<LineId, StationId[]>
 
-export type { Lines, Stations, StationId, LineId }
+export type { Lines, Stations, SegmentsFeatureCollection, SegmentFeature, StationId, LineId }

--- a/packages/hono-backend/tests/preload.ts
+++ b/packages/hono-backend/tests/preload.ts
@@ -1,4 +1,4 @@
 // We suppress logging in tests to avoid cluttering the output.
 // But to debug a test failure, you can run `TEST_LOG_LEVEL=info bun test` to enable logging.
 process.env.LOG_LEVEL = process.env.TEST_LOG_LEVEL ?? 'error'
-process.env.DATABASE_URL ??= 'postgres://postgres:postgres@localhost:5432/freifahren_test'
+process.env.DATABASE_URL = process.env.DATABASE_URL_TEST!

--- a/packages/hono-backend/tests/preload.ts
+++ b/packages/hono-backend/tests/preload.ts
@@ -1,4 +1,4 @@
 // We suppress logging in tests to avoid cluttering the output.
 // But to debug a test failure, you can run `TEST_LOG_LEVEL=info bun test` to enable logging.
 process.env.LOG_LEVEL = process.env.TEST_LOG_LEVEL ?? 'error'
-process.env.DATABASE_URL = process.env.DATABASE_URL_TEST!
+process.env.DATABASE_URL = process.env.DATABASE_URL_TEST ?? process.env.DATABASE_URL


### PR DESCRIPTION
## Describe the issue:
The clients consume the segments to display the lines of the map. We need a way to return them to the users. 

## Explain how you solved the issue:
I added a new schema for segments:
```
export const segments = pgTable('segments', {
    id: serial().primaryKey(),
    lineId: varchar({ length: 16 })
        .notNull()
        .references(() => lines.id, { onDelete: 'cascade' }),
    fromStationId: varchar({ length: 16 })
        .notNull()
        .references(() => stations.id, { onDelete: 'cascade' }),
    toStationId: varchar({ length: 16 })
        .notNull()
        .references(() => stations.id, { onDelete: 'cascade' }),
    color: varchar({ length: 7 }).notNull(),
    coordinates: jsonb().notNull().$type<[number, number][]>(),
})
```
Then seed it in `seed.ts` (For now we are just seeding it from the `segments.json`. In the future this will be replaced by the proper seed script where we can recreate them on the fly based on OSM data, making the backend truly stateless).
I also adjusted the default migration to include the new segments table and created an endpoint `/v0/transit/segments` that serializes the data to proper Geojson  and returns it to the client. Since the data is being cached we are only doing this once.

The next step is the ETag caching so that the client avoids requesting this data again and again.

## Additional notes or considerations:
- You have to wipe, migrate and reseed your db if you want to test this PR. 
- The type of one `SegmentFeature` is: `LineString`:
```
type SegmentFeature = {
    type: 'Feature'
    properties: SegmentProperties
    geometry: {
        type: 'LineString'
        coordinates: SegmentRow['coordinates']
    }
}
```
We might have to adjust this, once we write a proper seed db script since some of the lines have divergent paths making them `MultiLineStrings`
