### PR TITLE
feat: cache `GET /v0/reports`

### DIFF
--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -11,40 +11,6 @@ import { getReports, postReport, ReportsService } from './modules/reports/'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
 import { getLines, getStations } from './modules/transit/transit-routes'
 
-const app = new Hono<Env>()
-
-app.use(requestId())
-app.use(
-    pinoLogger({
-        pino: pino({
-            level: process.env.LOG_LEVEL ?? 'info',
-            transport: {
-                targets: [
-                    {
-                        target: 'pino-pretty',
-                        options: {
-                            colorize: true,
-                            ignore: 'pid,hostname,req,res,responseTime,reqId',
-                            translateTime: 'SYS:standard',
-                            destination: 1,
-                        },
-                    },
-                    {
-                        target: 'pino-roll',
-                        options: {
-                            file: './app.log',
-                            frequency: 'daily',
-                            mkdir: true,
-                        },
-                    },
-                ],
-            },
-        }),
-    })
-)
-
-app.onError(handleError)
-
 const createServices = (db: DbConnection) => {
     const transitNetworkDataService = new TransitNetworkDataService(db)
 
@@ -53,8 +19,47 @@ const createServices = (db: DbConnection) => {
     return { transitNetworkDataService, reportsService } satisfies Services
 }
 
-registerServices(app, createServices(db))
+export const createApp = (dbConnection: DbConnection = db) => {
+    const app = new Hono<Env>()
 
-registerRoutes(app, [getReports, postReport, getStations, getLines])
+    app.use(requestId())
+    app.use(
+        pinoLogger({
+            pino: pino({
+                level: process.env.LOG_LEVEL ?? 'info',
+                transport: {
+                    targets: [
+                        {
+                            target: 'pino-pretty',
+                            options: {
+                                colorize: true,
+                                ignore: 'pid,hostname,req,res,responseTime,reqId',
+                                translateTime: 'SYS:standard',
+                                destination: 1,
+                            },
+                        },
+                        {
+                            target: 'pino-roll',
+                            options: {
+                                file: './app.log',
+                                frequency: 'daily',
+                                mkdir: true,
+                            },
+                        },
+                    ],
+                },
+            }),
+        })
+    )
+
+    app.onError(handleError)
+
+    registerServices(app, createServices(dbConnection))
+    registerRoutes(app, [getReports, postReport, getStations, getLines])
+
+    return app
+}
+
+const app = createApp()
 
 export default app

--- a/packages/hono-backend/src/modules/reports/constants.ts
+++ b/packages/hono-backend/src/modules/reports/constants.ts
@@ -1,7 +1,7 @@
 import { DateTime, Duration, DurationLike } from 'luxon'
 
 export const DEFAULT_REPORTS_TIMEFRAME: DurationLike = { minutes: 60 }
-export const REPORTS_CACHE_TTL_MS = 5 * 60 * 1000
+export const REPORTS_CACHE_TTL_MS = 1 * 60 * 1000
 
 // Compile trick to show that MAX_REPORTS_TIMEFRAME is Days and not a number
 type Days = number & { readonly __brand: 'Days' }

--- a/packages/hono-backend/src/modules/reports/constants.ts
+++ b/packages/hono-backend/src/modules/reports/constants.ts
@@ -1,6 +1,7 @@
-import { DateTime, DurationLike } from 'luxon'
+import { DateTime, Duration, DurationLike } from 'luxon'
 
-const STANDARD_REPORTS_TIMEFRAME: DurationLike = { minutes: 60 }
+export const DEFAULT_REPORTS_TIMEFRAME: DurationLike = { minutes: 60 }
+export const REPORTS_CACHE_TTL_MS = 5 * 60 * 1000
 
 // Compile trick to show that MAX_REPORTS_TIMEFRAME is Days and not a number
 type Days = number & { readonly __brand: 'Days' }
@@ -8,7 +9,16 @@ export const MAX_REPORTS_TIMEFRAME = 7 as Days
 
 export const getDefaultReportsRange = (now: DateTime = DateTime.now()) => {
     const to = now
-    const from = now.minus(STANDARD_REPORTS_TIMEFRAME)
+    const from = now.minus(DEFAULT_REPORTS_TIMEFRAME)
 
     return { from, to }
+}
+
+export const isDefaultReportsWindow = ({ from, to, now }: { from: DateTime; to: DateTime; now: DateTime }): boolean => {
+    const defaultRangeMillis = Duration.fromDurationLike(DEFAULT_REPORTS_TIMEFRAME).toMillis()
+    const requestedRangeMillis = to.diff(from).toMillis()
+    const toAgeMillis = now.diff(to).toMillis()
+
+    // If the requested range is the same as the default range and the to timestamp is within the cache ttl, return true
+    return requestedRangeMillis === defaultRangeMillis && toAgeMillis >= 0 && toAgeMillis <= REPORTS_CACHE_TTL_MS
 }

--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -47,6 +47,8 @@ export const getReports = defineRoute<Env>()({
             if (ifModifiedSince !== undefined) {
                 const clientTimestamp = DateTime.fromHTTP(ifModifiedSince)
                 // Truncate server timestamp to second to match HTTP-date precision before comparing
+                // Note: This means for two reports that are created within the same second, the client will not see the updated report.
+                // But this can be ignored since the traffic is not as high
                 const serverTimestampTruncated = latestTimestamp.startOf('second')
 
                 // Only return 304 when the client's timestamp exactly matches the server's latest.

--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -7,7 +7,7 @@ import { AppError } from '../../common/errors'
 import { defineRoute } from '../../common/router'
 import { insertReportSchema } from '../../db'
 
-import { getDefaultReportsRange, MAX_REPORTS_TIMEFRAME } from './constants'
+import { isDefaultReportsWindow, MAX_REPORTS_TIMEFRAME } from './constants'
 
 export const getReports = defineRoute<Env>()({
     method: 'get',
@@ -36,49 +36,18 @@ export const getReports = defineRoute<Env>()({
     },
     handler: async (c) => {
         const reportsService = c.get('reportsService')
-
-        const latestTimestamp = await reportsService.getLatestReportTimestamp()
-
-        if (latestTimestamp !== undefined) {
-            // ToHTTP() returns null only for invalid DateTime objects; latestTimestamp is always valid here
-            const lastModified = latestTimestamp.toHTTP()!
-            const ifModifiedSince = c.req.header('If-Modified-Since')
-
-            if (ifModifiedSince !== undefined) {
-                const clientTimestamp = DateTime.fromHTTP(ifModifiedSince)
-                // Truncate server timestamp to second to match HTTP-date precision before comparing
-                // Note: This means for two reports that are created within the same second, the client will not see the updated report.
-                // But this can be ignored since the traffic is not as high
-                const serverTimestampTruncated = latestTimestamp.startOf('second')
-
-                // Only return 304 when the client's timestamp exactly matches the server's latest
-                // And the cached response is younger than 5 minutes. The TTL forces a re-fetch as
-                // Reports age out of the rolling window even when no new insert has occurred.
-                const cacheAgeSeconds = DateTime.now().diff(clientTimestamp).as('seconds')
-                const CACHE_TTL_SECONDS = 5 * 60
-                if (
-                    serverTimestampTruncated.valueOf() === clientTimestamp.valueOf() &&
-                    cacheAgeSeconds <= CACHE_TTL_SECONDS
-                ) {
-                    return new Response(null, {
-                        status: 304,
-                        headers: { 'Last-Modified': lastModified },
-                    })
-                }
-            }
-
-            c.header('Last-Modified', lastModified)
-        }
-
         const query = c.req.valid('query')
-        const defaultRange = getDefaultReportsRange()
+        const now = DateTime.now()
 
-        const range = {
-            from: query.from ?? defaultRange.from,
-            to: query.to ?? defaultRange.to,
+        // Tell client to not cache the response
+        // So that it is easier to reason about the cache behavior
+        c.header('Cache-Control', 'no-store')
+
+        if (isNil(query.from) || isNil(query.to) || isDefaultReportsWindow({ from: query.from, to: query.to, now })) {
+            return c.json(await reportsService.getDefaultReports(now))
         }
 
-        return c.json(await reportsService.getReports({ ...range, currentTime: DateTime.now() })) // Intentionally pass in local time
+        return c.json(await reportsService.getReports({ from: query.from, to: query.to, currentTime: now })) // Intentionally pass in local time
     },
 })
 

--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -46,7 +46,8 @@ export const getReports = defineRoute<Env>()({
     path: '/',
     docs: {
         summary: 'List reports',
-        description: 'Returns reports between an optional from/to ISO datetime range.',
+        description:
+            'Returns reports between an optional from/to ISO datetime range. Caching is disabled for routes that specify the from and to parameters.',
         tags: ['reports'],
         querySchema: z.object({
             from: z.iso.datetime().optional(),
@@ -69,12 +70,13 @@ export const getReports = defineRoute<Env>()({
         const reportsService = c.get('reportsService')
         const query = c.req.valid('query')
         const now = DateTime.now()
+        const hasExplicitRange = c.req.query('from') !== undefined || c.req.query('to') !== undefined
 
         // Tell client to not cache the response
         // So that it is easier to reason about the cache behavior
         c.header('Cache-Control', 'no-store')
 
-        if (isDefaultReportsWindow({ from: query.from, to: query.to, now })) {
+        if (!hasExplicitRange && isDefaultReportsWindow({ from: query.from, to: query.to, now })) {
             return c.json(await reportsService.getDefaultReports(now))
         }
 

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, lte, max } from 'drizzle-orm'
+import { and, desc, eq, gte, lte } from 'drizzle-orm'
 import { DateTime } from 'luxon'
 import { z } from 'zod'
 
@@ -8,6 +8,7 @@ import { DbConnection, InsertReport, reports } from '../../db/'
 import type { TransitNetworkDataService } from '../transit/transit-network-data-service'
 import type { StationId } from '../transit/types'
 
+import { getDefaultReportsRange, REPORTS_CACHE_TTL_MS } from './constants'
 import {
     assignLineIfSingleOption,
     clearStationReferenceIfNotOnLine,
@@ -76,24 +77,42 @@ type ReportSummary = Pick<typeof reports.$inferSelect, 'timestamp' | 'stationId'
     isPredicted: boolean
 }
 
+type DefaultReportsCacheEntry = {
+    expiresAtMillis: number
+    promise: Promise<ReportSummary[]>
+}
+
 export class ReportsService {
-    private latestReportTimestamp: DateTime | undefined = undefined
+    private defaultReportsCache: DefaultReportsCacheEntry | null = null
 
     constructor(
         private db: DbConnection,
         private transitNetworkDataService: TransitNetworkDataService
     ) {}
 
-    async getLatestReportTimestamp(): Promise<DateTime | undefined> {
-        if (this.latestReportTimestamp !== undefined) {
-            return this.latestReportTimestamp
+    async getDefaultReports(currentTime: DateTime): Promise<ReportSummary[]> {
+        const cachedEntry = this.defaultReportsCache
+        if (cachedEntry !== null && cachedEntry.expiresAtMillis > currentTime.toMillis()) {
+            return cachedEntry.promise
         }
-        // Called when `GET /reports` is called before `POST /reports` after a restart
-        const [result] = await this.db.select({ latest: max(reports.timestamp) }).from(reports)
-        if (result.latest) {
-            this.latestReportTimestamp = DateTime.fromJSDate(result.latest)
+
+        const range = getDefaultReportsRange(currentTime)
+        const promise = this.getReportsUncached({ ...range, currentTime })
+        const cacheEntry = {
+            expiresAtMillis: currentTime.toMillis() + REPORTS_CACHE_TTL_MS,
+            promise,
         }
-        return this.latestReportTimestamp
+        this.defaultReportsCache = cacheEntry
+
+        try {
+            return await promise
+        } catch (error) {
+            if (this.defaultReportsCache === cacheEntry) {
+                this.defaultReportsCache = null
+            }
+
+            throw error
+        }
     }
 
     async verifyRequest(headers: Record<string, string>): Promise<void> {
@@ -139,6 +158,18 @@ export class ReportsService {
     }
 
     async getReports({
+        from,
+        to,
+        currentTime,
+    }: {
+        from: DateTime
+        to: DateTime
+        currentTime: DateTime
+    }): Promise<ReportSummary[]> {
+        return this.getReportsUncached({ from, to, currentTime })
+    }
+
+    private async getReportsUncached({
         from,
         to,
         currentTime,
@@ -264,7 +295,7 @@ export class ReportsService {
             timestamp: Date
         }
     }> {
-        const [insertedReport] = await this.db.insert(reports).values(reportData).returning({
+        const [insertedReport] = await this.db.insert(reports).values({ ...reportData, timestamp: new Date() }).returning({
             reportId: reports.reportId,
             stationId: reports.stationId,
             lineId: reports.lineId,
@@ -273,11 +304,7 @@ export class ReportsService {
         })
         // Drizzle returns the inserted row for Postgres. If this ever becomes undefined, we want to surface it fast.
         const report = insertedReport!
-
-        const insertedTimestamp = DateTime.fromJSDate(report.timestamp)
-        if (this.latestReportTimestamp === undefined || insertedTimestamp > this.latestReportTimestamp) {
-            this.latestReportTimestamp = insertedTimestamp
-        }
+        this.defaultReportsCache = null
 
         let telegramNotificationSuccess = true
 

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, setSystemTime }
 import { eq } from 'drizzle-orm'
 import { DateTime, Settings } from 'luxon'
 
-import { db, lineStations, lines, reports, stations } from '../src/db'
+import { db, lineStations, lines, reports } from '../src/db'
 import { seedBaseData } from '../src/db/seed/seed'
 import app, { createApp } from '../src/index'
 import {
@@ -16,21 +16,9 @@ import { sendReportRequest } from './test-utils'
 let testStationId: string
 let testLineId: string
 
-// Note: this function is primarily used for timeframe filtering tests and prediction accuracy tests
-// It is better to use the `sendReportRequest` function for testing business logic and API behavior.
-// Since this function bypasses the API validation and post-processing pipeline, it is not a good fit for testing the API.
-const createReportWithTimestamp = async (
-    timestamp: Date,
-    stationId: string = testStationId,
-    lineId: string = testLineId
-) => {
-    await db.insert(reports).values({
-        stationId,
-        lineId,
-        directionId: stationId,
-        timestamp,
-        source: 'telegram',
-    })
+const sendReportAt = async (timestamp: Date, stationId: string = testStationId, lineId: string = testLineId) => {
+    setSystemTime(timestamp)
+    expect((await sendReportRequest({ stationId, lineId, source: 'telegram' })).status).toBe(200)
 }
 
 const toIsoSeconds = (value: DateTime) => value.toUTC().toISO({ suppressMilliseconds: true })!
@@ -64,11 +52,15 @@ describe('Timeframe filtering', () => {
     beforeAll(async () => {
         await seedBaseData(db)
 
-        const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
         const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
-
-        testStationId = station.id
         testLineId = line.id
+
+        const [stationOnLine] = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, testLineId))
+            .limit(1)
+        testStationId = stationOnLine.stationId
     })
 
     beforeEach(async () => {
@@ -77,18 +69,17 @@ describe('Timeframe filtering', () => {
 
     afterEach(async () => {
         await db.delete(reports)
+        setSystemTime()
     })
 
     it('returns data in the specified timeframe when from and to query params are present', async () => {
         const now = DateTime.now().toUTC()
-        const insideOne = now.minus({ minutes: 30 })
-        const insideTwo = now.minus({ minutes: 10 })
-        const outside = now.minus({ hours: 2 })
 
-        await createReportWithTimestamp(outside.toJSDate())
-        await createReportWithTimestamp(insideOne.toJSDate())
-        await createReportWithTimestamp(insideTwo.toJSDate())
+        await sendReportAt(now.minus({ hours: 2 }).toJSDate())
+        await sendReportAt(now.minus({ minutes: 30 }).toJSDate())
+        await sendReportAt(now.minus({ minutes: 10 }).toJSDate())
 
+        setSystemTime(now.toJSDate())
         const from = now.minus({ minutes: 45 }).toISO()
         const to = now.minus({ minutes: 5 }).toISO()
 
@@ -114,12 +105,10 @@ describe('Timeframe filtering', () => {
         const now = DateTime.now().toUTC()
         const { from, to } = getDefaultReportsRange(now)
 
-        const older = from.minus({ minutes: 10 })
-        const inside = from.plus({ minutes: 10 })
+        await sendReportAt(from.minus({ minutes: 10 }).toJSDate())
+        await sendReportAt(from.plus({ minutes: 10 }).toJSDate())
 
-        await createReportWithTimestamp(older.toJSDate())
-        await createReportWithTimestamp(inside.toJSDate())
-
+        setSystemTime(now.toJSDate())
         const response = await app.request('/v0/reports')
 
         expect(response.status).toBe(200)
@@ -184,6 +173,7 @@ describe('Predicted reports', () => {
 
     afterEach(async () => {
         await db.delete(reports)
+        setSystemTime()
     })
 
     it('ensures predicted reports have unique station IDs and do not overlap with real reports', async () => {
@@ -313,31 +303,28 @@ describe('Predicted reports', () => {
     it('predicts the most frequently reported station for a given time pattern', async () => {
         // Create a clear pattern: Station A reported 5 times on Mondays at 3pm
         // Station B reported 2 times on Mondays at 3pm
+        const now = DateTime.now().toUTC()
         const stationA = allStationIds[0]
         const stationB = allStationIds[1]
 
         // Get a Monday at 3pm (15:00) in the past for historical data
-        const historicalMonday = DateTime.now()
-            .toUTC()
+        const historicalMonday = now
             .minus({ weeks: 1 })
             .set({ weekday: 1, hour: 15, minute: 0, second: 0, millisecond: 0 })
 
         // Create 5 reports for station A
         for (let i = 0; i < 5; i++) {
-            await createReportWithTimestamp(historicalMonday.minus({ minutes: i }).toJSDate(), stationA, testLineId)
+            await sendReportAt(historicalMonday.minus({ minutes: i }).toJSDate(), stationA, testLineId)
         }
 
         // Create 2 reports for station B
         for (let i = 0; i < 2; i++) {
-            await createReportWithTimestamp(
-                historicalMonday.minus({ minutes: i + 10 }).toJSDate(),
-                stationB,
-                testLineId
-            )
+            await sendReportAt(historicalMonday.minus({ minutes: i + 10 }).toJSDate(), stationB, testLineId)
         }
 
         // Now query for current Monday at 3pm (should trigger predictions based on historical data)
-        const currentMonday = DateTime.now().toUTC().set({ weekday: 1, hour: 15, minute: 0, second: 0, millisecond: 0 })
+        setSystemTime(now.toJSDate())
+        const currentMonday = now.set({ weekday: 1, hour: 15, minute: 0, second: 0, millisecond: 0 })
 
         const from = currentMonday.minus({ minutes: 30 })
         const to = currentMonday.plus({ minutes: 30 })
@@ -364,22 +351,21 @@ describe('Predicted reports', () => {
     })
 
     it('uses expanding time windows when no exact match is found', async () => {
+        const now = DateTime.now().toUTC()
         const stationA = allStationIds[0]
 
         // Create reports on Tuesday at 10am (2 days and 5 hours away from target)
-        const historicalTuesday = DateTime.now()
-            .toUTC()
+        const historicalTuesday = now
             .minus({ weeks: 1 })
             .set({ weekday: 2, hour: 10, minute: 0, second: 0, millisecond: 0 })
 
         for (let i = 0; i < 3; i++) {
-            await createReportWithTimestamp(historicalTuesday.minus({ minutes: i }).toJSDate(), stationA, testLineId)
+            await sendReportAt(historicalTuesday.minus({ minutes: i }).toJSDate(), stationA, testLineId)
         }
 
         // Query for Thursday at 3pm (requires expanding window to find Tuesday 10am reports)
-        const currentThursday = DateTime.now()
-            .toUTC()
-            .set({ weekday: 4, hour: 15, minute: 0, second: 0, millisecond: 0 })
+        setSystemTime(now.toJSDate())
+        const currentThursday = now.set({ weekday: 4, hour: 15, minute: 0, second: 0, millisecond: 0 })
 
         const from = currentThursday.minus({ minutes: 30 })
         const to = currentThursday.plus({ minutes: 30 })
@@ -416,11 +402,12 @@ describe('Predicted reports threshold', () => {
                             days: dayOffset,
                             minutes: stationIdx * 2,
                         })
-                        await createReportWithTimestamp(historicalTime.toJSDate(), testStations[stationIdx], testLineId)
+                        await sendReportAt(historicalTime.toJSDate(), testStations[stationIdx], testLineId)
                     }
                 }
             }
         }
+        setSystemTime()
     }
 
     beforeAll(async () => {
@@ -448,6 +435,7 @@ describe('Predicted reports threshold', () => {
         await db.delete(reports)
         // Reset time mocking after each test
         Settings.now = () => Date.now()
+        setSystemTime()
     })
 
     it('returns more predicted reports during peak hours than night hours', async () => {

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -740,23 +740,26 @@ describe('GET reports cache routing', () => {
         setSystemTime()
     })
 
-    it('reuses the default cache for plain and explicit rolling 1h requests within the ttl', async () => {
-        const now = DateTime.now().toUTC()
+    it('bypasses the default cache for explicit rolling 1h requests within the ttl', async () => {
+        const now = DateTime.utc(2024, 1, 15, 12, 0, 0)
         setSystemTime(now.toJSDate())
         const payload = await getValidReportPayload()
         const routeApp = createApp()
-        const writerApp = createApp()
 
-        expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
+        await sendReportAt(now.minus({ minutes: 30 }).toJSDate(), payload.stationId, payload.lineId)
+
+        setSystemTime(now.toJSDate())
 
         const first = await appRequestWithRedirect('/reports', undefined, routeApp)
         expect(first.status).toBe(200)
         expect(first.headers.get('Cache-Control')).toBe('no-store')
         expect((await getRealReports(first)).length).toBe(1)
 
-        expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
-        const to = now.minus({ minutes: 4 })
-        const from = to.minus(DEFAULT_REPORTS_TIMEFRAME)
+        await sendReportAt(now.minus({ minutes: 10 }).toJSDate(), payload.stationId, payload.lineId)
+
+        setSystemTime(now.toJSDate())
+        const to = now
+        const from = now.minus(DEFAULT_REPORTS_TIMEFRAME)
 
         const second = await appRequestWithRedirect(
             `/reports?from=${encodeURIComponent(toIsoSeconds(from))}&to=${encodeURIComponent(toIsoSeconds(to))}`,
@@ -765,7 +768,7 @@ describe('GET reports cache routing', () => {
         )
 
         expect(second.status).toBe(200)
-        expect((await getRealReports(second)).length).toBe(1)
+        expect((await getRealReports(second)).length).toBe(2)
     })
 
     it('refreshes the default cache after the ttl expires', async () => {

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -681,7 +681,7 @@ describe('Reports by station route', () => {
         setSystemTime(now.toJSDate())
 
         const response = await appRequestWithRedirect(
-            `/v0/reports/${stationOneId}?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+            `/reports/${stationOneId}?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
         )
 
         expect(response.status).toBe(200)
@@ -712,7 +712,7 @@ describe('Reports by station route', () => {
         const to = mondayNoon.plus({ hours: 1 })
 
         const response = await appRequestWithRedirect(
-            `/v0/reports/${stationOneId}?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+            `/reports/${stationOneId}?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
         )
 
         expect(response.status).toBe(200)
@@ -750,7 +750,7 @@ describe('GET reports cache routing', () => {
 
         expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
 
-        const first = await routeApp.request('/v0/reports')
+        const first = await appRequestWithRedirect('/reports', undefined, routeApp)
         expect(first.status).toBe(200)
         expect(first.headers.get('Cache-Control')).toBe('no-store')
         expect((await getRealReports(first)).length).toBe(1)
@@ -759,8 +759,10 @@ describe('GET reports cache routing', () => {
         const to = now.minus({ minutes: 4 })
         const from = to.minus(DEFAULT_REPORTS_TIMEFRAME)
 
-        const second = await routeApp.request(
-            `/v0/reports?from=${encodeURIComponent(toIsoSeconds(from))}&to=${encodeURIComponent(toIsoSeconds(to))}`
+        const second = await appRequestWithRedirect(
+            `/reports?from=${encodeURIComponent(toIsoSeconds(from))}&to=${encodeURIComponent(toIsoSeconds(to))}`,
+            undefined,
+            routeApp
         )
 
         expect(second.status).toBe(200)
@@ -776,14 +778,14 @@ describe('GET reports cache routing', () => {
 
         expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
 
-        const first = await routeApp.request('/v0/reports')
+        const first = await appRequestWithRedirect('/reports', undefined, routeApp)
         expect(first.status).toBe(200)
         expect((await getRealReports(first)).length).toBe(1)
 
         expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
         setSystemTime(now.plus({ milliseconds: REPORTS_CACHE_TTL_MS + 1 }).toJSDate())
 
-        const second = await routeApp.request('/v0/reports')
+        const second = await appRequestWithRedirect('/reports', undefined, routeApp)
         expect(second.status).toBe(200)
         expect((await getRealReports(second)).length).toBe(2)
     })
@@ -797,7 +799,7 @@ describe('GET reports cache routing', () => {
 
         expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
 
-        const first = await routeApp.request('/v0/reports')
+        const first = await appRequestWithRedirect('/reports', undefined, routeApp)
         expect(first.status).toBe(200)
         expect((await getRealReports(first)).length).toBe(1)
 
@@ -805,8 +807,10 @@ describe('GET reports cache routing', () => {
         const to = now
         const from = now.minus({ minutes: 30 })
 
-        const response = await routeApp.request(
-            `/v0/reports?from=${encodeURIComponent(toIsoSeconds(from))}&to=${encodeURIComponent(toIsoSeconds(to))}`
+        const response = await appRequestWithRedirect(
+            `/reports?from=${encodeURIComponent(toIsoSeconds(from))}&to=${encodeURIComponent(toIsoSeconds(to))}`,
+            undefined,
+            routeApp
         )
 
         expect(response.status).toBe(200)
@@ -822,14 +826,14 @@ describe('GET reports cache routing', () => {
 
         expect((await sendReportRequest(payload, routeApp)).status).toBe(200)
 
-        const first = await routeApp.request('/v0/reports')
+        const first = await appRequestWithRedirect('/reports', undefined, routeApp)
         expect(first.status).toBe(200)
         expect((await getRealReports(first)).length).toBe(1)
 
         const postResponse = await sendReportRequest(payload, routeApp)
         expect(postResponse.status).toBe(200)
 
-        const second = await routeApp.request('/v0/reports')
+        const second = await appRequestWithRedirect('/reports', undefined, routeApp)
         expect(second.status).toBe(200)
         expect((await getRealReports(second)).length).toBe(2)
     })

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -1,12 +1,16 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, setSystemTime } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { DateTime, Settings } from 'luxon'
 
 import { db, lineStations, lines, reports, stations } from '../src/db'
 import { seedBaseData } from '../src/db/seed/seed'
-import app from '../src/index'
-
-import { getDefaultReportsRange, MAX_REPORTS_TIMEFRAME } from '../src/modules/reports/constants'
+import app, { createApp } from '../src/index'
+import {
+    DEFAULT_REPORTS_TIMEFRAME,
+    getDefaultReportsRange,
+    MAX_REPORTS_TIMEFRAME,
+    REPORTS_CACHE_TTL_MS,
+} from '../src/modules/reports/constants'
 import { sendReportRequest } from './test-utils'
 
 let testStationId: string
@@ -27,6 +31,33 @@ const createReportWithTimestamp = async (
         timestamp,
         source: 'telegram',
     })
+}
+
+const toIsoSeconds = (value: DateTime) => value.toUTC().toISO({ suppressMilliseconds: true })!
+
+const getRealReports = async (response: Response) => {
+    const body = (await response.json()) as Array<{
+        timestamp: string
+        stationId: string
+        isPredicted: boolean
+    }>
+
+    return body.filter((report) => !report.isPredicted)
+}
+
+const getValidReportPayload = async () => {
+    const [stationOnLine] = await db
+        .select({ stationId: lineStations.stationId })
+        .from(lineStations)
+        .where(eq(lineStations.lineId, testLineId))
+        .limit(1)
+
+    return {
+        stationId: stationOnLine.stationId,
+        lineId: testLineId,
+        directionId: stationOnLine.stationId,
+        source: 'telegram' as const,
+    }
 }
 
 describe('Timeframe filtering', () => {
@@ -612,119 +643,106 @@ describe('Predicted reports threshold', () => {
     })
 })
 
-describe('Last-Modified / If-Modified-Since caching', () => {
-    let cachingStationId: string
-    let cachingLineId: string
-
-    const reportPayload = () => ({
-        stationId: cachingStationId,
-        lineId: cachingLineId,
-        directionId: cachingStationId,
-        source: 'telegram',
-    })
-
-    const get = (headers?: Record<string, string>) =>
-        headers ? app.request('/v0/reports', { headers }) : app.request('/v0/reports')
-
-    beforeAll(async () => {
-        await seedBaseData(db)
-        const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
-        cachingLineId = line.id
-        // Pick a station that's actually on the selected line so postProcessReport doesn't clear it
-        const [stationOnLine] = await db
-            .select({ stationId: lineStations.stationId })
-            .from(lineStations)
-            .where(eq(lineStations.lineId, cachingLineId))
-            .limit(1)
-        cachingStationId = stationOnLine.stationId
-    })
-
+describe('GET reports cache routing', () => {
     beforeEach(async () => {
         await db.delete(reports)
     })
 
-    afterEach(async () => {
-        await db.delete(reports)
+    afterEach(() => {
         Settings.now = () => Date.now()
+        setSystemTime()
     })
 
-    it('includes Last-Modified in the response when reports exist', async () => {
-        await sendReportRequest(reportPayload())
+    it('reuses the default cache for plain and explicit rolling 1h requests within the ttl', async () => {
+        const now = DateTime.now().toUTC()
+        setSystemTime(now.toJSDate())
+        const payload = await getValidReportPayload()
+        const routeApp = createApp()
+        const writerApp = createApp()
 
-        const response = await get()
+        expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
+
+        const first = await routeApp.request('/v0/reports')
+        expect(first.status).toBe(200)
+        expect(first.headers.get('Cache-Control')).toBe('no-store')
+        expect((await getRealReports(first)).length).toBe(1)
+
+        expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
+        const to = now.minus({ minutes: 4 })
+        const from = to.minus(DEFAULT_REPORTS_TIMEFRAME)
+
+        const second = await routeApp.request(
+            `/v0/reports?from=${encodeURIComponent(toIsoSeconds(from))}&to=${encodeURIComponent(toIsoSeconds(to))}`
+        )
+
+        expect(second.status).toBe(200)
+        expect((await getRealReports(second)).length).toBe(1)
+    })
+
+    it('refreshes the default cache after the ttl expires', async () => {
+        const now = DateTime.now().toUTC()
+        setSystemTime(now.toJSDate())
+        const payload = await getValidReportPayload()
+        const routeApp = createApp()
+        const writerApp = createApp()
+
+        expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
+
+        const first = await routeApp.request('/v0/reports')
+        expect(first.status).toBe(200)
+        expect((await getRealReports(first)).length).toBe(1)
+
+        expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
+        setSystemTime(now.plus({ milliseconds: REPORTS_CACHE_TTL_MS + 1 }).toJSDate())
+
+        const second = await routeApp.request('/v0/reports')
+        expect(second.status).toBe(200)
+        expect((await getRealReports(second)).length).toBe(2)
+    })
+
+    it('bypasses the default cache for non-default ranges', async () => {
+        const now = DateTime.now().toUTC()
+        setSystemTime(now.toJSDate())
+        const payload = await getValidReportPayload()
+        const routeApp = createApp()
+        const writerApp = createApp()
+
+        expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
+
+        const first = await routeApp.request('/v0/reports')
+        expect(first.status).toBe(200)
+        expect((await getRealReports(first)).length).toBe(1)
+
+        expect((await sendReportRequest(payload, writerApp)).status).toBe(200)
+        const to = now
+        const from = now.minus({ minutes: 30 })
+
+        const response = await routeApp.request(
+            `/v0/reports?from=${encodeURIComponent(toIsoSeconds(from))}&to=${encodeURIComponent(toIsoSeconds(to))}`
+        )
 
         expect(response.status).toBe(200)
-        expect(response.headers.get('Last-Modified')).not.toBeNull()
+        expect((await getRealReports(response)).length).toBe(2)
     })
 
-    it('returns 304 with an empty body when If-Modified-Since matches Last-Modified', async () => {
-        await sendReportRequest(reportPayload())
+    it('invalidates the default cache after posting a report through the api', async () => {
+        const now = DateTime.now().toUTC()
+        setSystemTime(now.toJSDate())
+        const payload = await getValidReportPayload()
 
-        const first = await get()
-        const lastModified = first.headers.get('Last-Modified')!
+        const routeApp = createApp()
 
-        const second = await get({ 'If-Modified-Since': lastModified })
+        expect((await sendReportRequest(payload, routeApp)).status).toBe(200)
 
-        expect(second.status).toBe(304)
-        expect(second.headers.get('Last-Modified')).toBe(lastModified)
-        expect(await second.text()).toBe('')
-    })
+        const first = await routeApp.request('/v0/reports')
+        expect(first.status).toBe(200)
+        expect((await getRealReports(first)).length).toBe(1)
 
-    it('returns 200 with data when If-Modified-Since is after the latest report', async () => {
-        await sendReportRequest(reportPayload())
+        const postResponse = await sendReportRequest(payload, routeApp)
+        expect(postResponse.status).toBe(200)
 
-        const future = DateTime.now().plus({ hours: 1 }).toHTTP()!
-
-        const response = await get({ 'If-Modified-Since': future })
-
-        expect(response.status).toBe(200)
-        expect(response.headers.get('Last-Modified')).not.toBeNull()
-    })
-
-    it('returns 200 with Last-Modified when If-Modified-Since predates the latest report', async () => {
-        await sendReportRequest(reportPayload())
-
-        const past = DateTime.now().minus({ hours: 1 }).toHTTP()!
-
-        const response = await get({ 'If-Modified-Since': past })
-
-        expect(response.status).toBe(200)
-        expect(DateTime.fromHTTP(response.headers.get('Last-Modified')!) > DateTime.fromHTTP(past)).toBe(true)
-    })
-
-    it('returns 200 when If-Modified-Since is older than 5 minutes even without a new report', async () => {
-        await sendReportRequest(reportPayload())
-
-        const first = await get()
-        const lastModified = first.headers.get('Last-Modified')!
-
-        // Simulate 6 minutes passing with no new inserts.
-        // Pre-compute the millis before assigning — Settings.now must not call DateTime.now() itself
-        // or it will recurse infinitely since Luxon routes DateTime.now() through Settings.now.
-        const sixMinutesLater = DateTime.fromHTTP(lastModified)!.plus({ minutes: 6 }).toMillis()
-        Settings.now = () => sixMinutesLater
-
-        const response = await get({ 'If-Modified-Since': lastModified })
-        expect(response.status).toBe(200)
-    })
-
-    it('reflects a new report in Last-Modified and invalidates the client cache', async () => {
-        await sendReportRequest(reportPayload())
-
-        const first = await get()
-        const t1 = first.headers.get('Last-Modified')!
-
-        // HTTP-date has 1-second precision — wait long enough for the next second to tick over
-        // so that the second report gets a strictly later timestamp in HTTP-date format
-        await new Promise((r) => setTimeout(r, 1100))
-
-        await sendReportRequest(reportPayload())
-
-        // The previously valid If-Modified-Since is now stale → 200
-        const response = await get({ 'If-Modified-Since': t1 })
-        expect(response.status).toBe(200)
-
-        const t2 = response.headers.get('Last-Modified')!
-        expect(DateTime.fromHTTP(t2) > DateTime.fromHTTP(t1)).toBe(true)
+        const second = await routeApp.request('/v0/reports')
+        expect(second.status).toBe(200)
+        expect((await getRealReports(second)).length).toBe(2)
     })
 })

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -48,7 +48,6 @@ const getValidReportPayload = async () => {
     }
 }
 
-
 describe('Timeframe filtering', () => {
     beforeAll(async () => {
         await seedBaseData(db)

--- a/packages/hono-backend/tests/test-utils.ts
+++ b/packages/hono-backend/tests/test-utils.ts
@@ -1,7 +1,7 @@
 import app from '../src/index'
 
-export const sendReportRequest = async (payload: object) => {
-    return app.request('/v0/reports', {
+export const sendReportRequest = async (payload: object, routeApp = app) => {
+    return routeApp.request('/v0/reports', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Describe the issue:
We are requesting the reports every 30 sec on the client. For every request we would touch the database, serialize the data and return it to the client, even if the data did not change since the latest request.
This can create an issue, since the centralized has to handle a lot more transactions then needed, which can limit scalability.

## Explain how you solved the issue:
We are now storing the `private latestReportTimestamp: DateTime | undefined = undefined`. It will be updated on every `POST /v0/reports` request, based on the databases response.

For every `GET /v0/reports` request we are returning a `modified-since` header which contains the `latestReportTimestamp`. The client can use this timestamp to include a `if-modified-since` header for subsequent requests, the server compares `latestReportTimestamp` against the `if-modified-since` header, if the servers `latestReportTimestamp` is newer it will return `200` with the reports. If they match the server will return `304 not modified`. 

Since we are storing `latestReportTimestamp` server side, we now only have to request the database if there is actually new content. 

## Additional notes or considerations:
If the `if-modified-since` header that the client sends is older then 5 min, we are returning the data even if the header is still valid. I made this decision since otherwise if there are no new reports for a while, the existing data that is outside of the requested time window would not fade out.
For example:
- at 12:00 a client requests data for the past hour.
- the server returns with a report that is dated at 11:01 and at 11:59
- 2 min later at 12:02 the client requests data again, since no new report has been made in that time the client thinks the data is still valid. Which its not since the 11:01 report is now too old to be displayed.
- The client requests again at 12:05, here the server returns the entire data again even though there has not been a new report, just to inform the client that the 11:01 report is not valid anymore. 

So at the worst case we are accepting data that is 5 min stale. I know this is a little bit hacky but I could not find a better solution. If we run into issues with the database being too busy, I would suggest we track this caching mechanism and see how often we are hitting the cache/ missing it and can decide on a more stable caching mechanism based on this.