### PR TITLE
refactor: replace `createReportWithTimestamp`

### DIFF
--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -250,7 +250,7 @@ export class ReportsService {
             timestamp: Date
         }
     }> {
-        const [insertedReport] = await this.db.insert(reports).values(reportData).returning({
+        const [insertedReport] = await this.db.insert(reports).values({ ...reportData, timestamp: DateTime.utc().toJSDate() }).returning({
             reportId: reports.reportId,
             stationId: reports.stationId,
             lineId: reports.lineId,

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -250,13 +250,16 @@ export class ReportsService {
             timestamp: Date
         }
     }> {
-        const [insertedReport] = await this.db.insert(reports).values({ ...reportData, timestamp: DateTime.utc().toJSDate() }).returning({
-            reportId: reports.reportId,
-            stationId: reports.stationId,
-            lineId: reports.lineId,
-            directionId: reports.directionId,
-            timestamp: reports.timestamp,
-        })
+        const [insertedReport] = await this.db
+            .insert(reports)
+            .values({ ...reportData, timestamp: DateTime.utc().toJSDate() })
+            .returning({
+                reportId: reports.reportId,
+                stationId: reports.stationId,
+                lineId: reports.lineId,
+                directionId: reports.directionId,
+                timestamp: reports.timestamp,
+            })
         // Drizzle returns the inserted row for Postgres. If this ever becomes undefined, we want to surface it fast.
         const report = insertedReport!
 


### PR DESCRIPTION
## Describe the issue:
We were using the `createReportWithTimestamp` function, which would allow us to add reports in tests at a later time. The issue with this was that we would add them directly to the database since the API does not accept a timestamp parameter. This means that we would essentially mock the POST reports API endpoint instead of actually using it, moving the test environment a little out of touch with the actual production environment.

## Explain how you solved the issue:
Instead we are now just using `Settings.now` to set the local time of the system, this means we just simulate the wait time and submit the report via the API. This makes the tests a little more realistic and thus more reliable. 

## Notes:
We are now passing the local time from the server to the database for the `timestamp` creation of the report, instead of relying on the timestamp support by postgres. This is necessary so that the `Settings.now` work.

