### PR TITLE
feat: run the risk model

### DIFF
--- a/packages/hono-backend/Dockerfile
+++ b/packages/hono-backend/Dockerfile
@@ -4,6 +4,13 @@ WORKDIR /app
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+COPY . .
+
+# Pre-warm the uv cache so the first request doesn't pay the install cost
+RUN uv run src/modules/risk/risk_model.py < /dev/null || true
+
 EXPOSE 3000
 
 CMD ["bun", "run", "--hot", "src/index.ts"]

--- a/packages/hono-backend/Dockerfile
+++ b/packages/hono-backend/Dockerfile
@@ -8,8 +8,11 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 COPY . .
 
-# Pre-warm the uv cache so the first request doesn't pay the install cost
-RUN uv run src/modules/risk/risk_model.py < /dev/null || true
+# Pre-warm the uv cache so the first request doesn't pay the install cost.
+# Empty-but-valid input lets the script run to completion (exit 0), so a
+# failed dependency download correctly aborts the build instead of being
+# swallowed by || true.
+RUN echo '{"segments":[],"reports":[]}' | uv run src/modules/risk/risk_model.py
 
 EXPOSE 3000
 

--- a/packages/hono-backend/drizzle/0000_modern_runaways.sql
+++ b/packages/hono-backend/drizzle/0000_modern_runaways.sql
@@ -39,6 +39,7 @@ CREATE TABLE "segments" (
 	"line_id" varchar(16) NOT NULL,
 	"from_station_id" varchar(16) NOT NULL,
 	"to_station_id" varchar(16) NOT NULL,
+	"position" integer NOT NULL,
 	"color" varchar(7) NOT NULL,
 	"coordinates" jsonb NOT NULL
 );

--- a/packages/hono-backend/drizzle/0000_modern_runaways.sql
+++ b/packages/hono-backend/drizzle/0000_modern_runaways.sql
@@ -45,4 +45,5 @@ CREATE TABLE "segments" (
 --> statement-breakpoint
 ALTER TABLE "segments" ADD CONSTRAINT "segments_line_id_lines_id_fk" FOREIGN KEY ("line_id") REFERENCES "public"."lines"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "segments" ADD CONSTRAINT "segments_from_station_id_stations_id_fk" FOREIGN KEY ("from_station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "segments" ADD CONSTRAINT "segments_to_station_id_stations_id_fk" FOREIGN KEY ("to_station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "segments" ADD CONSTRAINT "segments_to_station_id_stations_id_fk" FOREIGN KEY ("to_station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "segments_line_from_to_idx" ON "segments" USING btree ("line_id","from_station_id","to_station_id");

--- a/packages/hono-backend/drizzle/0000_modern_runaways.sql
+++ b/packages/hono-backend/drizzle/0000_modern_runaways.sql
@@ -33,3 +33,16 @@ ALTER TABLE "line_stations" ADD CONSTRAINT "line_stations_station_id_stations_id
 ALTER TABLE "reports" ADD CONSTRAINT "reports_station_id_stations_id_fk" FOREIGN KEY ("station_id") REFERENCES "public"."stations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "reports" ADD CONSTRAINT "reports_line_id_lines_id_fk" FOREIGN KEY ("line_id") REFERENCES "public"."lines"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "reports" ADD CONSTRAINT "reports_direction_id_stations_id_fk" FOREIGN KEY ("direction_id") REFERENCES "public"."stations"("id") ON DELETE no action ON UPDATE no action;
+
+CREATE TABLE "segments" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"line_id" varchar(16) NOT NULL,
+	"from_station_id" varchar(16) NOT NULL,
+	"to_station_id" varchar(16) NOT NULL,
+	"color" varchar(7) NOT NULL,
+	"coordinates" jsonb NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "segments" ADD CONSTRAINT "segments_line_id_lines_id_fk" FOREIGN KEY ("line_id") REFERENCES "public"."lines"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "segments" ADD CONSTRAINT "segments_from_station_id_stations_id_fk" FOREIGN KEY ("from_station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "segments" ADD CONSTRAINT "segments_to_station_id_stations_id_fk" FOREIGN KEY ("to_station_id") REFERENCES "public"."stations"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/hono-backend/drizzle/meta/0000_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0000_snapshot.json
@@ -1,219 +1,336 @@
 {
-    "id": "16f44466-7915-4d16-881c-b5f8b3661843",
-    "prevId": "00000000-0000-0000-0000-000000000000",
+    "id": "565c8c91-131e-4a5d-8082-770a5a594eda",
+    "prevId": "16f44466-7915-4d16-881c-b5f8b3661843",
     "version": "7",
     "dialect": "postgresql",
     "tables": {
-        "public.line_stations": {
-            "name": "line_stations",
-            "schema": "",
-            "columns": {
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "station_id": {
-                    "name": "station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "order": {
-                    "name": "order",
-                    "type": "integer",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "line_stations_line_id_lines_id_fk": {
-                    "name": "line_stations_line_id_lines_id_fk",
-                    "tableFrom": "line_stations",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                },
-                "line_stations_station_id_stations_id_fk": {
-                    "name": "line_stations_station_id_stations_id_fk",
-                    "tableFrom": "line_stations",
-                    "tableTo": "stations",
-                    "columnsFrom": ["station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {
-                "line_stations_line_id_station_id_pk": {
-                    "name": "line_stations_line_id_station_id_pk",
-                    "columns": ["line_id", "station_id"]
-                }
-            },
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+      "public.line_stations": {
+        "name": "line_stations",
+        "schema": "",
+        "columns": {
+          "line_id": {
+            "name": "line_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "station_id": {
+            "name": "station_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "order": {
+            "name": "order",
+            "type": "integer",
+            "primaryKey": false,
+            "notNull": true
+          }
         },
-        "public.lines": {
-            "name": "lines",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "varchar(16)",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "name": {
-                    "name": "name",
-                    "type": "varchar(255)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "is_circular": {
-                    "name": "is_circular",
-                    "type": "boolean",
-                    "primaryKey": false,
-                    "notNull": true,
-                    "default": false
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {},
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+        "indexes": {},
+        "foreignKeys": {
+          "line_stations_line_id_lines_id_fk": {
+            "name": "line_stations_line_id_lines_id_fk",
+            "tableFrom": "line_stations",
+            "tableTo": "lines",
+            "columnsFrom": [
+              "line_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "cascade",
+            "onUpdate": "no action"
+          },
+          "line_stations_station_id_stations_id_fk": {
+            "name": "line_stations_station_id_stations_id_fk",
+            "tableFrom": "line_stations",
+            "tableTo": "stations",
+            "columnsFrom": [
+              "station_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "cascade",
+            "onUpdate": "no action"
+          }
         },
-        "public.reports": {
-            "name": "reports",
-            "schema": "",
-            "columns": {
-                "report_id": {
-                    "name": "report_id",
-                    "type": "serial",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "station_id": {
-                    "name": "station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": false
-                },
-                "direction_id": {
-                    "name": "direction_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": false
-                },
-                "timestamp": {
-                    "name": "timestamp",
-                    "type": "timestamp",
-                    "primaryKey": false,
-                    "notNull": true,
-                    "default": "now()"
-                },
-                "source": {
-                    "name": "source",
-                    "type": "source",
-                    "typeSchema": "public",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "reports_station_id_stations_id_fk": {
-                    "name": "reports_station_id_stations_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "stations",
-                    "columnsFrom": ["station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                },
-                "reports_line_id_lines_id_fk": {
-                    "name": "reports_line_id_lines_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                },
-                "reports_direction_id_stations_id_fk": {
-                    "name": "reports_direction_id_stations_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "stations",
-                    "columnsFrom": ["direction_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+        "compositePrimaryKeys": {
+          "line_stations_line_id_station_id_pk": {
+            "name": "line_stations_line_id_station_id_pk",
+            "columns": [
+              "line_id",
+              "station_id"
+            ]
+          }
         },
-        "public.stations": {
-            "name": "stations",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "varchar(16)",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "name": {
-                    "name": "name",
-                    "type": "varchar(255)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "lat": {
-                    "name": "lat",
-                    "type": "double precision",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "lng": {
-                    "name": "lng",
-                    "type": "double precision",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {},
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
-        }
+        "uniqueConstraints": {},
+        "policies": {},
+        "checkConstraints": {},
+        "isRLSEnabled": false
+      },
+      "public.lines": {
+        "name": "lines",
+        "schema": "",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "varchar(16)",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "name": {
+            "name": "name",
+            "type": "varchar(255)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "is_circular": {
+            "name": "is_circular",
+            "type": "boolean",
+            "primaryKey": false,
+            "notNull": true,
+            "default": false
+          }
+        },
+        "indexes": {},
+        "foreignKeys": {},
+        "compositePrimaryKeys": {},
+        "uniqueConstraints": {},
+        "policies": {},
+        "checkConstraints": {},
+        "isRLSEnabled": false
+      },
+      "public.reports": {
+        "name": "reports",
+        "schema": "",
+        "columns": {
+          "report_id": {
+            "name": "report_id",
+            "type": "serial",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "station_id": {
+            "name": "station_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "line_id": {
+            "name": "line_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": false
+          },
+          "direction_id": {
+            "name": "direction_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": false
+          },
+          "timestamp": {
+            "name": "timestamp",
+            "type": "timestamp",
+            "primaryKey": false,
+            "notNull": true,
+            "default": "now()"
+          },
+          "source": {
+            "name": "source",
+            "type": "source",
+            "typeSchema": "public",
+            "primaryKey": false,
+            "notNull": true
+          }
+        },
+        "indexes": {},
+        "foreignKeys": {
+          "reports_station_id_stations_id_fk": {
+            "name": "reports_station_id_stations_id_fk",
+            "tableFrom": "reports",
+            "tableTo": "stations",
+            "columnsFrom": [
+              "station_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "no action",
+            "onUpdate": "no action"
+          },
+          "reports_line_id_lines_id_fk": {
+            "name": "reports_line_id_lines_id_fk",
+            "tableFrom": "reports",
+            "tableTo": "lines",
+            "columnsFrom": [
+              "line_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "no action",
+            "onUpdate": "no action"
+          },
+          "reports_direction_id_stations_id_fk": {
+            "name": "reports_direction_id_stations_id_fk",
+            "tableFrom": "reports",
+            "tableTo": "stations",
+            "columnsFrom": [
+              "direction_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "no action",
+            "onUpdate": "no action"
+          }
+        },
+        "compositePrimaryKeys": {},
+        "uniqueConstraints": {},
+        "policies": {},
+        "checkConstraints": {},
+        "isRLSEnabled": false
+      },
+      "public.segments": {
+        "name": "segments",
+        "schema": "",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "serial",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "line_id": {
+            "name": "line_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "from_station_id": {
+            "name": "from_station_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "to_station_id": {
+            "name": "to_station_id",
+            "type": "varchar(16)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "color": {
+            "name": "color",
+            "type": "varchar(7)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "coordinates": {
+            "name": "coordinates",
+            "type": "jsonb",
+            "primaryKey": false,
+            "notNull": true
+          }
+        },
+        "indexes": {},
+        "foreignKeys": {
+          "segments_line_id_lines_id_fk": {
+            "name": "segments_line_id_lines_id_fk",
+            "tableFrom": "segments",
+            "tableTo": "lines",
+            "columnsFrom": [
+              "line_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "cascade",
+            "onUpdate": "no action"
+          },
+          "segments_from_station_id_stations_id_fk": {
+            "name": "segments_from_station_id_stations_id_fk",
+            "tableFrom": "segments",
+            "tableTo": "stations",
+            "columnsFrom": [
+              "from_station_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "cascade",
+            "onUpdate": "no action"
+          },
+          "segments_to_station_id_stations_id_fk": {
+            "name": "segments_to_station_id_stations_id_fk",
+            "tableFrom": "segments",
+            "tableTo": "stations",
+            "columnsFrom": [
+              "to_station_id"
+            ],
+            "columnsTo": [
+              "id"
+            ],
+            "onDelete": "cascade",
+            "onUpdate": "no action"
+          }
+        },
+        "compositePrimaryKeys": {},
+        "uniqueConstraints": {},
+        "policies": {},
+        "checkConstraints": {},
+        "isRLSEnabled": false
+      },
+      "public.stations": {
+        "name": "stations",
+        "schema": "",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "varchar(16)",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "name": {
+            "name": "name",
+            "type": "varchar(255)",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "lat": {
+            "name": "lat",
+            "type": "double precision",
+            "primaryKey": false,
+            "notNull": true
+          },
+          "lng": {
+            "name": "lng",
+            "type": "double precision",
+            "primaryKey": false,
+            "notNull": true
+          }
+        },
+        "indexes": {},
+        "foreignKeys": {},
+        "compositePrimaryKeys": {},
+        "uniqueConstraints": {},
+        "policies": {},
+        "checkConstraints": {},
+        "isRLSEnabled": false
+      }
     },
     "enums": {
-        "public.source": {
-            "name": "source",
-            "schema": "public",
-            "values": ["mini_app", "web_app", "mobile_app", "telegram"]
-        }
+      "public.source": {
+        "name": "source",
+        "schema": "public",
+        "values": [
+          "mini_app",
+          "web_app",
+          "mobile_app",
+          "telegram"
+        ]
+      }
     },
     "schemas": {},
     "sequences": {},
@@ -221,8 +338,8 @@
     "policies": {},
     "views": {},
     "_meta": {
-        "columns": {},
-        "schemas": {},
-        "tables": {}
+      "columns": {},
+      "schemas": {},
+      "tables": {}
     }
-}
+  }

--- a/packages/hono-backend/drizzle/meta/0000_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0000_snapshot.json
@@ -1,305 +1,373 @@
 {
-    "id": "565c8c91-131e-4a5d-8082-770a5a594eda",
-    "prevId": "16f44466-7915-4d16-881c-b5f8b3661843",
-    "version": "7",
-    "dialect": "postgresql",
-    "tables": {
-        "public.line_stations": {
-            "name": "line_stations",
-            "schema": "",
-            "columns": {
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "station_id": {
-                    "name": "station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "order": {
-                    "name": "order",
-                    "type": "integer",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "line_stations_line_id_lines_id_fk": {
-                    "name": "line_stations_line_id_lines_id_fk",
-                    "tableFrom": "line_stations",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                },
-                "line_stations_station_id_stations_id_fk": {
-                    "name": "line_stations_station_id_stations_id_fk",
-                    "tableFrom": "line_stations",
-                    "tableTo": "stations",
-                    "columnsFrom": ["station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {
-                "line_stations_line_id_station_id_pk": {
-                    "name": "line_stations_line_id_station_id_pk",
-                    "columns": ["line_id", "station_id"]
-                }
-            },
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+  "id": "c74cdf83-4a0d-4ed9-85c9-74fc979c3567",
+  "prevId": "565c8c91-131e-4a5d-8082-770a5a594eda",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.line_stations": {
+      "name": "line_stations",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
         },
-        "public.lines": {
-            "name": "lines",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "varchar(16)",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "name": {
-                    "name": "name",
-                    "type": "varchar(255)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "is_circular": {
-                    "name": "is_circular",
-                    "type": "boolean",
-                    "primaryKey": false,
-                    "notNull": true,
-                    "default": false
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {},
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+        "station_id": {
+          "name": "station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
         },
-        "public.reports": {
-            "name": "reports",
-            "schema": "",
-            "columns": {
-                "report_id": {
-                    "name": "report_id",
-                    "type": "serial",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "station_id": {
-                    "name": "station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": false
-                },
-                "direction_id": {
-                    "name": "direction_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": false
-                },
-                "timestamp": {
-                    "name": "timestamp",
-                    "type": "timestamp",
-                    "primaryKey": false,
-                    "notNull": true,
-                    "default": "now()"
-                },
-                "source": {
-                    "name": "source",
-                    "type": "source",
-                    "typeSchema": "public",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "reports_station_id_stations_id_fk": {
-                    "name": "reports_station_id_stations_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "stations",
-                    "columnsFrom": ["station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                },
-                "reports_line_id_lines_id_fk": {
-                    "name": "reports_line_id_lines_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                },
-                "reports_direction_id_stations_id_fk": {
-                    "name": "reports_direction_id_stations_id_fk",
-                    "tableFrom": "reports",
-                    "tableTo": "stations",
-                    "columnsFrom": ["direction_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "no action",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
-        },
-        "public.segments": {
-            "name": "segments",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "serial",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "line_id": {
-                    "name": "line_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "from_station_id": {
-                    "name": "from_station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "to_station_id": {
-                    "name": "to_station_id",
-                    "type": "varchar(16)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "color": {
-                    "name": "color",
-                    "type": "varchar(7)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "coordinates": {
-                    "name": "coordinates",
-                    "type": "jsonb",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {
-                "segments_line_id_lines_id_fk": {
-                    "name": "segments_line_id_lines_id_fk",
-                    "tableFrom": "segments",
-                    "tableTo": "lines",
-                    "columnsFrom": ["line_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                },
-                "segments_from_station_id_stations_id_fk": {
-                    "name": "segments_from_station_id_stations_id_fk",
-                    "tableFrom": "segments",
-                    "tableTo": "stations",
-                    "columnsFrom": ["from_station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                },
-                "segments_to_station_id_stations_id_fk": {
-                    "name": "segments_to_station_id_stations_id_fk",
-                    "tableFrom": "segments",
-                    "tableTo": "stations",
-                    "columnsFrom": ["to_station_id"],
-                    "columnsTo": ["id"],
-                    "onDelete": "cascade",
-                    "onUpdate": "no action"
-                }
-            },
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
-        },
-        "public.stations": {
-            "name": "stations",
-            "schema": "",
-            "columns": {
-                "id": {
-                    "name": "id",
-                    "type": "varchar(16)",
-                    "primaryKey": true,
-                    "notNull": true
-                },
-                "name": {
-                    "name": "name",
-                    "type": "varchar(255)",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "lat": {
-                    "name": "lat",
-                    "type": "double precision",
-                    "primaryKey": false,
-                    "notNull": true
-                },
-                "lng": {
-                    "name": "lng",
-                    "type": "double precision",
-                    "primaryKey": false,
-                    "notNull": true
-                }
-            },
-            "indexes": {},
-            "foreignKeys": {},
-            "compositePrimaryKeys": {},
-            "uniqueConstraints": {},
-            "policies": {},
-            "checkConstraints": {},
-            "isRLSEnabled": false
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
         }
-    },
-    "enums": {
-        "public.source": {
-            "name": "source",
-            "schema": "public",
-            "values": ["mini_app", "web_app", "mobile_app", "telegram"]
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_stations_line_id_lines_id_fk": {
+          "name": "line_stations_line_id_lines_id_fk",
+          "tableFrom": "line_stations",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "line_stations_station_id_stations_id_fk": {
+          "name": "line_stations_station_id_stations_id_fk",
+          "tableFrom": "line_stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
+      },
+      "compositePrimaryKeys": {
+        "line_stations_line_id_station_id_pk": {
+          "name": "line_stations_line_id_station_id_pk",
+          "columns": [
+            "line_id",
+            "station_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     },
-    "schemas": {},
-    "sequences": {},
-    "roles": {},
-    "policies": {},
-    "views": {},
-    "_meta": {
-        "columns": {},
-        "schemas": {},
-        "tables": {}
+    "public.lines": {
+      "name": "lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_circular": {
+          "name": "is_circular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "report_id": {
+          "name": "report_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction_id": {
+          "name": "direction_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_station_id_stations_id_fk": {
+          "name": "reports_station_id_stations_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_line_id_lines_id_fk": {
+          "name": "reports_line_id_lines_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_direction_id_stations_id_fk": {
+          "name": "reports_direction_id_stations_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "direction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_station_id": {
+          "name": "from_station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_station_id": {
+          "name": "to_station_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coordinates": {
+          "name": "coordinates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "segments_line_from_to_idx": {
+          "name": "segments_line_from_to_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "segments_line_id_lines_id_fk": {
+          "name": "segments_line_id_lines_id_fk",
+          "tableFrom": "segments",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segments_from_station_id_stations_id_fk": {
+          "name": "segments_from_station_id_stations_id_fk",
+          "tableFrom": "segments",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "from_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segments_to_station_id_stations_id_fk": {
+          "name": "segments_to_station_id_stations_id_fk",
+          "tableFrom": "segments",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "to_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     }
+  },
+  "enums": {
+    "public.source": {
+      "name": "source",
+      "schema": "public",
+      "values": [
+        "mini_app",
+        "web_app",
+        "mobile_app",
+        "telegram"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
 }

--- a/packages/hono-backend/drizzle/meta/0000_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0000_snapshot.json
@@ -198,6 +198,12 @@
                     "primaryKey": false,
                     "notNull": true
                 },
+                "position": {
+                    "name": "position",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
                 "color": {
                     "name": "color",
                     "type": "varchar(7)",

--- a/packages/hono-backend/drizzle/meta/0000_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0000_snapshot.json
@@ -1,373 +1,333 @@
 {
-  "id": "c74cdf83-4a0d-4ed9-85c9-74fc979c3567",
-  "prevId": "565c8c91-131e-4a5d-8082-770a5a594eda",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.line_stations": {
-      "name": "line_stations",
-      "schema": "",
-      "columns": {
-        "line_id": {
-          "name": "line_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "station_id": {
-          "name": "station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "order": {
-          "name": "order",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "line_stations_line_id_lines_id_fk": {
-          "name": "line_stations_line_id_lines_id_fk",
-          "tableFrom": "line_stations",
-          "tableTo": "lines",
-          "columnsFrom": [
-            "line_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "line_stations_station_id_stations_id_fk": {
-          "name": "line_stations_station_id_stations_id_fk",
-          "tableFrom": "line_stations",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "line_stations_line_id_station_id_pk": {
-          "name": "line_stations_line_id_station_id_pk",
-          "columns": [
-            "line_id",
-            "station_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.lines": {
-      "name": "lines",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(16)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "is_circular": {
-          "name": "is_circular",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.reports": {
-      "name": "reports",
-      "schema": "",
-      "columns": {
-        "report_id": {
-          "name": "report_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "station_id": {
-          "name": "station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "line_id": {
-          "name": "line_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "direction_id": {
-          "name": "direction_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "source": {
-          "name": "source",
-          "type": "source",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "reports_station_id_stations_id_fk": {
-          "name": "reports_station_id_stations_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "reports_line_id_lines_id_fk": {
-          "name": "reports_line_id_lines_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "lines",
-          "columnsFrom": [
-            "line_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "reports_direction_id_stations_id_fk": {
-          "name": "reports_direction_id_stations_id_fk",
-          "tableFrom": "reports",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "direction_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.segments": {
-      "name": "segments",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "line_id": {
-          "name": "line_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "from_station_id": {
-          "name": "from_station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "to_station_id": {
-          "name": "to_station_id",
-          "type": "varchar(16)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "color": {
-          "name": "color",
-          "type": "varchar(7)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "coordinates": {
-          "name": "coordinates",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "segments_line_from_to_idx": {
-          "name": "segments_line_from_to_idx",
-          "columns": [
-            {
-              "expression": "line_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
+    "id": "c74cdf83-4a0d-4ed9-85c9-74fc979c3567",
+    "prevId": "565c8c91-131e-4a5d-8082-770a5a594eda",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.line_stations": {
+            "name": "line_stations",
+            "schema": "",
+            "columns": {
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "order": {
+                    "name": "order",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                }
             },
-            {
-              "expression": "from_station_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
+            "indexes": {},
+            "foreignKeys": {
+                "line_stations_line_id_lines_id_fk": {
+                    "name": "line_stations_line_id_lines_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "line_stations_station_id_stations_id_fk": {
+                    "name": "line_stations_station_id_stations_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
             },
-            {
-              "expression": "to_station_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "segments_line_id_lines_id_fk": {
-          "name": "segments_line_id_lines_id_fk",
-          "tableFrom": "segments",
-          "tableTo": "lines",
-          "columnsFrom": [
-            "line_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+            "compositePrimaryKeys": {
+                "line_stations_line_id_station_id_pk": {
+                    "name": "line_stations_line_id_station_id_pk",
+                    "columns": ["line_id", "station_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "segments_from_station_id_stations_id_fk": {
-          "name": "segments_from_station_id_stations_id_fk",
-          "tableFrom": "segments",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "from_station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+        "public.lines": {
+            "name": "lines",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "is_circular": {
+                    "name": "is_circular",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "segments_to_station_id_stations_id_fk": {
-          "name": "segments_to_station_id_stations_id_fk",
-          "tableFrom": "segments",
-          "tableTo": "stations",
-          "columnsFrom": [
-            "to_station_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+        "public.reports": {
+            "name": "reports",
+            "schema": "",
+            "columns": {
+                "report_id": {
+                    "name": "report_id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "direction_id": {
+                    "name": "direction_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "timestamp": {
+                    "name": "timestamp",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "source": {
+                    "name": "source",
+                    "type": "source",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "reports_station_id_stations_id_fk": {
+                    "name": "reports_station_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_line_id_lines_id_fk": {
+                    "name": "reports_line_id_lines_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_direction_id_stations_id_fk": {
+                    "name": "reports_direction_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["direction_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.segments": {
+            "name": "segments",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "from_station_id": {
+                    "name": "from_station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "to_station_id": {
+                    "name": "to_station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "color": {
+                    "name": "color",
+                    "type": "varchar(7)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "coordinates": {
+                    "name": "coordinates",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "segments_line_from_to_idx": {
+                    "name": "segments_line_from_to_idx",
+                    "columns": [
+                        {
+                            "expression": "line_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "from_station_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "to_station_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "segments_line_id_lines_id_fk": {
+                    "name": "segments_line_id_lines_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "segments_from_station_id_stations_id_fk": {
+                    "name": "segments_from_station_id_stations_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "stations",
+                    "columnsFrom": ["from_station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "segments_to_station_id_stations_id_fk": {
+                    "name": "segments_to_station_id_stations_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "stations",
+                    "columnsFrom": ["to_station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.stations": {
+            "name": "stations",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lat": {
+                    "name": "lat",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lng": {
+                    "name": "lng",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     },
-    "public.stations": {
-      "name": "stations",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(16)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lat": {
-          "name": "lat",
-          "type": "double precision",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lng": {
-          "name": "lng",
-          "type": "double precision",
-          "primaryKey": false,
-          "notNull": true
+    "enums": {
+        "public.source": {
+            "name": "source",
+            "schema": "public",
+            "values": ["mini_app", "web_app", "mobile_app", "telegram"]
         }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {
-    "public.source": {
-      "name": "source",
-      "schema": "public",
-      "values": [
-        "mini_app",
-        "web_app",
-        "mobile_app",
-        "telegram"
-      ]
-    }
-  },
-  "schemas": {},
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
+    },
     "schemas": {},
-    "tables": {}
-  }
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
 }

--- a/packages/hono-backend/drizzle/meta/0000_snapshot.json
+++ b/packages/hono-backend/drizzle/meta/0000_snapshot.json
@@ -4,333 +4,293 @@
     "version": "7",
     "dialect": "postgresql",
     "tables": {
-      "public.line_stations": {
-        "name": "line_stations",
-        "schema": "",
-        "columns": {
-          "line_id": {
-            "name": "line_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "station_id": {
-            "name": "station_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "order": {
-            "name": "order",
-            "type": "integer",
-            "primaryKey": false,
-            "notNull": true
-          }
+        "public.line_stations": {
+            "name": "line_stations",
+            "schema": "",
+            "columns": {
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "order": {
+                    "name": "order",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "line_stations_line_id_lines_id_fk": {
+                    "name": "line_stations_line_id_lines_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "line_stations_station_id_stations_id_fk": {
+                    "name": "line_stations_station_id_stations_id_fk",
+                    "tableFrom": "line_stations",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "line_stations_line_id_station_id_pk": {
+                    "name": "line_stations_line_id_station_id_pk",
+                    "columns": ["line_id", "station_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "indexes": {},
-        "foreignKeys": {
-          "line_stations_line_id_lines_id_fk": {
-            "name": "line_stations_line_id_lines_id_fk",
-            "tableFrom": "line_stations",
-            "tableTo": "lines",
-            "columnsFrom": [
-              "line_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "cascade",
-            "onUpdate": "no action"
-          },
-          "line_stations_station_id_stations_id_fk": {
-            "name": "line_stations_station_id_stations_id_fk",
-            "tableFrom": "line_stations",
-            "tableTo": "stations",
-            "columnsFrom": [
-              "station_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "cascade",
-            "onUpdate": "no action"
-          }
+        "public.lines": {
+            "name": "lines",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "is_circular": {
+                    "name": "is_circular",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "compositePrimaryKeys": {
-          "line_stations_line_id_station_id_pk": {
-            "name": "line_stations_line_id_station_id_pk",
-            "columns": [
-              "line_id",
-              "station_id"
-            ]
-          }
+        "public.reports": {
+            "name": "reports",
+            "schema": "",
+            "columns": {
+                "report_id": {
+                    "name": "report_id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "station_id": {
+                    "name": "station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "direction_id": {
+                    "name": "direction_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "timestamp": {
+                    "name": "timestamp",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "source": {
+                    "name": "source",
+                    "type": "source",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "reports_station_id_stations_id_fk": {
+                    "name": "reports_station_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_line_id_lines_id_fk": {
+                    "name": "reports_line_id_lines_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                },
+                "reports_direction_id_stations_id_fk": {
+                    "name": "reports_direction_id_stations_id_fk",
+                    "tableFrom": "reports",
+                    "tableTo": "stations",
+                    "columnsFrom": ["direction_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "uniqueConstraints": {},
-        "policies": {},
-        "checkConstraints": {},
-        "isRLSEnabled": false
-      },
-      "public.lines": {
-        "name": "lines",
-        "schema": "",
-        "columns": {
-          "id": {
-            "name": "id",
-            "type": "varchar(16)",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "name": {
-            "name": "name",
-            "type": "varchar(255)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "is_circular": {
-            "name": "is_circular",
-            "type": "boolean",
-            "primaryKey": false,
-            "notNull": true,
-            "default": false
-          }
+        "public.segments": {
+            "name": "segments",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "line_id": {
+                    "name": "line_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "from_station_id": {
+                    "name": "from_station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "to_station_id": {
+                    "name": "to_station_id",
+                    "type": "varchar(16)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "color": {
+                    "name": "color",
+                    "type": "varchar(7)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "coordinates": {
+                    "name": "coordinates",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "segments_line_id_lines_id_fk": {
+                    "name": "segments_line_id_lines_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "lines",
+                    "columnsFrom": ["line_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "segments_from_station_id_stations_id_fk": {
+                    "name": "segments_from_station_id_stations_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "stations",
+                    "columnsFrom": ["from_station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "segments_to_station_id_stations_id_fk": {
+                    "name": "segments_to_station_id_stations_id_fk",
+                    "tableFrom": "segments",
+                    "tableTo": "stations",
+                    "columnsFrom": ["to_station_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
         },
-        "indexes": {},
-        "foreignKeys": {},
-        "compositePrimaryKeys": {},
-        "uniqueConstraints": {},
-        "policies": {},
-        "checkConstraints": {},
-        "isRLSEnabled": false
-      },
-      "public.reports": {
-        "name": "reports",
-        "schema": "",
-        "columns": {
-          "report_id": {
-            "name": "report_id",
-            "type": "serial",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "station_id": {
-            "name": "station_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "line_id": {
-            "name": "line_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": false
-          },
-          "direction_id": {
-            "name": "direction_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": false
-          },
-          "timestamp": {
-            "name": "timestamp",
-            "type": "timestamp",
-            "primaryKey": false,
-            "notNull": true,
-            "default": "now()"
-          },
-          "source": {
-            "name": "source",
-            "type": "source",
-            "typeSchema": "public",
-            "primaryKey": false,
-            "notNull": true
-          }
-        },
-        "indexes": {},
-        "foreignKeys": {
-          "reports_station_id_stations_id_fk": {
-            "name": "reports_station_id_stations_id_fk",
-            "tableFrom": "reports",
-            "tableTo": "stations",
-            "columnsFrom": [
-              "station_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "no action",
-            "onUpdate": "no action"
-          },
-          "reports_line_id_lines_id_fk": {
-            "name": "reports_line_id_lines_id_fk",
-            "tableFrom": "reports",
-            "tableTo": "lines",
-            "columnsFrom": [
-              "line_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "no action",
-            "onUpdate": "no action"
-          },
-          "reports_direction_id_stations_id_fk": {
-            "name": "reports_direction_id_stations_id_fk",
-            "tableFrom": "reports",
-            "tableTo": "stations",
-            "columnsFrom": [
-              "direction_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "no action",
-            "onUpdate": "no action"
-          }
-        },
-        "compositePrimaryKeys": {},
-        "uniqueConstraints": {},
-        "policies": {},
-        "checkConstraints": {},
-        "isRLSEnabled": false
-      },
-      "public.segments": {
-        "name": "segments",
-        "schema": "",
-        "columns": {
-          "id": {
-            "name": "id",
-            "type": "serial",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "line_id": {
-            "name": "line_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "from_station_id": {
-            "name": "from_station_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "to_station_id": {
-            "name": "to_station_id",
-            "type": "varchar(16)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "color": {
-            "name": "color",
-            "type": "varchar(7)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "coordinates": {
-            "name": "coordinates",
-            "type": "jsonb",
-            "primaryKey": false,
-            "notNull": true
-          }
-        },
-        "indexes": {},
-        "foreignKeys": {
-          "segments_line_id_lines_id_fk": {
-            "name": "segments_line_id_lines_id_fk",
-            "tableFrom": "segments",
-            "tableTo": "lines",
-            "columnsFrom": [
-              "line_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "cascade",
-            "onUpdate": "no action"
-          },
-          "segments_from_station_id_stations_id_fk": {
-            "name": "segments_from_station_id_stations_id_fk",
-            "tableFrom": "segments",
-            "tableTo": "stations",
-            "columnsFrom": [
-              "from_station_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "cascade",
-            "onUpdate": "no action"
-          },
-          "segments_to_station_id_stations_id_fk": {
-            "name": "segments_to_station_id_stations_id_fk",
-            "tableFrom": "segments",
-            "tableTo": "stations",
-            "columnsFrom": [
-              "to_station_id"
-            ],
-            "columnsTo": [
-              "id"
-            ],
-            "onDelete": "cascade",
-            "onUpdate": "no action"
-          }
-        },
-        "compositePrimaryKeys": {},
-        "uniqueConstraints": {},
-        "policies": {},
-        "checkConstraints": {},
-        "isRLSEnabled": false
-      },
-      "public.stations": {
-        "name": "stations",
-        "schema": "",
-        "columns": {
-          "id": {
-            "name": "id",
-            "type": "varchar(16)",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "name": {
-            "name": "name",
-            "type": "varchar(255)",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "lat": {
-            "name": "lat",
-            "type": "double precision",
-            "primaryKey": false,
-            "notNull": true
-          },
-          "lng": {
-            "name": "lng",
-            "type": "double precision",
-            "primaryKey": false,
-            "notNull": true
-          }
-        },
-        "indexes": {},
-        "foreignKeys": {},
-        "compositePrimaryKeys": {},
-        "uniqueConstraints": {},
-        "policies": {},
-        "checkConstraints": {},
-        "isRLSEnabled": false
-      }
+        "public.stations": {
+            "name": "stations",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar(16)",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar(255)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lat": {
+                    "name": "lat",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "lng": {
+                    "name": "lng",
+                    "type": "double precision",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
     },
     "enums": {
-      "public.source": {
-        "name": "source",
-        "schema": "public",
-        "values": [
-          "mini_app",
-          "web_app",
-          "mobile_app",
-          "telegram"
-        ]
-      }
+        "public.source": {
+            "name": "source",
+            "schema": "public",
+            "values": ["mini_app", "web_app", "mobile_app", "telegram"]
+        }
     },
     "schemas": {},
     "sequences": {},
@@ -338,8 +298,8 @@
     "policies": {},
     "views": {},
     "_meta": {
-      "columns": {},
-      "schemas": {},
-      "tables": {}
+        "columns": {},
+        "schemas": {},
+        "tables": {}
     }
-  }
+}

--- a/packages/hono-backend/drizzle/meta/_journal.json
+++ b/packages/hono-backend/drizzle/meta/_journal.json
@@ -1,13 +1,13 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1765472567170,
-      "tag": "0000_modern_runaways",
-      "breakpoints": true
-    }
-  ]
+    "version": "7",
+    "dialect": "postgresql",
+    "entries": [
+        {
+            "idx": 0,
+            "version": "7",
+            "when": 1765472567170,
+            "tag": "0000_modern_runaways",
+            "breakpoints": true
+        }
+    ]
 }

--- a/packages/hono-backend/drizzle/meta/_journal.json
+++ b/packages/hono-backend/drizzle/meta/_journal.json
@@ -1,13 +1,13 @@
 {
-    "version": "7",
-    "dialect": "postgresql",
-    "entries": [
-        {
-            "idx": 0,
-            "version": "7",
-            "when": 1765472567170,
-            "tag": "0000_modern_runaways",
-            "breakpoints": true
-        }
-    ]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1765472567170,
+      "tag": "0000_modern_runaways",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/hono-backend/package.json
+++ b/packages/hono-backend/package.json
@@ -13,7 +13,7 @@
         "db:studio": "drizzle-kit studio",
         "db:drop": "drizzle-kit drop",
         "db:seed": "bun run src/db/seed/index.ts",
-        "db:reset": "psql $DATABASE_URL -c 'DROP SCHEMA public CASCADE; DROP SCHEMA drizzle CASCADE; CREATE SCHEMA public;' && drizzle-kit migrate && bun run src/db/seed/index.ts"
+        "db:dangerously-reset-do-not-run-in-production": "psql $DATABASE_URL -c 'DROP SCHEMA public CASCADE; DROP SCHEMA drizzle CASCADE; CREATE SCHEMA public;' && drizzle-kit migrate && bun run src/db/seed/index.ts"
     },
     "dependencies": {
         "@types/lodash": "^4.17.20",

--- a/packages/hono-backend/package.json
+++ b/packages/hono-backend/package.json
@@ -12,7 +12,8 @@
         "db:push": "drizzle-kit push",
         "db:studio": "drizzle-kit studio",
         "db:drop": "drizzle-kit drop",
-        "db:seed": "bun run src/db/seed/index.ts"
+        "db:seed": "bun run src/db/seed/index.ts",
+        "db:reset": "psql $DATABASE_URL -c 'DROP SCHEMA public CASCADE; DROP SCHEMA drizzle CASCADE; CREATE SCHEMA public;' && drizzle-kit migrate && bun run src/db/seed/index.ts"
     },
     "dependencies": {
         "@types/lodash": "^4.17.20",

--- a/packages/hono-backend/src/app-env.ts
+++ b/packages/hono-backend/src/app-env.ts
@@ -2,10 +2,12 @@ import { Hono } from 'hono'
 import { PinoLogger } from 'hono-pino'
 
 import { ReportsService } from './modules/reports'
+import { RiskService } from './modules/risk'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
 
 export type Services = {
     reportsService: ReportsService
+    riskService: RiskService
     transitNetworkDataService: TransitNetworkDataService
 }
 

--- a/packages/hono-backend/src/common/error-handler.ts
+++ b/packages/hono-backend/src/common/error-handler.ts
@@ -18,7 +18,8 @@ export const handleError = (err: Error, c: Context) => {
                 message: err.message,
                 details: {
                     internal_code: err.internalCode,
-                    description: err.description,
+                    // We do not want to leak sensitive information to the client in production
+                    description: process.env.NODE_ENV === 'development' ? err.description : undefined,
                 },
             },
             err.statusCode
@@ -31,7 +32,8 @@ export const handleError = (err: Error, c: Context) => {
             message: 'Internal Server Error',
             details: {
                 internal_code: 'UNKNOWN_ERROR',
-                description: process.env.NODE_ENV === 'production' ? undefined : err.message,
+                // We do not want to leak sensitive information to the client in production
+                description: process.env.NODE_ENV === 'development' ? err.message : undefined,
             },
         },
         500 as ContentfulStatusCode

--- a/packages/hono-backend/src/common/errors.ts
+++ b/packages/hono-backend/src/common/errors.ts
@@ -5,7 +5,7 @@ export type InternalCode =
     | 'UNKNOWN_ERROR'
     | 'SPAM_REPORT_DETECTED'
     | 'VALIDATION_FAILED'
-
+    | 'RISK_MODEL_FAILED'
 export interface AppErrorDetails {
     internal_code: InternalCode
     description?: string

--- a/packages/hono-backend/src/db/index.ts
+++ b/packages/hono-backend/src/db/index.ts
@@ -3,13 +3,14 @@ import postgres from 'postgres'
 
 import { lines, lineStations } from './schema/lines'
 import { reports } from './schema/reports'
+import { segments } from './schema/segments'
 import { stations } from './schema/stations'
 
 const connectionString = process.env.DATABASE_URL!
 
 export const client = postgres(connectionString, { prepare: false })
 export const db = drizzle(client, {
-    schema: { reports, stations, lines, lineStations },
+    schema: { reports, stations, lines, lineStations, segments },
     casing: 'snake_case',
 })
 
@@ -18,3 +19,4 @@ export type DbConnection = typeof db
 export * from './schema/reports'
 export * from './schema/lines'
 export * from './schema/stations'
+export * from './schema/segments'

--- a/packages/hono-backend/src/db/schema/segments.ts
+++ b/packages/hono-backend/src/db/schema/segments.ts
@@ -1,19 +1,23 @@
-import { jsonb, pgTable, serial, varchar } from 'drizzle-orm/pg-core'
+import { jsonb, pgTable, serial, uniqueIndex, varchar } from 'drizzle-orm/pg-core'
 
 import { lines } from './lines'
 import { stations } from './stations'
 
-export const segments = pgTable('segments', {
-    id: serial().primaryKey(),
-    lineId: varchar({ length: 16 })
-        .notNull()
-        .references(() => lines.id, { onDelete: 'cascade' }),
-    fromStationId: varchar({ length: 16 })
-        .notNull()
-        .references(() => stations.id, { onDelete: 'cascade' }),
-    toStationId: varchar({ length: 16 })
-        .notNull()
-        .references(() => stations.id, { onDelete: 'cascade' }),
-    color: varchar({ length: 7 }).notNull(),
-    coordinates: jsonb().notNull().$type<[number, number][]>(),
-})
+export const segments = pgTable(
+    'segments',
+    {
+        id: serial().primaryKey(),
+        lineId: varchar({ length: 16 })
+            .notNull()
+            .references(() => lines.id, { onDelete: 'cascade' }),
+        fromStationId: varchar({ length: 16 })
+            .notNull()
+            .references(() => stations.id, { onDelete: 'cascade' }),
+        toStationId: varchar({ length: 16 })
+            .notNull()
+            .references(() => stations.id, { onDelete: 'cascade' }),
+        color: varchar({ length: 7 }).notNull(),
+        coordinates: jsonb().notNull().$type<[number, number][]>(),
+    },
+    (table) => [uniqueIndex('segments_line_from_to_idx').on(table.lineId, table.fromStationId, table.toStationId)]
+)

--- a/packages/hono-backend/src/db/schema/segments.ts
+++ b/packages/hono-backend/src/db/schema/segments.ts
@@ -1,4 +1,4 @@
-import { jsonb, pgTable, serial, uniqueIndex, varchar } from 'drizzle-orm/pg-core'
+import { integer, jsonb, pgTable, serial, uniqueIndex, varchar } from 'drizzle-orm/pg-core'
 
 import { lines } from './lines'
 import { stations } from './stations'
@@ -16,6 +16,7 @@ export const segments = pgTable(
         toStationId: varchar({ length: 16 })
             .notNull()
             .references(() => stations.id, { onDelete: 'cascade' }),
+        position: integer().notNull(),
         color: varchar({ length: 7 }).notNull(),
         coordinates: jsonb().notNull().$type<[number, number][]>(),
     },

--- a/packages/hono-backend/src/db/schema/segments.ts
+++ b/packages/hono-backend/src/db/schema/segments.ts
@@ -1,0 +1,19 @@
+import { jsonb, pgTable, serial, varchar } from 'drizzle-orm/pg-core'
+
+import { lines } from './lines'
+import { stations } from './stations'
+
+export const segments = pgTable('segments', {
+    id: serial().primaryKey(),
+    lineId: varchar({ length: 16 })
+        .notNull()
+        .references(() => lines.id, { onDelete: 'cascade' }),
+    fromStationId: varchar({ length: 16 })
+        .notNull()
+        .references(() => stations.id, { onDelete: 'cascade' }),
+    toStationId: varchar({ length: 16 })
+        .notNull()
+        .references(() => stations.id, { onDelete: 'cascade' }),
+    color: varchar({ length: 7 }).notNull(),
+    coordinates: jsonb().notNull().$type<[number, number][]>(),
+})

--- a/packages/hono-backend/src/db/seed/index.ts
+++ b/packages/hono-backend/src/db/seed/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+ 
 import { db } from '../index'
 
 import { seedBaseData } from './seed'

--- a/packages/hono-backend/src/db/seed/index.ts
+++ b/packages/hono-backend/src/db/seed/index.ts
@@ -1,4 +1,3 @@
- 
 import { db } from '../index'
 
 import { seedBaseData } from './seed'

--- a/packages/hono-backend/src/db/seed/seed.ts
+++ b/packages/hono-backend/src/db/seed/seed.ts
@@ -70,10 +70,12 @@ export const seedBaseData = async (db: DbConnection) => {
     const segmentRecords = (segmentsJson.features as SegmentFeature[]).map((feature) => {
         const [lineId, stationPart] = feature.properties.sid.split('.')
         const [fromStationId, toStationId] = stationPart.split(':')
+        const position = (linesData[lineId] ?? []).indexOf(fromStationId)
         return {
             lineId,
             fromStationId,
             toStationId,
+            position,
             color: feature.properties.line_color,
             coordinates: feature.geometry.coordinates as [number, number][],
         }

--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -9,7 +9,7 @@ import { registerRoutes } from './common/router'
 import { db, DbConnection } from './db'
 import { getReports, postReport, ReportsService } from './modules/reports/'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
-import { getLines, getStations } from './modules/transit/transit-routes'
+import { getLines, getSegments, getStations } from './modules/transit/transit-routes'
 
 const app = new Hono<Env>()
 
@@ -55,6 +55,6 @@ const createServices = (db: DbConnection) => {
 
 registerServices(app, createServices(db))
 
-registerRoutes(app, [getReports, postReport, getStations, getLines])
+registerRoutes(app, [getReports, postReport, getStations, getLines, getSegments])
 
 export default app

--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -8,6 +8,7 @@ import { handleError } from './common/error-handler'
 import { registerRoutes } from './common/router'
 import { db, DbConnection } from './db'
 import { getReports, postReport, ReportsService } from './modules/reports/'
+import { getRisk, RiskService } from './modules/risk'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
 import { getLines, getSegments, getStations } from './modules/transit/transit-routes'
 
@@ -50,11 +51,13 @@ const createServices = (db: DbConnection) => {
 
     const reportsService = new ReportsService(db, transitNetworkDataService)
 
-    return { transitNetworkDataService, reportsService } satisfies Services
+    const riskService = new RiskService(reportsService, transitNetworkDataService)
+
+    return { transitNetworkDataService, reportsService, riskService } satisfies Services
 }
 
 registerServices(app, createServices(db))
 
-registerRoutes(app, [getReports, postReport, getStations, getLines, getSegments])
+registerRoutes(app, [getReports, postReport, getStations, getLines, getSegments, getRisk])
 
 export default app

--- a/packages/hono-backend/src/modules/risk/index.ts
+++ b/packages/hono-backend/src/modules/risk/index.ts
@@ -1,0 +1,2 @@
+export * from './risk-service'
+export * from './risk-routes'

--- a/packages/hono-backend/src/modules/risk/risk-routes.ts
+++ b/packages/hono-backend/src/modules/risk/risk-routes.ts
@@ -1,0 +1,11 @@
+import type { Env } from '../../app-env'
+import { defineRoute } from '../../common/router'
+
+export const getRisk = defineRoute<Env>()({
+    method: 'get',
+    path: 'v0/risk',
+    handler: async (c) => {
+        const riskService = c.get('riskService')
+        return c.json(await riskService.getRisk())
+    },
+})

--- a/packages/hono-backend/src/modules/risk/risk-routes.ts
+++ b/packages/hono-backend/src/modules/risk/risk-routes.ts
@@ -3,7 +3,7 @@ import { defineRoute } from '../../common/router'
 
 export const getRisk = defineRoute<Env>()({
     method: 'get',
-    path: 'v0/risk',
+    path: '/',
     handler: async (c) => {
         const riskService = c.get('riskService')
         return c.json(await riskService.getRisk())

--- a/packages/hono-backend/src/modules/risk/risk-service.ts
+++ b/packages/hono-backend/src/modules/risk/risk-service.ts
@@ -1,0 +1,60 @@
+import { join } from 'path'
+
+import { DateTime } from 'luxon'
+
+import { AppError } from '../../common/errors'
+import type { ReportsService } from '../reports/reports-service'
+import type { TransitNetworkDataService } from '../transit/transit-network-data-service'
+
+type RiskData = {
+    segments_risk: Record<string, { color: string; risk: number }>
+}
+
+export class RiskService {
+    constructor(
+        private reportsService: ReportsService,
+        private transitNetworkDataService: TransitNetworkDataService
+    ) {}
+
+    async getRisk(): Promise<RiskData> {
+        const now = DateTime.utc()
+        const oneHourAgo = now.minus({ hours: 1 })
+
+        const [segmentsCollection, realReports, stations] = await Promise.all([
+            this.transitNetworkDataService.getSegments(),
+            this.reportsService.getRealReports({ from: oneHourAgo, to: now }),
+            this.transitNetworkDataService.getStations(),
+        ])
+
+        const pythonReports = realReports.flatMap((r) => {
+            const lines = r.lineId !== null ? [r.lineId] : stations[r.stationId].lines
+            if (lines.length === 0) return []
+            return [
+                {
+                    station_id: r.stationId,
+                    lines,
+                    direction: r.directionId ?? '',
+                    timestamp: r.timestamp.toISOString(),
+                },
+            ]
+        })
+
+        const scriptPath = join(import.meta.dir, 'risk_model.py')
+        const uvBin = process.env.UV_BIN ?? 'uv'
+        const proc = Bun.spawn([uvBin, 'run', scriptPath], { stdin: 'pipe', stdout: 'pipe', stderr: 'pipe' })
+        proc.stdin.write(JSON.stringify({ segments: segmentsCollection.features, reports: pythonReports }))
+        await proc.stdin.end()
+
+        const exitCode = await proc.exited
+        if (exitCode !== 0) {
+            throw new AppError({
+                message: 'Risk model failed',
+                statusCode: 500,
+                internalCode: 'RISK_MODEL_FAILED',
+                description: await new Response(proc.stderr).text(),
+            })
+        }
+
+        return (await new Response(proc.stdout).json()) as RiskData
+    }
+}

--- a/packages/hono-backend/src/modules/risk/risk_model.py
+++ b/packages/hono-backend/src/modules/risk/risk_model.py
@@ -1,0 +1,404 @@
+# This will inline the dependencies into the script
+# Means we can run the script without having to install the dependencies
+# /// script
+# dependencies = [
+#   "numpy",
+#   "scipy",
+# ]
+# ///
+
+from typing import Dict, List, Optional, Tuple
+from datetime import datetime, timezone
+import json
+import sys
+from dataclasses import dataclass
+import math
+import numpy as np
+from scipy.stats import betabinom
+
+
+@dataclass
+class Report:
+    station_id: str
+    timestamp: datetime
+    direction_id: Optional[str]
+    lines: List[str]
+    is_multi: bool = False
+    is_ring: bool = False
+
+
+@dataclass
+class Segment:
+    sid: str
+    line_id: str
+    from_station_id: str
+    to_station_id: str
+    rank: int = 0  # Position in the line sequence
+
+
+class RiskPredictor:
+    def __init__(self, segments: List[Segment]):
+        """
+        Initialize the risk prediction model.
+
+        Args:
+            segments: List of transport line segments
+        """
+        self.segments = segments
+        self.colors = [
+            "#13C184",  # Green (default/no risk)
+            "#FACB3F",  # Yellow (low risk)
+            "#F05044",  # Red (medium risk)
+            "#A92725",  # Dark Red (high risk)
+        ]
+
+        # Create a mapping of ordered station pairs -> list of segments
+        self.overlapping_segments: Dict[Tuple[str, str], List[Segment]] = {}
+        for segment in segments:
+            # Order station IDs alphabetically to handle bidirectional segments
+            stations = sorted([segment.from_station_id, segment.to_station_id])
+            key = (stations[0], stations[1])
+            if key not in self.overlapping_segments:
+                self.overlapping_segments[key] = []
+            self.overlapping_segments[key].append(segment)
+
+        # Calculate ranks for segments within each line
+        self._calculate_segment_ranks()
+
+    def _calculate_segment_ranks(self):
+        """Calculate the position (rank) of each segment within its line."""
+        line_segments = {}
+        for segment in self.segments:
+            if segment.line_id not in line_segments:
+                line_segments[segment.line_id] = []
+            line_segments[segment.line_id].append(segment)
+
+        for line_id, segments in line_segments.items():
+            for i, segment in enumerate(segments):
+                segment.rank = i
+
+    def _calculate_temporal_decay(
+        self,
+        time_diff_seconds: float,
+        ttl: float = 1000,
+        strength: float = 0.2,
+        shift: float = 0.4,
+    ) -> float:
+        """
+        Calculate temporal decay factor using a logistic function.
+
+        Args:
+            time_diff_seconds: Time difference in seconds between now and the report
+            ttl: Time-to-live in seconds
+            strength: Controls the steepness of the decay curve
+            shift: Shifts the midpoint of the decay curve
+
+        Returns:
+            Decay factor between 0 and 1
+        """
+        strength_adj = strength * ttl
+        adjusted_ttl = ttl * (1 + shift)
+        return 1 / (1 + math.exp((time_diff_seconds - adjusted_ttl) / strength_adj))
+
+    def _calculate_direct_risk(self, report: Report, time_diff: float) -> float:
+        """Calculate direct risk based on direction and temporal decay."""
+        if report.direction_id is None:
+            return 0.0
+
+        base_risk = 0.8  # High base risk for directed reports
+        return base_risk * self._calculate_temporal_decay(
+            time_diff, ttl=1000, strength=0.2, shift=0.4
+        )
+
+    def _calculate_bidirect_risk(self, report: Report, time_diff: float) -> float:
+        """Calculate bidirectional risk based on direction and temporal decay."""
+        if report.direction_id is None:
+            base_risk = 1.0  # Highest risk when direction is unknown
+        else:
+            base_risk = 0.2  # Lower risk when direction is known
+
+        # Apply multi-line penalty
+        if report.is_multi:
+            base_risk *= 0.2
+
+        return base_risk * self._calculate_temporal_decay(
+            time_diff, ttl=2000, strength=0.3, shift=0.4
+        )
+
+    def _calculate_line_risk(self, report: Report, time_diff: float) -> float:
+        """Calculate line-wide risk based on report type and temporal decay."""
+        base_risk = 0.1 if report.station_id is None else 0.05
+        return base_risk * self._calculate_temporal_decay(
+            time_diff, ttl=4000, strength=0.3, shift=0.2
+        )
+
+    def _dbbinom_scaled(
+        self,
+        x: np.ndarray,
+        alpha: float,
+        beta: float,
+        size: int,
+        peak: int = 1,
+        shift: int = 0,
+    ) -> np.ndarray:
+        """
+        Calculate scaled beta-binomial distribution for spatial decay.
+
+        Args:
+            x: Array of distances
+            alpha: Alpha parameter of beta distribution
+            beta: Beta parameter of beta distribution
+            size: Size parameter of binomial distribution
+            peak: Position of maximum probability
+            shift: Shift in the distribution
+
+        Returns:
+            Array of probabilities
+        """
+        x = np.abs(x) + shift
+        peak_prob = betabinom.pmf(peak, size, alpha, beta)
+        probs = betabinom.pmf(x, size, alpha, beta)
+        return probs / peak_prob if peak_prob > 0 else probs
+
+    def _calculate_spatial_decay(self, distance: int, decay_type: str) -> float:
+        """
+        Calculate spatial decay based on distance and type.
+
+        Args:
+            distance: Distance between segments
+            decay_type: Type of decay ('direct', 'bidirect', or 'line')
+
+        Returns:
+            Decay factor between 0 and 1
+        """
+        if decay_type == "direct":
+            return float(
+                self._dbbinom_scaled(
+                    np.array([distance]), alpha=1.456, beta=2.547, size=6, peak=1
+                )[0]
+            )
+        elif decay_type == "bidirect":
+            return float(
+                self._dbbinom_scaled(
+                    np.array([distance]),
+                    alpha=1.336,
+                    beta=1.968,
+                    size=5,
+                    peak=1,
+                    shift=1,
+                )[0]
+            )
+        else:  # line
+            return float(
+                self._dbbinom_scaled(
+                    np.array([distance]),
+                    alpha=0.9891,
+                    beta=1.175,
+                    size=30,
+                    peak=0,
+                    shift=0,
+                )[0]
+            )
+
+    def predict(self, reports: List[Report]) -> Dict[str, Dict[str, str]]:
+        """
+        Predict risk levels for transport segments based on inspector reports.
+
+        The prediction process works as follows:
+        1. For each report, calculates three types of risk:
+           - Direct risk: Highest for reports with known direction
+           - Bidirectional risk: Highest when direction is unknown
+           - Line-wide risk: Base risk applied to entire lines
+
+        2. Risk propagation:
+           - For station-based reports: Risk decays spatially based on segment distance
+           - For line-wide reports: Risk is distributed across all segments of the line
+           - Multiple reports' risks are combined additively (capped at 1.0)
+           - Risk is propagated to overlapping segments
+
+        3. Risk to color conversion:
+           - <= 0.2: Green (no risk)
+           - <= 0.5: Yellow (low risk)
+           - <= 0.9: Red (medium risk)
+           - > 0.9: Dark Red (high risk)
+
+        Args:
+            reports: List of Report objects containing inspector observations
+
+        Returns:
+            Dictionary mapping segment IDs to color codes representing risk levels.
+            Only segments with risk (non-green) are included in the output.
+        """
+        # Get current time for temporal decay calculation
+        current_time = datetime.now(timezone.utc)
+
+        # Initialize risk components for all segments
+        segment_risks = {
+            segment.sid: {"direct": 0.0, "bidirect": 0.0, "line": 0.0}
+            for segment in self.segments
+        }
+
+        # Process each report
+        for report in reports:
+            time_diff = (current_time - report.timestamp).total_seconds()
+
+            # Calculate base risks for this report
+            direct_risk = self._calculate_direct_risk(report, time_diff)
+            bidirect_risk = self._calculate_bidirect_risk(report, time_diff)
+            line_risk = self._calculate_line_risk(report, time_diff)
+
+            # Find affected segments and propagate risks
+            for segment in self.segments:
+                if segment.line_id in report.lines:
+                    # Calculate distance from report location
+                    if report.station_id:
+                        # For station-based reports
+                        station_rank = next(
+                            (
+                                s.rank
+                                for s in self.segments
+                                if s.line_id == segment.line_id
+                                and (
+                                    s.from_station_id == report.station_id
+                                    or s.to_station_id == report.station_id
+                                )
+                            ),
+                            None,
+                        )
+                        if station_rank is not None:
+                            distance = abs(segment.rank - station_rank)
+
+                            # Apply spatial decay to each risk component
+                            direct_decay = self._calculate_spatial_decay(
+                                distance, "direct"
+                            )
+                            bidirect_decay = self._calculate_spatial_decay(
+                                distance, "bidirect"
+                            )
+                            line_decay = self._calculate_spatial_decay(distance, "line")
+
+                            # Update segment risks
+                            current_risks = segment_risks[segment.sid]
+                            current_risks["direct"] = min(
+                                1.0,
+                                current_risks["direct"] + direct_risk * direct_decay,
+                            )
+                            current_risks["bidirect"] = min(
+                                1.0,
+                                current_risks["bidirect"]
+                                + bidirect_risk * bidirect_decay,
+                            )
+                            current_risks["line"] = min(
+                                1.0, current_risks["line"] + line_risk * line_decay
+                            )
+                    else:
+                        # For line-wide reports
+                        segment_risks[segment.sid]["line"] = min(
+                            1.0, segment_risks[segment.sid]["line"] + line_risk
+                        )
+
+        # Calculate final risk scores
+        final_risks = {}
+        for sid, risks in segment_risks.items():
+            # Combine risk components
+            total_risk = min(1.0, risks["direct"] + risks["bidirect"] + risks["line"])
+            final_risks[sid] = total_risk
+
+        # Convert risks to colors and create response
+        segment_colors = {}
+        for sid, risk in final_risks.items():
+            color = self._risk_to_color(risk)
+            if color != self.colors[0]:  # Only include segments with risk
+                segment_colors[sid] = {
+                    "color": color,
+                    "risk": round(risk, 3),  # Round to 3 decimal places for readability
+                }
+
+        # Create a dictionary to store segments by their start and end stations
+        segments_by_stations: Dict[Tuple[str, str], List[Segment]] = {}
+        for segment in self.segments:
+            # order station IDs alphabetically to handle bidirectional segments
+            stations = tuple(sorted((segment.from_station_id, segment.to_station_id)))
+            if stations not in segments_by_stations:
+                segments_by_stations[stations] = []
+            segments_by_stations[stations].append(segment)
+
+        # Propagate risk colors to overlapping segments
+        for sid, data in list(
+            segment_colors.items()
+        ):  # Iterate over a copy to avoid modifying the dictionary while iterating
+            # Find the segment corresponding to the current sid
+            current_segment = next((s for s in self.segments if s.sid == sid), None)
+            if current_segment:
+                # Get station pair for current segment
+                stations = tuple(
+                    sorted(
+                        (current_segment.from_station_id, current_segment.to_station_id)
+                    )
+                )
+                # overlapping segment inherits risk color and value
+                overlapping_segments = segments_by_stations.get(stations, [])
+                for overlapping_segment in overlapping_segments:
+                    segment_colors[overlapping_segment.sid] = data
+
+        return segment_colors
+
+    def _risk_to_color(self, risk: float) -> str:
+        """Convert risk score to color code using thresholds from R model."""
+        if risk <= 0.2:
+            return self.colors[0]  # Green
+        elif risk <= 0.5:
+            return self.colors[1]  # Yellow
+        elif risk <= 0.9:
+            return self.colors[2]  # Red
+        else:
+            return self.colors[3]  # Dark Red
+
+
+def main():
+    try:
+        # Read JSON input from stdin: {"segments": [GeoJSON features], "reports": [...]}
+        input_data = json.load(sys.stdin)
+
+        segments = []
+        for feature in input_data["segments"]:
+            props = feature["properties"]
+            segment = Segment(
+                sid=f"{props['line']}.{props['from']}:{props['to']}",
+                line_id=props["line"],
+                from_station_id=props["from"],
+                to_station_id=props["to"],
+            )
+            segments.append(segment)
+
+        # Initialize risk predictor
+        predictor = RiskPredictor(segments)
+
+        reports = []
+        for inspector in input_data["reports"]:
+            timestamp = datetime.fromisoformat(
+                inspector["timestamp"].replace("Z", "+00:00")
+            )
+            reports.append(
+                Report(
+                    station_id=inspector["station_id"],
+                    timestamp=timestamp,
+                    direction_id=(
+                        inspector["direction"] if inspector["direction"] else None
+                    ),
+                    lines=inspector["lines"],
+                )
+            )
+
+        # Generate predictions
+        segment_colors = predictor.predict(reports)
+
+        # Output results to stdout
+        json.dump({"segments_risk": segment_colors}, sys.stdout)
+
+    except Exception as e:
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/hono-backend/src/modules/risk/risk_model.py
+++ b/packages/hono-backend/src/modules/risk/risk_model.py
@@ -23,7 +23,6 @@ class Report:
     timestamp: datetime
     direction_id: Optional[str]
     lines: List[str]
-    is_multi: bool = False
     is_ring: bool = False
 
 
@@ -106,6 +105,8 @@ class RiskPredictor:
             return 0.0
 
         base_risk = 0.8  # High base risk for directed reports
+        if len(report.lines) > 1:
+            base_risk /= len(report.lines)
         return base_risk * self._calculate_temporal_decay(
             time_diff, ttl=1000, strength=0.2, shift=0.4
         )
@@ -117,9 +118,8 @@ class RiskPredictor:
         else:
             base_risk = 0.2  # Lower risk when direction is known
 
-        # Apply multi-line penalty
-        if report.is_multi:
-            base_risk *= 0.2
+        if len(report.lines) > 1:
+            base_risk /= len(report.lines)
 
         return base_risk * self._calculate_temporal_decay(
             time_diff, ttl=2000, strength=0.3, shift=0.4
@@ -128,6 +128,8 @@ class RiskPredictor:
     def _calculate_line_risk(self, report: Report, time_diff: float) -> float:
         """Calculate line-wide risk based on report type and temporal decay."""
         base_risk = 0.1 if report.station_id is None else 0.05
+        if len(report.lines) > 1:
+            base_risk /= len(report.lines)
         return base_risk * self._calculate_temporal_decay(
             time_diff, ttl=4000, strength=0.3, shift=0.2
         )

--- a/packages/hono-backend/src/modules/risk/risk_model.py
+++ b/packages/hono-backend/src/modules/risk/risk_model.py
@@ -364,7 +364,7 @@ def main():
         for feature in input_data["segments"]:
             props = feature["properties"]
             segment = Segment(
-                sid=f"{props['line']}.{props['from']}:{props['to']}",
+                sid=str(props["id"]),
                 line_id=props["line"],
                 from_station_id=props["from"],
                 to_station_id=props["to"],

--- a/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
+++ b/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
@@ -102,6 +102,7 @@ export class TransitNetworkDataService {
                         coordinates: segments.coordinates,
                     })
                     .from(segments)
+                    .orderBy(asc(segments.lineId), asc(segments.position))
 
                 return {
                     type: 'FeatureCollection' as const,

--- a/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
+++ b/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
@@ -94,6 +94,7 @@ export class TransitNetworkDataService {
             try {
                 const rows = await this.db
                     .select({
+                        id: segments.id,
                         line: segments.lineId,
                         from: segments.fromStationId,
                         to: segments.toStationId,
@@ -107,6 +108,7 @@ export class TransitNetworkDataService {
                     features: rows.map((row) => ({
                         type: 'Feature' as const,
                         properties: {
+                            id: row.id,
                             line: row.line,
                             from: row.from,
                             to: row.to,

--- a/packages/hono-backend/src/modules/transit/transit-routes.ts
+++ b/packages/hono-backend/src/modules/transit/transit-routes.ts
@@ -18,3 +18,12 @@ export const getLines = defineRoute<Env>()({
         return c.json(await transitNetworkDataService.getLines())
     },
 })
+
+export const getSegments = defineRoute<Env>()({
+    method: 'get' as const,
+    path: 'v0/transit/segments',
+    handler: async (c) => {
+        const transitNetworkDataService = c.get('transitNetworkDataService')
+        return c.json(await transitNetworkDataService.getSegments())
+    },
+})

--- a/packages/hono-backend/src/modules/transit/transit-routes.ts
+++ b/packages/hono-backend/src/modules/transit/transit-routes.ts
@@ -1,9 +1,13 @@
+import type { Handler } from 'hono'
+import { etag } from 'hono/etag'
+
 import { Env } from '../../app-env'
 import { defineRoute } from '../../common/router'
 
 export const getStations = defineRoute<Env>()({
     method: 'get' as const,
     path: 'v0/transit/stations',
+    middlewares: [etag() as Handler<Env>],
     handler: async (c) => {
         const transitNetworkDataService = c.get('transitNetworkDataService')
         return c.json(await transitNetworkDataService.getStations())
@@ -13,6 +17,7 @@ export const getStations = defineRoute<Env>()({
 export const getLines = defineRoute<Env>()({
     method: 'get' as const,
     path: 'v0/transit/lines',
+    middlewares: [etag() as Handler<Env>],
     handler: async (c) => {
         const transitNetworkDataService = c.get('transitNetworkDataService')
         return c.json(await transitNetworkDataService.getLines())
@@ -22,6 +27,7 @@ export const getLines = defineRoute<Env>()({
 export const getSegments = defineRoute<Env>()({
     method: 'get' as const,
     path: 'v0/transit/segments',
+    middlewares: [etag() as Handler<Env>],
     handler: async (c) => {
         const transitNetworkDataService = c.get('transitNetworkDataService')
         return c.json(await transitNetworkDataService.getSegments())

--- a/packages/hono-backend/src/modules/transit/types.ts
+++ b/packages/hono-backend/src/modules/transit/types.ts
@@ -1,10 +1,12 @@
 import { InferSelectModel } from 'drizzle-orm'
 
 import { lines } from '../../db/schema/lines'
+import { segments } from '../../db/schema/segments'
 import { stations } from '../../db/schema/stations'
 
 type StationRow = InferSelectModel<typeof stations>
 type LineRow = InferSelectModel<typeof lines>
+type SegmentRow = InferSelectModel<typeof segments>
 
 type StationId = StationRow['id']
 type LineId = LineRow['id']
@@ -15,7 +17,28 @@ type Station = {
     lines: LineId[]
 }
 
+type SegmentProperties = {
+    line: SegmentRow['lineId']
+    from: SegmentRow['fromStationId']
+    to: SegmentRow['toStationId']
+    color: SegmentRow['color']
+}
+
+type SegmentFeature = {
+    type: 'Feature'
+    properties: SegmentProperties
+    geometry: {
+        type: 'LineString'
+        coordinates: SegmentRow['coordinates']
+    }
+}
+
+type SegmentsFeatureCollection = {
+    type: 'FeatureCollection'
+    features: SegmentFeature[]
+}
+
 type Stations = Record<StationId, Station>
 type Lines = Record<LineId, StationId[]>
 
-export type { Lines, Stations, StationId, LineId }
+export type { Lines, Stations, SegmentsFeatureCollection, SegmentFeature, StationId, LineId }

--- a/packages/hono-backend/src/modules/transit/types.ts
+++ b/packages/hono-backend/src/modules/transit/types.ts
@@ -18,6 +18,7 @@ type Station = {
 }
 
 type SegmentProperties = {
+    id: SegmentRow['id']
     line: SegmentRow['lineId']
     from: SegmentRow['fromStationId']
     to: SegmentRow['toStationId']

--- a/packages/hono-backend/tests/getRisk.test.ts
+++ b/packages/hono-backend/tests/getRisk.test.ts
@@ -1,0 +1,548 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { eq } from 'drizzle-orm'
+
+import { db, lineStations, lines, reports, segments } from '../src/db'
+import { seedBaseData } from '../src/db/seed/seed'
+import app from '../src/index'
+import { sendReportRequest } from './test-utils'
+
+type SegmentRisk = { color: string; risk: number }
+type RiskResponse = { segments_risk: Record<string, SegmentRisk> }
+
+const VALID_COLORS = ['#13C184', '#FACB3F', '#F05044', '#A92725']
+const GREEN = '#13C184'
+
+let testStationId: string
+let testLineId: string
+
+describe('GET /v0/risk response shape', () => {
+    beforeAll(async () => {
+        await seedBaseData(db)
+
+        const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
+        const [stationOnLine] = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, line!.id))
+            .limit(1)
+
+        testLineId = line!.id
+        testStationId = stationOnLine!.stationId
+    })
+
+    beforeEach(async () => {
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        await db.delete(reports)
+    })
+
+    it('returns 200 with a segments_risk object', async () => {
+        const response = await app.request('/v0/risk')
+
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as RiskResponse
+        expect(body).toHaveProperty('segments_risk')
+        expect(typeof body.segments_risk).toBe('object')
+        expect(Array.isArray(body.segments_risk)).toBe(false)
+    })
+
+    it('returns empty segments_risk when there are no recent reports', async () => {
+        const response = await app.request('/v0/risk')
+
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as RiskResponse
+        expect(Object.keys(body.segments_risk).length).toBe(0)
+    })
+
+    it('returns non-empty segments_risk after a recent real report', async () => {
+        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+
+        const response = await app.request('/v0/risk')
+
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as RiskResponse
+        expect(Object.keys(body.segments_risk).length).toBeGreaterThan(0)
+    })
+
+    it('each segment entry has a valid color and a risk score between 0 and 1', async () => {
+        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+
+        const response = await app.request('/v0/risk')
+        const body = (await response.json()) as RiskResponse
+
+        for (const [sid, data] of Object.entries(body.segments_risk)) {
+            expect(typeof sid).toBe('string')
+            expect(VALID_COLORS).toContain(data.color)
+            expect(data.risk).toBeGreaterThan(0)
+            expect(data.risk).toBeLessThanOrEqual(1)
+        }
+    })
+
+    it('only includes segments with risk — green segments are excluded', async () => {
+        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+
+        const response = await app.request('/v0/risk')
+        const body = (await response.json()) as RiskResponse
+
+        for (const data of Object.values(body.segments_risk)) {
+            expect(data.color).not.toBe(GREEN)
+            expect(data.risk).toBeGreaterThan(0.2)
+        }
+    })
+
+    it('segment IDs are numeric strings matching database IDs', async () => {
+        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+
+        const response = await app.request('/v0/risk')
+        const body = (await response.json()) as RiskResponse
+
+        for (const sid of Object.keys(body.segments_risk)) {
+            expect(sid).toMatch(/^\d+$/)
+        }
+    })
+})
+
+describe('GET /v0/risk timeframe filtering', () => {
+    beforeAll(async () => {
+        await seedBaseData(db)
+
+        const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
+        const [stationOnLine] = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, line!.id))
+            .limit(1)
+
+        testLineId = line!.id
+        testStationId = stationOnLine!.stationId
+    })
+
+    beforeEach(async () => {
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        await db.delete(reports)
+    })
+
+    it('ignores reports older than 1 hour', async () => {
+        const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
+
+        await db.insert(reports).values({
+            stationId: testStationId,
+            lineId: testLineId,
+            directionId: null,
+            timestamp: twoHoursAgo,
+            source: 'telegram',
+        })
+
+        const response = await app.request('/v0/risk')
+
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as RiskResponse
+        expect(Object.keys(body.segments_risk).length).toBe(0)
+    })
+
+    it('includes reports from within the last hour', async () => {
+        const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000)
+
+        await db.insert(reports).values({
+            stationId: testStationId,
+            lineId: testLineId,
+            directionId: null,
+            timestamp: thirtyMinutesAgo,
+            source: 'telegram',
+        })
+
+        const response = await app.request('/v0/risk')
+
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as RiskResponse
+        expect(Object.keys(body.segments_risk).length).toBeGreaterThan(0)
+    })
+
+    it('a very recent report produces higher risk than one from 55 minutes ago', async () => {
+        // Insert an old-ish report
+        const fiftyFiveMinutesAgo = new Date(Date.now() - 55 * 60 * 1000)
+        await db.insert(reports).values({
+            stationId: testStationId,
+            lineId: testLineId,
+            directionId: null,
+            timestamp: fiftyFiveMinutesAgo,
+            source: 'telegram',
+        })
+
+        const oldResponse = await app.request('/v0/risk')
+        const oldBody = (await oldResponse.json()) as RiskResponse
+
+        await db.delete(reports)
+
+        // Insert a fresh report
+        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+
+        const freshResponse = await app.request('/v0/risk')
+        const freshBody = (await freshResponse.json()) as RiskResponse
+
+        // Find a segment that appears in both responses
+        const sharedSid = Object.keys(freshBody.segments_risk).find((sid) => sid in oldBody.segments_risk)
+
+        if (sharedSid !== undefined) {
+            expect(freshBody.segments_risk[sharedSid]!.risk).toBeGreaterThan(oldBody.segments_risk[sharedSid]!.risk)
+        }
+
+        // At minimum, the fresh report should produce at least as many risky segments
+        expect(Object.keys(freshBody.segments_risk).length).toBeGreaterThanOrEqual(
+            Object.keys(oldBody.segments_risk).length
+        )
+    })
+})
+
+describe('GET /v0/risk segment targeting', () => {
+    let segmentLineId: string
+    let stationOnSegmentLine: string
+
+    beforeAll(async () => {
+        await seedBaseData(db)
+
+        // Find a segment and a station that belongs to its line
+        const [segment] = await db
+            .select({
+                lineId: segments.lineId,
+                fromStationId: segments.fromStationId,
+                toStationId: segments.toStationId,
+            })
+            .from(segments)
+            .limit(1)
+
+        segmentLineId = segment!.lineId
+
+        // Get any station on this line to use as the report's station
+        const [stationEntry] = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, segmentLineId))
+            .limit(1)
+
+        stationOnSegmentLine = stationEntry!.stationId
+    })
+
+    beforeEach(async () => {
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        await db.delete(reports)
+    })
+
+    it('a report on a line causes segments of that line to appear in the risk output', async () => {
+        await sendReportRequest({ stationId: stationOnSegmentLine, lineId: segmentLineId, source: 'telegram' })
+
+        const response = await app.request('/v0/risk')
+        const body = (await response.json()) as RiskResponse
+
+        // Resolve the DB IDs for segments on the reported line
+        const segmentsOnLine = await db
+            .select({ id: segments.id })
+            .from(segments)
+            .where(eq(segments.lineId, segmentLineId))
+
+        const segmentIdsOnLine = new Set(segmentsOnLine.map((s) => String(s.id)))
+        const riskySegmentsOnLine = Object.keys(body.segments_risk).filter((sid) => segmentIdsOnLine.has(sid))
+
+        expect(riskySegmentsOnLine.length).toBeGreaterThan(0)
+    })
+
+    it('a report with lineId null falls back to the station lines for risk assignment', async () => {
+        const { TransitNetworkDataService } = await import('../src/modules/transit/transit-network-data-service')
+        const service = new TransitNetworkDataService(db)
+        const stationsMap = await service.getStations()
+
+        const singleLineStation = Object.entries(stationsMap).find(([, s]) => s.lines.length === 1)
+        if (!singleLineStation) return // skip if no such station in seed data
+
+        const [singleLineStationId, singleLineStationData] = singleLineStation
+        const inferredLineId = singleLineStationData.lines[0]!
+
+        await sendReportRequest({ stationId: singleLineStationId, source: 'telegram' })
+
+        const response = await app.request('/v0/risk')
+        const body = (await response.json()) as RiskResponse
+
+        // Resolve DB IDs for segments on the inferred line
+        const segmentsOnLine = await db
+            .select({ id: segments.id })
+            .from(segments)
+            .where(eq(segments.lineId, inferredLineId))
+
+        const segmentIdsOnLine = new Set(segmentsOnLine.map((s) => String(s.id)))
+        const riskySegmentsOnLine = Object.keys(body.segments_risk).filter((sid) => segmentIdsOnLine.has(sid))
+
+        // (the model also propagates risk to overlapping segments on other lines,
+        // so we only assert that at least one segment from the inferred line appears)
+        expect(riskySegmentsOnLine.length).toBeGreaterThan(0)
+    })
+
+    it('a report on line A does not affect segments on an unrelated line B', async () => {
+        const allLines = await db.select({ id: lines.id }).from(lines).limit(10)
+        if (allLines.length < 2) return
+
+        const lineA = allLines[0]!.id
+        const lineB = allLines[1]!.id
+
+        const [stationA] = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, lineA))
+            .limit(1)
+
+        if (!stationA) return
+
+        await sendReportRequest({ stationId: stationA.stationId, lineId: lineA, source: 'telegram' })
+
+        const response = await app.request('/v0/risk')
+        const body = (await response.json()) as RiskResponse
+
+        // Resolve DB IDs for segments exclusively on line B (not on line A)
+        const segmentsOnLineB = await db.select({ id: segments.id }).from(segments).where(eq(segments.lineId, lineB))
+
+        const segmentIdsOnLineB = new Set(segmentsOnLineB.map((s) => String(s.id)))
+
+        for (const sid of Object.keys(body.segments_risk)) {
+            expect(segmentIdsOnLineB.has(sid)).toBe(false)
+        }
+    })
+})
+
+describe('GET /v0/risk report type handling', () => {
+    beforeAll(async () => {
+        await seedBaseData(db)
+
+        const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
+        const [stationOnLine] = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, line!.id))
+            .limit(1)
+
+        testLineId = line!.id
+        testStationId = stationOnLine!.stationId
+    })
+
+    beforeEach(async () => {
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        await db.delete(reports)
+    })
+
+    it('multiple reports on the same line accumulate higher risk than a single report', async () => {
+        // Single report
+        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+
+        const singleResponse = await app.request('/v0/risk')
+        const singleBody = (await singleResponse.json()) as RiskResponse
+        const singleRiskValues = Object.values(singleBody.segments_risk).map((s) => s.risk)
+        const singleMaxRisk = Math.max(...singleRiskValues)
+
+        await db.delete(reports)
+
+        // Get another station on the same line for a second report
+        const stationsOnLine = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, testLineId))
+            .limit(2)
+
+        for (const s of stationsOnLine) {
+            await sendReportRequest({ stationId: s.stationId, lineId: testLineId, source: 'telegram' })
+        }
+
+        const multiResponse = await app.request('/v0/risk')
+        const multiBody = (await multiResponse.json()) as RiskResponse
+        const multiRiskValues = Object.values(multiBody.segments_risk).map((s) => s.risk)
+        const multiMaxRisk = Math.max(...multiRiskValues)
+
+        expect(multiMaxRisk).toBeGreaterThanOrEqual(singleMaxRisk)
+    })
+
+    it('a report with a direction produces directed risk (higher risk than without direction)', async () => {
+        // Get two stations on the same line to use as station + direction
+        const stationsOnLine = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, testLineId))
+            .limit(2)
+
+        if (stationsOnLine.length < 2) return
+
+        const stationId = stationsOnLine[0]!.stationId
+        const directionId = stationsOnLine[stationsOnLine.length - 1]!.stationId
+
+        // Report without direction
+        await sendReportRequest({ stationId, lineId: testLineId, source: 'telegram' })
+
+        const undirectedResponse = await app.request('/v0/risk')
+        const undirectedBody = (await undirectedResponse.json()) as RiskResponse
+
+        await db.delete(reports)
+
+        // Report with direction
+        await sendReportRequest({ stationId, lineId: testLineId, directionId, source: 'telegram' })
+
+        const directedResponse = await app.request('/v0/risk')
+        const directedBody = (await directedResponse.json()) as RiskResponse
+
+        // Both should produce risky segments
+        expect(Object.keys(undirectedBody.segments_risk).length).toBeGreaterThan(0)
+        expect(Object.keys(directedBody.segments_risk).length).toBeGreaterThan(0)
+    })
+
+    it('a report with no lineId spreads risk across all station lines, divided by number of lines', async () => {
+        const { TransitNetworkDataService } = await import('../src/modules/transit/transit-network-data-service')
+        const service = new TransitNetworkDataService(db)
+        const stationsMap = await service.getStations()
+
+        // Find a station on exactly 2 lines so the divisor is known and predictable
+        const twoLineStation = Object.entries(stationsMap).find(([, s]) => s.lines.length === 2)
+        if (!twoLineStation) return
+
+        const [multiLineStationId, multiLineStationData] = twoLineStation
+        const [lineA, lineB] = multiLineStationData.lines as [string, string]
+
+        // Find a single-line station that is only on lineA, to use as our baseline
+        const singleLineStationOnA = Object.entries(stationsMap).find(
+            ([id, s]) => s.lines.length === 1 && s.lines[0] === lineA && id !== multiLineStationId
+        )
+        if (!singleLineStationOnA) return
+
+        const [singleLineStationId] = singleLineStationOnA
+
+        // --- Baseline: report at a single-line station on lineA with an explicit lineId ---
+        await sendReportRequest({ stationId: singleLineStationId, lineId: lineA, source: 'telegram' })
+
+        const baselineResponse = await app.request('/v0/risk')
+        const baselineBody = (await baselineResponse.json()) as RiskResponse
+        const baselineSegmentsA = await db.select({ id: segments.id }).from(segments).where(eq(segments.lineId, lineA))
+        const baselineIdsA = new Set(baselineSegmentsA.map((s) => String(s.id)))
+        const baselineMaxRisk = Math.max(
+            ...Object.entries(baselineBody.segments_risk)
+                .filter(([sid]) => baselineIdsA.has(sid))
+                .map(([, d]) => d.risk),
+            0
+        )
+
+        await db.delete(reports)
+
+        // --- Multi-line: same station but no lineId → lines = [lineA, lineB] ---
+        await sendReportRequest({ stationId: multiLineStationId, source: 'telegram' })
+
+        const multiResponse = await app.request('/v0/risk')
+        const multiBody = (await multiResponse.json()) as RiskResponse
+
+        // Segments from BOTH lines should appear in the output
+        const segmentsOnB = await db.select({ id: segments.id }).from(segments).where(eq(segments.lineId, lineB))
+        const segmentIdsOnB = new Set(segmentsOnB.map((s) => String(s.id)))
+        const riskyOnB = Object.keys(multiBody.segments_risk).filter((sid) => segmentIdsOnB.has(sid))
+        expect(riskyOnB.length).toBeGreaterThan(0)
+
+        const riskyOnA = Object.keys(multiBody.segments_risk).filter((sid) => baselineIdsA.has(sid))
+        expect(riskyOnA.length).toBeGreaterThan(0)
+
+        // Risk on lineA segments should be roughly half of the single-line baseline (divided by 2 lines)
+        const multiMaxRiskOnA = Math.max(
+            ...Object.entries(multiBody.segments_risk)
+                .filter(([sid]) => baselineIdsA.has(sid))
+                .map(([, d]) => d.risk),
+            0
+        )
+        expect(multiMaxRiskOnA).toBeLessThan(baselineMaxRisk)
+    })
+})
+
+describe('GET /v0/risk overlapping segments', () => {
+    // Segments sharing the same from/to station pair (e.g. a shared tram/bus stop between two lines)
+    // should all inherit the same risk color when any one of them is risky.
+
+    let overlapIds: string[] = []
+    let primaryLineId: string | null = null
+
+    beforeAll(async () => {
+        await seedBaseData(db)
+
+        const allSegments = await db
+            .select({
+                id: segments.id,
+                lineId: segments.lineId,
+                fromStationId: segments.fromStationId,
+                toStationId: segments.toStationId,
+            })
+            .from(segments)
+
+        // Group by normalized (sorted) station pair to find overlapping segments
+        const pairMap = new Map<string, { ids: number[]; lineIds: string[] }>()
+        for (const seg of allSegments) {
+            const key = [seg.fromStationId, seg.toStationId].sort().join(':')
+            const entry = pairMap.get(key) ?? { ids: [], lineIds: [] }
+            entry.ids.push(seg.id)
+            entry.lineIds.push(seg.lineId)
+            pairMap.set(key, entry)
+        }
+
+        const overlap = Array.from(pairMap.values()).find((v) => v.ids.length > 1)
+        if (overlap) {
+            overlapIds = overlap.ids.map(String)
+            primaryLineId = overlap.lineIds[0]!
+        }
+    })
+
+    beforeEach(async () => {
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        await db.delete(reports)
+    })
+
+    it('all segments sharing the same station pair get colored when one of them is risky', async () => {
+        if (!primaryLineId || overlapIds.length === 0) return // skip if seed data has no overlapping pairs
+
+        const overlapSegmentIds = overlapIds
+
+        // Find a station that is directly one of the endpoints of the overlapping segment pair.
+        // Reporting there puts the segment at distance 0, guaranteeing it appears in the output.
+        const [stationEntry] = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, primaryLineId))
+            .limit(1)
+
+        if (!stationEntry) return
+
+        await sendReportRequest({ stationId: stationEntry.stationId, lineId: primaryLineId, source: 'telegram' })
+
+        const response = await app.request('/v0/risk')
+        const body = (await response.json()) as RiskResponse
+
+        const riskyIds = new Set(Object.keys(body.segments_risk))
+
+        // Every segment in the overlapping group must appear in the risk output
+        for (const sid of overlapSegmentIds) {
+            expect(riskyIds.has(sid)).toBe(true)
+        }
+
+        // All overlapping segments must share the same color (propagated from the primary segment)
+        const colors = overlapSegmentIds.map((sid) => body.segments_risk[sid]?.color)
+        const firstColor = colors[0]
+        for (const color of colors) {
+            expect(color).toBe(firstColor)
+        }
+    })
+})

--- a/packages/hono-backend/tests/getRisk.test.ts
+++ b/packages/hono-backend/tests/getRisk.test.ts
@@ -3,8 +3,7 @@ import { eq } from 'drizzle-orm'
 
 import { db, lineStations, lines, reports, segments } from '../src/db'
 import { seedBaseData } from '../src/db/seed/seed'
-import app from '../src/index'
-import { sendReportRequest } from './test-utils'
+import { appRequestWithRedirect, sendReportRequest } from './test-utils'
 
 type SegmentRisk = { color: string; risk: number }
 type RiskResponse = { segments_risk: Record<string, SegmentRisk> }
@@ -39,7 +38,7 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('returns 200 with a segments_risk object', async () => {
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
 
         expect(response.status).toBe(200)
 
@@ -50,7 +49,7 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('returns empty segments_risk when there are no recent reports', async () => {
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
 
         expect(response.status).toBe(200)
 
@@ -61,7 +60,7 @@ describe('GET /v0/risk response shape', () => {
     it('returns non-empty segments_risk after a recent real report', async () => {
         await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
 
         expect(response.status).toBe(200)
 
@@ -72,7 +71,7 @@ describe('GET /v0/risk response shape', () => {
     it('each segment entry has a valid color and a risk score between 0 and 1', async () => {
         await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
         const body = (await response.json()) as RiskResponse
 
         for (const [sid, data] of Object.entries(body.segments_risk)) {
@@ -86,7 +85,7 @@ describe('GET /v0/risk response shape', () => {
     it('only includes segments with risk — green segments are excluded', async () => {
         await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
         const body = (await response.json()) as RiskResponse
 
         for (const data of Object.values(body.segments_risk)) {
@@ -98,7 +97,7 @@ describe('GET /v0/risk response shape', () => {
     it('segment IDs are numeric strings matching database IDs', async () => {
         await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
         const body = (await response.json()) as RiskResponse
 
         for (const sid of Object.keys(body.segments_risk)) {
@@ -141,7 +140,7 @@ describe('GET /v0/risk timeframe filtering', () => {
             source: 'telegram',
         })
 
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
 
         expect(response.status).toBe(200)
 
@@ -160,7 +159,7 @@ describe('GET /v0/risk timeframe filtering', () => {
             source: 'telegram',
         })
 
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
 
         expect(response.status).toBe(200)
 
@@ -179,7 +178,7 @@ describe('GET /v0/risk timeframe filtering', () => {
             source: 'telegram',
         })
 
-        const oldResponse = await app.request('/v0/risk')
+        const oldResponse = await appRequestWithRedirect('/risk')
         const oldBody = (await oldResponse.json()) as RiskResponse
 
         // The 55-minute-old report must still produce output (bidirect decay ≈ 0.3 at that age),
@@ -191,7 +190,7 @@ describe('GET /v0/risk timeframe filtering', () => {
         // Insert a fresh report
         await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const freshResponse = await app.request('/v0/risk')
+        const freshResponse = await appRequestWithRedirect('/risk')
         const freshBody = (await freshResponse.json()) as RiskResponse
 
         // Both reports target the same station/line, so there must be a segment in common
@@ -242,7 +241,7 @@ describe('GET /v0/risk segment targeting', () => {
     it('a report on a line causes segments of that line to appear in the risk output', async () => {
         await sendReportRequest({ stationId: stationOnSegmentLine, lineId: segmentLineId, source: 'telegram' })
 
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
         const body = (await response.json()) as RiskResponse
 
         // Resolve the DB IDs for segments on the reported line
@@ -270,7 +269,7 @@ describe('GET /v0/risk segment targeting', () => {
 
         await sendReportRequest({ stationId: singleLineStationId, source: 'telegram' })
 
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
         const body = (await response.json()) as RiskResponse
 
         // Resolve DB IDs for segments on the inferred line
@@ -304,7 +303,7 @@ describe('GET /v0/risk segment targeting', () => {
 
         await sendReportRequest({ stationId: stationA.stationId, lineId: lineA, source: 'telegram' })
 
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
         const body = (await response.json()) as RiskResponse
 
         // Collect the normalized station pairs (sorted from:to) for all line A segments.
@@ -364,7 +363,7 @@ describe('GET /v0/risk report type handling', () => {
         // Single report
         await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const singleResponse = await app.request('/v0/risk')
+        const singleResponse = await appRequestWithRedirect('/risk')
         const singleBody = (await singleResponse.json()) as RiskResponse
         const singleRiskValues = Object.values(singleBody.segments_risk).map((s) => s.risk)
         const singleMaxRisk = Math.max(...singleRiskValues)
@@ -382,7 +381,7 @@ describe('GET /v0/risk report type handling', () => {
             await sendReportRequest({ stationId: s.stationId, lineId: testLineId, source: 'telegram' })
         }
 
-        const multiResponse = await app.request('/v0/risk')
+        const multiResponse = await appRequestWithRedirect('/risk')
         const multiBody = (await multiResponse.json()) as RiskResponse
         const multiRiskValues = Object.values(multiBody.segments_risk).map((s) => s.risk)
         const multiMaxRisk = Math.max(...multiRiskValues)
@@ -406,7 +405,7 @@ describe('GET /v0/risk report type handling', () => {
         // Report without direction
         await sendReportRequest({ stationId, lineId: testLineId, source: 'telegram' })
 
-        const undirectedResponse = await app.request('/v0/risk')
+        const undirectedResponse = await appRequestWithRedirect('/risk')
         const undirectedBody = (await undirectedResponse.json()) as RiskResponse
 
         await db.delete(reports)
@@ -414,7 +413,7 @@ describe('GET /v0/risk report type handling', () => {
         // Report with direction
         await sendReportRequest({ stationId, lineId: testLineId, directionId, source: 'telegram' })
 
-        const directedResponse = await app.request('/v0/risk')
+        const directedResponse = await appRequestWithRedirect('/risk')
         const directedBody = (await directedResponse.json()) as RiskResponse
 
         // Both should produce risky segments
@@ -445,7 +444,7 @@ describe('GET /v0/risk report type handling', () => {
         // --- Baseline: report at a single-line station on lineA with an explicit lineId ---
         await sendReportRequest({ stationId: singleLineStationId, lineId: lineA, source: 'telegram' })
 
-        const baselineResponse = await app.request('/v0/risk')
+        const baselineResponse = await appRequestWithRedirect('/risk')
         const baselineBody = (await baselineResponse.json()) as RiskResponse
         const baselineSegmentsA = await db.select({ id: segments.id }).from(segments).where(eq(segments.lineId, lineA))
         const baselineIdsA = new Set(baselineSegmentsA.map((s) => String(s.id)))
@@ -461,7 +460,7 @@ describe('GET /v0/risk report type handling', () => {
         // --- Multi-line: same station but no lineId → lines = [lineA, lineB] ---
         await sendReportRequest({ stationId: multiLineStationId, source: 'telegram' })
 
-        const multiResponse = await app.request('/v0/risk')
+        const multiResponse = await appRequestWithRedirect('/risk')
         const multiBody = (await multiResponse.json()) as RiskResponse
 
         // Segments from BOTH lines should appear in the output
@@ -545,7 +544,7 @@ describe('GET /v0/risk overlapping segments', () => {
 
         await sendReportRequest({ stationId: stationEntry.stationId, lineId: primaryLineId, source: 'telegram' })
 
-        const response = await app.request('/v0/risk')
+        const response = await appRequestWithRedirect('/risk')
         const body = (await response.json()) as RiskResponse
 
         const riskyIds = new Set(Object.keys(body.segments_risk))

--- a/packages/hono-backend/tests/preload.ts
+++ b/packages/hono-backend/tests/preload.ts
@@ -2,3 +2,8 @@
 // But to debug a test failure, you can run `TEST_LOG_LEVEL=info bun test` to enable logging.
 process.env.LOG_LEVEL = process.env.TEST_LOG_LEVEL ?? 'error'
 process.env.DATABASE_URL = process.env.DATABASE_URL_TEST ?? process.env.DATABASE_URL
+
+import { migrate } from 'drizzle-orm/postgres-js/migrator'
+import { db } from '../src/db'
+
+await migrate(db, { migrationsFolder: './drizzle' })

--- a/packages/hono-backend/tests/test-utils.ts
+++ b/packages/hono-backend/tests/test-utils.ts
@@ -6,6 +6,9 @@ import { app } from '../src/index'
  * @param init - The request init.
  * @param targetApp - The app to send the request to. Defaults to the singleton app.
  * @returns The response.
+ * We use this instead of app.request because we want to test the latest version of the API.
+ * Otherwise we would have to specify the route version in every test.
+ * With this function we can just call the route path and it will be redirected to the latest version.
  */
 export const appRequestWithRedirect = async (path: string, init?: RequestInit, targetApp = app) => {
     const response = await targetApp.request(path, init)

--- a/packages/hono-backend/tsconfig.json
+++ b/packages/hono-backend/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "module": "esnext",
         "strict": true,
         "jsx": "react-jsx",
         "jsxImportSource": "hono/jsx",

--- a/packages/hono-backend/tsconfig.json
+++ b/packages/hono-backend/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
+        "moduleResolution": "bundler",
         "strict": true,
         "jsx": "react-jsx",
         "jsxImportSource": "hono/jsx",

--- a/packages/hono-backend/tsconfig.json
+++ b/packages/hono-backend/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "target": "esnext",
         "module": "esnext",
         "moduleResolution": "bundler",
         "strict": true,


### PR DESCRIPTION
## Explain how you solved the issue:
I moved the risk model to the new backend, it now works in a similar way we are still running it as a python sub process, now with uv to make handling dependencies a little easier (I also adjusted the dockerfile to pull uv on start up). 
We are now also passing in the report AND segments with `stdin` instead of relying on a `segments.json` file.

I added extensive tests for this feature. 

## Additional notes or considerations:
I had to make some changes in the tsconfig to handle the sub process

Next step is caching
