### PR TITLE
Disable link preview options in send_message

### DIFF
--- a/packages/nlp_service/services/telegram_adapter.py
+++ b/packages/nlp_service/services/telegram_adapter.py
@@ -46,8 +46,7 @@ def send_message(
         parse_mode (str): Message parsing mode (default: HTML).
     """
     try:
-        lp_opts = LinkPreviewOptions(
-            url=preview_url, prefer_large_media=True, show_above_text=False
+        lp_opts = LinkPreviewOptions(is_disabled=True)
         )
 
         bot.send_message(


### PR DESCRIPTION
Fixes #442

The bot currently sends messages with `prefer_large_media=True`, which renders 
the FreiFahren logo as a large image on every inspector report. With hundreds 
of messages per day, this creates significant visual noise in the group chat.

This fix disables the link preview directly in the bot's `send_message` function 
in `telegram_adapter.py`.

As an alternative `prefer_small_media=True` is also available. This might mititage some of the noise. 