### PR TITLE
feat: cache risk model

### DIFF
--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -188,6 +188,7 @@ export const postReport = defineRoute<Env>()({
         const { telegramNotificationSuccess, report } = await reportsService.createReport({
             ...postProcessedReportData,
         })
+        c.get('riskService').clearCache()
 
         if (!telegramNotificationSuccess) {
             logger.error('Failed to notify Telegram bot about inspector report')

--- a/packages/hono-backend/src/modules/risk/risk-service.ts
+++ b/packages/hono-backend/src/modules/risk/risk-service.ts
@@ -10,14 +10,50 @@ type RiskData = {
     segments_risk: Record<string, { color: string; risk: number }>
 }
 
+const RISK_CACHE_TTL_MS = 5 * 60 * 1000
+
+type RiskCacheEntry = {
+    expiresAtMillis: number
+    promise: Promise<RiskData>
+}
+
 export class RiskService {
+    private riskCache: RiskCacheEntry | null = null
+
     constructor(
         private reportsService: ReportsService,
         private transitNetworkDataService: TransitNetworkDataService
     ) {}
 
-    async getRisk(): Promise<RiskData> {
-        const now = DateTime.utc()
+    async getRisk(currentTime: DateTime = DateTime.utc()): Promise<RiskData> {
+        const cachedEntry = this.riskCache
+        if (cachedEntry !== null && cachedEntry.expiresAtMillis > currentTime.toMillis()) {
+            return cachedEntry.promise
+        }
+
+        const promise = this.getRiskUncached(currentTime)
+        const cacheEntry = {
+            expiresAtMillis: currentTime.toMillis() + RISK_CACHE_TTL_MS,
+            promise,
+        }
+        this.riskCache = cacheEntry
+
+        try {
+            return await promise
+        } catch (error) {
+            if (this.riskCache === cacheEntry) {
+                this.riskCache = null
+            }
+
+            throw error
+        }
+    }
+
+    clearCache(): void {
+        this.riskCache = null
+    }
+
+    private async getRiskUncached(now: DateTime): Promise<RiskData> {
         const oneHourAgo = now.minus({ hours: 1 })
 
         const [segmentsCollection, realReports, stations] = await Promise.all([

--- a/packages/hono-backend/tests/getRisk.test.ts
+++ b/packages/hono-backend/tests/getRisk.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
 import { eq } from 'drizzle-orm'
 
+import { createApp } from '../src'
 import { db, lineStations, lines, reports, segments } from '../src/db'
 import { seedBaseData } from '../src/db/seed/seed'
 import { appRequestWithRedirect, sendReportRequest } from './test-utils'
@@ -13,6 +14,14 @@ const GREEN = '#13C184'
 
 let testStationId: string
 let testLineId: string
+let routeApp = createApp()
+
+const getRisk = () => appRequestWithRedirect('/risk', undefined, routeApp)
+const postRiskReport = (payload: object) => sendReportRequest(payload, routeApp)
+
+beforeEach(() => {
+    routeApp = createApp()
+})
 
 describe('GET /v0/risk response shape', () => {
     beforeAll(async () => {
@@ -38,7 +47,7 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('returns 200 with a segments_risk object', async () => {
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
 
         expect(response.status).toBe(200)
 
@@ -49,7 +58,7 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('returns empty segments_risk when there are no recent reports', async () => {
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
 
         expect(response.status).toBe(200)
 
@@ -58,9 +67,9 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('returns non-empty segments_risk after a recent real report', async () => {
-        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
 
         expect(response.status).toBe(200)
 
@@ -69,9 +78,9 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('each segment entry has a valid color and a risk score between 0 and 1', async () => {
-        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
         const body = (await response.json()) as RiskResponse
 
         for (const [sid, data] of Object.entries(body.segments_risk)) {
@@ -83,9 +92,9 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('only includes segments with risk — green segments are excluded', async () => {
-        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
         const body = (await response.json()) as RiskResponse
 
         for (const data of Object.values(body.segments_risk)) {
@@ -95,9 +104,9 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('segment IDs are numeric strings matching database IDs', async () => {
-        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
         const body = (await response.json()) as RiskResponse
 
         for (const sid of Object.keys(body.segments_risk)) {
@@ -140,7 +149,7 @@ describe('GET /v0/risk timeframe filtering', () => {
             source: 'telegram',
         })
 
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
 
         expect(response.status).toBe(200)
 
@@ -159,7 +168,7 @@ describe('GET /v0/risk timeframe filtering', () => {
             source: 'telegram',
         })
 
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
 
         expect(response.status).toBe(200)
 
@@ -178,7 +187,7 @@ describe('GET /v0/risk timeframe filtering', () => {
             source: 'telegram',
         })
 
-        const oldResponse = await appRequestWithRedirect('/risk')
+        const oldResponse = await getRisk()
         const oldBody = (await oldResponse.json()) as RiskResponse
 
         // The 55-minute-old report must still produce output (bidirect decay ≈ 0.3 at that age),
@@ -188,9 +197,9 @@ describe('GET /v0/risk timeframe filtering', () => {
         await db.delete(reports)
 
         // Insert a fresh report
-        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const freshResponse = await appRequestWithRedirect('/risk')
+        const freshResponse = await getRisk()
         const freshBody = (await freshResponse.json()) as RiskResponse
 
         // Both reports target the same station/line, so there must be a segment in common
@@ -239,9 +248,9 @@ describe('GET /v0/risk segment targeting', () => {
     })
 
     it('a report on a line causes segments of that line to appear in the risk output', async () => {
-        await sendReportRequest({ stationId: stationOnSegmentLine, lineId: segmentLineId, source: 'telegram' })
+        await postRiskReport({ stationId: stationOnSegmentLine, lineId: segmentLineId, source: 'telegram' })
 
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
         const body = (await response.json()) as RiskResponse
 
         // Resolve the DB IDs for segments on the reported line
@@ -267,9 +276,9 @@ describe('GET /v0/risk segment targeting', () => {
         const [singleLineStationId, singleLineStationData] = singleLineStation
         const inferredLineId = singleLineStationData.lines[0]!
 
-        await sendReportRequest({ stationId: singleLineStationId, source: 'telegram' })
+        await postRiskReport({ stationId: singleLineStationId, source: 'telegram' })
 
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
         const body = (await response.json()) as RiskResponse
 
         // Resolve DB IDs for segments on the inferred line
@@ -301,9 +310,9 @@ describe('GET /v0/risk segment targeting', () => {
 
         if (!stationA) return
 
-        await sendReportRequest({ stationId: stationA.stationId, lineId: lineA, source: 'telegram' })
+        await postRiskReport({ stationId: stationA.stationId, lineId: lineA, source: 'telegram' })
 
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
         const body = (await response.json()) as RiskResponse
 
         // Collect the normalized station pairs (sorted from:to) for all line A segments.
@@ -361,9 +370,9 @@ describe('GET /v0/risk report type handling', () => {
 
     it('multiple reports on the same line accumulate higher risk than a single report', async () => {
         // Single report
-        await sendReportRequest({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
 
-        const singleResponse = await appRequestWithRedirect('/risk')
+        const singleResponse = await getRisk()
         const singleBody = (await singleResponse.json()) as RiskResponse
         const singleRiskValues = Object.values(singleBody.segments_risk).map((s) => s.risk)
         const singleMaxRisk = Math.max(...singleRiskValues)
@@ -378,10 +387,10 @@ describe('GET /v0/risk report type handling', () => {
             .limit(2)
 
         for (const s of stationsOnLine) {
-            await sendReportRequest({ stationId: s.stationId, lineId: testLineId, source: 'telegram' })
+            await postRiskReport({ stationId: s.stationId, lineId: testLineId, source: 'telegram' })
         }
 
-        const multiResponse = await appRequestWithRedirect('/risk')
+        const multiResponse = await getRisk()
         const multiBody = (await multiResponse.json()) as RiskResponse
         const multiRiskValues = Object.values(multiBody.segments_risk).map((s) => s.risk)
         const multiMaxRisk = Math.max(...multiRiskValues)
@@ -403,17 +412,17 @@ describe('GET /v0/risk report type handling', () => {
         const directionId = stationsOnLine[stationsOnLine.length - 1]!.stationId
 
         // Report without direction
-        await sendReportRequest({ stationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId, lineId: testLineId, source: 'telegram' })
 
-        const undirectedResponse = await appRequestWithRedirect('/risk')
+        const undirectedResponse = await getRisk()
         const undirectedBody = (await undirectedResponse.json()) as RiskResponse
 
         await db.delete(reports)
 
         // Report with direction
-        await sendReportRequest({ stationId, lineId: testLineId, directionId, source: 'telegram' })
+        await postRiskReport({ stationId, lineId: testLineId, directionId, source: 'telegram' })
 
-        const directedResponse = await appRequestWithRedirect('/risk')
+        const directedResponse = await getRisk()
         const directedBody = (await directedResponse.json()) as RiskResponse
 
         // Both should produce risky segments
@@ -442,9 +451,9 @@ describe('GET /v0/risk report type handling', () => {
         const [singleLineStationId] = singleLineStationOnA
 
         // --- Baseline: report at a single-line station on lineA with an explicit lineId ---
-        await sendReportRequest({ stationId: singleLineStationId, lineId: lineA, source: 'telegram' })
+        await postRiskReport({ stationId: singleLineStationId, lineId: lineA, source: 'telegram' })
 
-        const baselineResponse = await appRequestWithRedirect('/risk')
+        const baselineResponse = await getRisk()
         const baselineBody = (await baselineResponse.json()) as RiskResponse
         const baselineSegmentsA = await db.select({ id: segments.id }).from(segments).where(eq(segments.lineId, lineA))
         const baselineIdsA = new Set(baselineSegmentsA.map((s) => String(s.id)))
@@ -458,9 +467,9 @@ describe('GET /v0/risk report type handling', () => {
         await db.delete(reports)
 
         // --- Multi-line: same station but no lineId → lines = [lineA, lineB] ---
-        await sendReportRequest({ stationId: multiLineStationId, source: 'telegram' })
+        await postRiskReport({ stationId: multiLineStationId, source: 'telegram' })
 
-        const multiResponse = await appRequestWithRedirect('/risk')
+        const multiResponse = await getRisk()
         const multiBody = (await multiResponse.json()) as RiskResponse
 
         // Segments from BOTH lines should appear in the output
@@ -534,9 +543,9 @@ describe('GET /v0/risk overlapping segments', () => {
 
         const overlapSegmentIds = overlapIds
 
-        await sendReportRequest({ stationId: overlapStationId, lineId: primaryLineId, source: 'telegram' })
+        await postRiskReport({ stationId: overlapStationId, lineId: primaryLineId, source: 'telegram' })
 
-        const response = await appRequestWithRedirect('/risk')
+        const response = await getRisk()
         const body = (await response.json()) as RiskResponse
 
         const riskyIds = new Set(Object.keys(body.segments_risk))


### PR DESCRIPTION
## Describe the issue:
The risk model was being run on every request. This is not very efficient since we only need to run it every 5 min or if a report updates. 

## Explain how you solved the issue:
Added a 5 Min TTL cache.

## Additional notes or considerations:
Also changed the tests to create a new appInstance for each test so that we do not get issues with caching in tests