### PR TITLE
refactor: speed up tests

### DIFF
--- a/packages/hono-backend/tests/generalAPI.test.ts
+++ b/packages/hono-backend/tests/generalAPI.test.ts
@@ -1,13 +1,7 @@
-import { beforeAll, describe, expect, it } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 
-import { seedBaseData } from '../src/db/seed/seed'
-import { db } from '../src/db'
 import { app } from '../src/index'
 import { appRequestWithRedirect } from './test-utils'
-
-beforeAll(async () => {
-    await seedBaseData(db)
-})
 
 describe('Versioning', () => {
     it('serves GET /v0/reports directly', async () => {

--- a/packages/hono-backend/tests/getDistance.test.ts
+++ b/packages/hono-backend/tests/getDistance.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeAll, describe, expect, it } from 'bun:test'
 import { asc, eq, inArray } from 'drizzle-orm'
 
 import { db, lines, lineStations, stations } from '../src/db'
-import { seedBaseData } from '../src/db/seed/seed'
 import { app, createApp } from '../src/index'
 import { appRequestWithRedirect } from './test-utils'
 
@@ -32,8 +31,6 @@ const getDistance = (from: string, to: string, targetApp = app) => {
 
 describe('GET /v0/transit/distance', () => {
     beforeAll(async () => {
-        await seedBaseData(db)
-
         const rows = await db
             .select({
                 lineId: lineStations.lineId,

--- a/packages/hono-backend/tests/getReports.test.ts
+++ b/packages/hono-backend/tests/getReports.test.ts
@@ -3,7 +3,6 @@ import { eq } from 'drizzle-orm'
 import { DateTime, Settings } from 'luxon'
 
 import { db, lineStations, lines, reports } from '../src/db'
-import { seedBaseData } from '../src/db/seed/seed'
 import { createApp } from '../src/index'
 import {
     DEFAULT_REPORTS_TIMEFRAME,
@@ -50,8 +49,6 @@ const getValidReportPayload = async () => {
 
 describe('Timeframe filtering', () => {
     beforeAll(async () => {
-        await seedBaseData(db)
-
         const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
         testLineId = line.id
 
@@ -153,8 +150,6 @@ describe('Predicted reports', () => {
     let allStationIds: string[]
 
     beforeAll(async () => {
-        await seedBaseData(db)
-
         const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
         testLineId = line.id
 
@@ -418,8 +413,6 @@ describe('Predicted reports threshold', () => {
     }
 
     beforeAll(async () => {
-        await seedBaseData(db)
-
         const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
         testLineId = line.id
 
@@ -644,8 +637,6 @@ describe('Reports by station route', () => {
     let lineId: string
 
     beforeAll(async () => {
-        await seedBaseData(db)
-
         const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
         lineId = line.id
 

--- a/packages/hono-backend/tests/getRisk.test.ts
+++ b/packages/hono-backend/tests/getRisk.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test
 import { eq } from 'drizzle-orm'
 
 import { db, lineStations, lines, reports, segments } from '../src/db'
-import { seedBaseData } from '../src/db/seed/seed'
 import { appRequestWithRedirect, sendReportRequest } from './test-utils'
 
 type SegmentRisk = { color: string; risk: number }
@@ -16,8 +15,6 @@ let testLineId: string
 
 describe('GET /v0/risk response shape', () => {
     beforeAll(async () => {
-        await seedBaseData(db)
-
         const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
         const [stationOnLine] = await db
             .select({ stationId: lineStations.stationId })
@@ -108,8 +105,6 @@ describe('GET /v0/risk response shape', () => {
 
 describe('GET /v0/risk timeframe filtering', () => {
     beforeAll(async () => {
-        await seedBaseData(db)
-
         const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
         const [stationOnLine] = await db
             .select({ stationId: lineStations.stationId })
@@ -206,8 +201,6 @@ describe('GET /v0/risk segment targeting', () => {
     let stationOnSegmentLine: string
 
     beforeAll(async () => {
-        await seedBaseData(db)
-
         // Find a segment and a station that belongs to its line
         const [segment] = await db
             .select({
@@ -338,8 +331,6 @@ describe('GET /v0/risk segment targeting', () => {
 
 describe('GET /v0/risk report type handling', () => {
     beforeAll(async () => {
-        await seedBaseData(db)
-
         const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
         const [stationOnLine] = await db
             .select({ stationId: lineStations.stationId })
@@ -492,8 +483,6 @@ describe('GET /v0/risk overlapping segments', () => {
     let overlapStationId: string | null = null
 
     beforeAll(async () => {
-        await seedBaseData(db)
-
         const allSegments = await db
             .select({
                 id: segments.id,

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -4,7 +4,6 @@ import { Hono } from 'hono'
 import { Stations } from '../src/modules/transit/types'
 import { TransitNetworkDataService } from '../src/modules/transit/transit-network-data-service'
 import { db, lineStations, reports, stations } from '../src/db'
-import { seedBaseData } from '../src/db/seed/seed'
 import { and, desc, eq } from 'drizzle-orm'
 import { sendReportRequest } from './test-utils'
 
@@ -23,8 +22,6 @@ describe('Telegram notification', () => {
     let shouldFail: boolean
 
     beforeAll(async () => {
-        await seedBaseData(db)
-
         const fakeNlp = new Hono()
 
         fakeNlp.post('/report-inspector', async (c) => {
@@ -140,7 +137,6 @@ describe('Security Verification', () => {
 
 describe('Report API contract', () => {
     beforeAll(async () => {
-        await seedBaseData(db)
         process.env.NODE_ENV = 'production'
         process.env.REPORT_PASSWORD = 'test-password' // To pass the security check
     })
@@ -409,7 +405,6 @@ describe('Report Post Processing', () => {
     let firstStationOnLineId: string
 
     beforeAll(async () => {
-        await seedBaseData(db)
         const transitService = new TransitNetworkDataService(db)
         stationsMap = await transitService.getStations()
         linesMap = Object.fromEntries(

--- a/packages/hono-backend/tests/preload.ts
+++ b/packages/hono-backend/tests/preload.ts
@@ -3,11 +3,15 @@
 process.env.LOG_LEVEL = process.env.TEST_LOG_LEVEL ?? 'error'
 process.env.DATABASE_URL = process.env.DATABASE_URL_TEST ?? process.env.DATABASE_URL
 
-import { migrate } from 'drizzle-orm/postgres-js/migrator'
-import { db } from '../src/db'
-import { seedBaseData } from '../src/db/seed/seed'
+const [{ migrate }, { db }, { seedBaseData }] = await Promise.all([
+    import('drizzle-orm/postgres-js/migrator'),
+    import('../src/db'),
+    import('../src/db/seed/seed'),
+])
 
 await migrate(db, { migrationsFolder: './drizzle' })
 
 // Seed the read-only reference tables (stations, lines, line_stations, segments) once for the whole test run.
 await seedBaseData(db)
+
+export {}

--- a/packages/hono-backend/tests/preload.ts
+++ b/packages/hono-backend/tests/preload.ts
@@ -5,5 +5,9 @@ process.env.DATABASE_URL = process.env.DATABASE_URL_TEST ?? process.env.DATABASE
 
 import { migrate } from 'drizzle-orm/postgres-js/migrator'
 import { db } from '../src/db'
+import { seedBaseData } from '../src/db/seed/seed'
 
 await migrate(db, { migrationsFolder: './drizzle' })
+
+// Seed the read-only reference tables (stations, lines, line_stations, segments) once for the whole test run.
+await seedBaseData(db)


### PR DESCRIPTION
## Describe the issue:
We were reseeding the db before each test. This was super inefficient since the data did not change.

## Explain how you solved the issue:
We are now only seeding once in `preload.ts`. This reduced the time it takes to run the test by roughly 50%.

