### PR TITLE
refactor: Make CORS origins configurable

### DIFF
--- a/packages/hono-backend/README.md
+++ b/packages/hono-backend/README.md
@@ -9,6 +9,7 @@ The .env file contains the following variables:
 - `NLP_SERVICE_URL`: The URL of the NLP service to use.
 - `REPORT_PASSWORD`: The password to use for the report API.
 - `SECURITY_MICROSERVICE_URL`: The URL of the security microservice to use.
+- `CORS_ORIGINS`: Comma-separated list of frontend origins allowed to call the API, for example `http://localhost:1871,https://freifahren.org`.
 
 ## Start containers
 

--- a/packages/hono-backend/compose-hono.test.yaml
+++ b/packages/hono-backend/compose-hono.test.yaml
@@ -27,6 +27,7 @@ services:
             NLP_SERVICE_URL: http://localhost:6000
             REPORT_PASSWORD: password
             SECURITY_MICROSERVICE_URL: http://localhost:4000
+            CORS_ORIGINS: http://localhost:1871,http://127.0.0.1:1871
         ports:
             - '80:3000'
         volumes:

--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { cors } from 'hono/cors'
 import { requestId } from 'hono/request-id'
 import { pinoLogger } from 'hono-pino'
 
@@ -14,6 +15,18 @@ import { RiskService } from './modules/risk/risk-service'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
 import { getDistance, getLines, getSegments, getStations } from './modules/transit/transit-routes'
 
+const getCorsOrigins = () => {
+    const configuredOrigins = Bun.env.CORS_ORIGINS?.split(',')
+        .map((origin) => origin.trim())
+        .filter((origin) => origin !== '')
+
+    if (configuredOrigins === undefined || configuredOrigins.length === 0) {
+        throw new Error('CORS_ORIGINS must be set to a comma-separated list of allowed origins')
+    }
+
+    return configuredOrigins
+}
+
 const createServices = (db: DbConnection) => {
     const transitNetworkDataService = new TransitNetworkDataService(db)
 
@@ -28,6 +41,15 @@ export const createApp = (dbConnection: DbConnection = db) => {
     const app = new Hono<Env>()
 
     app.use(requestId())
+    app.use(
+        '*',
+        cors({
+            origin: getCorsOrigins(),
+            allowHeaders: ['Accept', 'Content-Type', 'If-Modified-Since', 'If-None-Match'],
+            allowMethods: ['GET', 'POST', 'OPTIONS'],
+            exposeHeaders: ['ETag', 'Last-Modified'],
+        })
+    )
     app.use(
         pinoLogger({
             pino: logger,


### PR DESCRIPTION
## Summary

Adds CORS middleware to the Hono backend and reads the allowed origins from a required `CORS_ORIGINS` environment variable. The local Docker Compose setup now provides the local frontend origins, and the backend README documents the production configuration.

## Why

The frontend runs on a different origin than the Hono API in local development and production. Requests using ETag caching send `If-None-Match`, which triggers browser preflight checks. The backend needs explicit CORS handling for those requests and should fail fast when allowed origins are not configured.

## Validation

- `bun -e "import './src/index.ts'; console.log('ok')"` in `packages/hono-backend`

Full backend typecheck was not used because it is currently blocked by existing Drizzle declaration errors in `node_modules`.