### PR TITLE
fix: retain CORS headers on etag 304 responses

### DIFF
--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import { etag, RETAINED_304_HEADERS } from 'hono/etag'
 import { requestId } from 'hono/request-id'
 import { pinoLogger } from 'hono-pino'
 
@@ -48,6 +49,17 @@ export const createApp = (dbConnection: DbConnection = db) => {
             allowHeaders: ['Accept', 'Content-Type', 'If-Modified-Since', 'If-None-Match'],
             allowMethods: ['GET', 'POST', 'OPTIONS'],
             exposeHeaders: ['ETag', 'Last-Modified'],
+        })
+    )
+    app.use(
+        '/v0/transit/*',
+        etag({
+            retainedHeaders: [
+                ...RETAINED_304_HEADERS,
+                'access-control-allow-origin',
+                'access-control-allow-credentials',
+                'access-control-expose-headers',
+            ],
         })
     )
     app.use(

--- a/packages/hono-backend/src/modules/transit/transit-routes.ts
+++ b/packages/hono-backend/src/modules/transit/transit-routes.ts
@@ -1,5 +1,3 @@
-import type { Handler } from 'hono'
-import { etag } from 'hono/etag'
 import { z } from 'zod'
 
 import { Env } from '../../app-env'
@@ -8,7 +6,6 @@ import { defineRoute } from '../../common/router'
 export const getStations = defineRoute<Env>()({
     method: 'get' as const,
     path: '/stations',
-    middlewares: [etag() as Handler<Env>],
     docs: {
         summary: 'List stations',
         description: 'Returns all transit stations in the network.',
@@ -34,7 +31,6 @@ export const getStations = defineRoute<Env>()({
 export const getLines = defineRoute<Env>()({
     method: 'get' as const,
     path: '/lines',
-    middlewares: [etag() as Handler<Env>],
     docs: {
         summary: 'List lines',
         description: 'Returns all transit lines in the network.',
@@ -50,7 +46,6 @@ export const getLines = defineRoute<Env>()({
 export const getSegments = defineRoute<Env>()({
     method: 'get' as const,
     path: '/segments',
-    middlewares: [etag() as Handler<Env>],
     docs: {
         summary: 'List segments',
         description: 'Returns all transit line segments as GeoJSON features.',

--- a/packages/hono-backend/tests/generalAPI.test.ts
+++ b/packages/hono-backend/tests/generalAPI.test.ts
@@ -55,3 +55,32 @@ describe('Versioning', () => {
         expect(body).not.toContain('availableVersions')
     })
 })
+
+describe('ETag 304 + CORS', () => {
+    const ALLOWED_ORIGIN = 'http://localhost:1871'
+
+    it('returns 304 with Access-Control-Allow-Origin when If-None-Match matches', async () => {
+        const initial = await app.request('/v0/transit/stations', {
+            headers: { Origin: ALLOWED_ORIGIN },
+        })
+        expect(initial.status).toBe(200)
+        expect(initial.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED_ORIGIN)
+
+        const etag = initial.headers.get('ETag')
+        expect(etag).not.toBeNull()
+
+        const revalidated = await app.request('/v0/transit/stations', {
+            headers: {
+                Origin: ALLOWED_ORIGIN,
+                'If-None-Match': etag!,
+            },
+        })
+
+        expect(revalidated.status).toBe(304)
+        // Without this header the browser blocks the cross-origin 304 and the
+        // frontend's localStorage cache path fails — that is the regression we
+        // are guarding against.
+        expect(revalidated.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED_ORIGIN)
+        expect(revalidated.headers.get('ETag')).toBe(etag)
+    })
+})


### PR DESCRIPTION
## Summary

Configure Hono's `etag` middleware to retain the CORS headers when it rebuilds 304 responses, and apply it once globally on `/v0/transit/*` instead of per-route.

## Why

Hono's `etag` middleware replaces the response with a fresh `304 Not Modified` and only keeps a small whitelist of headers (`cache-control`, `content-location`, `date`, `etag`, `expires`, `vary`). The `cors` middleware sets `Access-Control-Allow-Origin` *before* `next()` and only appends `Vary` after, so once `etag` strips ACAO nothing puts it back.

Without ACAO, the browser blocks the cross-origin 304. The frontend's `fetch` rejects, React Query treats the request as a failure, and the cached transit data (stations, segments, lines) never reaches the map.

Extending `retainedHeaders` with the CORS headers keeps them on the 304 so the browser accepts the response and the frontend's localStorage cache path works as intended.

## Validation

- [x] Hit `/v0/transit/stations` twice from the frontend; second request returns `304` and the map renders from `localStorage`.
- [x] Response headers on the `304` include `Access-Control-Allow-Origin`.