### PR TITLE
Add custom message format to Pino logger output

### DIFF
--- a/packages/hono-backend/src/common/logger.ts
+++ b/packages/hono-backend/src/common/logger.ts
@@ -9,6 +9,7 @@ export const logger = pino({
                 options: {
                     colorize: true,
                     ignore: 'pid,hostname,req,res,responseTime,reqId',
+                    messageFormat: '{req.method} {req.url} {res.status} ({responseTime}ms)',
                     translateTime: 'SYS:standard',
                     destination: 1,
                 },


### PR DESCRIPTION
## Describe the issue:
The logger output was not displaying request/response information in a user-friendly format, making it harder to quickly understand HTTP request details in logs.

## Explain how you solved the issue:
Added a custom `messageFormat` configuration to the Pino logger that displays HTTP request method, URL, response status code, and response time in a concise format: `{req.method} {req.url} {res.status} ({responseTime}ms)`. This provides better visibility into request handling without requiring manual parsing of log fields.

## Additional notes or considerations:
- The format string leverages Pino's built-in field interpolation for HTTP transport
- Other fields like `pid`, `hostname`, `req`, `res`, and `reqId` are already being ignored via the existing `ignore` configuration, so the new format focuses on the most relevant information
- This change improves log readability for development and debugging purposes

https://claude.ai/code/session_01BeW7U4RPGRTUQmpBfTeNb4