### PR TITLE
refactor: return lines as an array of {id, name, stations}

### DIFF
--- a/packages/hono-backend/src/modules/reports/post-process-report.ts
+++ b/packages/hono-backend/src/modules/reports/post-process-report.ts
@@ -129,7 +129,7 @@ const correctDirectionIfImplied =
         if (reportData.stationId === undefined) return reportData
         if (reportData.directionId === null || reportData.directionId === undefined) return reportData
 
-        const stationsOnLine = lines[reportData.lineId]
+        const stationsOnLine = lines.find((line) => line.id === reportData.lineId)?.stations
         if (stationsOnLine === undefined || stationsOnLine.length < 2) return reportData
 
         const firstStationOnLine = stationsOnLine[0]

--- a/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
+++ b/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
@@ -5,7 +5,7 @@ import { DbConnection, stations, lineStations, lines, segments } from '../../db'
 
 import { buildGraph, type Graph, type StationId } from './pathfinding'
 import { TransitPathCacheService } from './transit-path-cache-service'
-import type { Lines, SegmentsFeatureCollection, Stations } from './types'
+import type { Line, Lines, SegmentsFeatureCollection, Stations } from './types'
 
 export class TransitNetworkDataService {
     private stationsCache: Promise<Stations> | null = null
@@ -67,20 +67,25 @@ export class TransitNetworkDataService {
                 const joinedRows = await this.db
                     .select({
                         lineId: lines.id,
+                        lineName: lines.name,
                         stationId: lineStations.stationId,
                     })
                     .from(lines)
                     .leftJoin(lineStations, eq(lineStations.lineId, lines.id))
                     .orderBy(asc(lines.id), asc(lineStations.order))
 
-                return joinedRows.reduce<Lines>((linesById, row) => {
-                    const base = Object.prototype.hasOwnProperty.call(linesById, row.lineId)
-                        ? linesById[row.lineId]
-                        : []
-                    const stations = row.stationId !== null ? [...base, row.stationId] : base
-                    linesById[row.lineId] = stations
-                    return linesById
-                }, {} as Lines)
+                const byId = new Map<string, Line>()
+                for (const row of joinedRows) {
+                    let line = byId.get(row.lineId)
+                    if (!line) {
+                        line = { id: row.lineId, name: row.lineName, stations: [] }
+                        byId.set(row.lineId, line)
+                    }
+                    if (row.stationId !== null) {
+                        line.stations.push(row.stationId)
+                    }
+                }
+                return Array.from(byId.values())
             } catch (error) {
                 this.linesCache = null
                 throw error

--- a/packages/hono-backend/src/modules/transit/transit-routes.ts
+++ b/packages/hono-backend/src/modules/transit/transit-routes.ts
@@ -35,7 +35,13 @@ export const getLines = defineRoute<Env>()({
         summary: 'List lines',
         description: 'Returns all transit lines in the network.',
         tags: ['transit'],
-        responseSchema: z.record(z.string(), z.array(z.string())),
+        responseSchema: z.array(
+            z.object({
+                id: z.string(),
+                name: z.string(),
+                stations: z.array(z.string()),
+            })
+        ),
     },
     handler: async (c) => {
         const transitNetworkDataService = c.get('transitNetworkDataService')

--- a/packages/hono-backend/src/modules/transit/types.ts
+++ b/packages/hono-backend/src/modules/transit/types.ts
@@ -40,6 +40,13 @@ type SegmentsFeatureCollection = {
 }
 
 type Stations = Record<StationId, Station>
-type Lines = Record<LineId, StationId[]>
 
-export type { Lines, Stations, SegmentsFeatureCollection, SegmentFeature, StationId, LineId }
+type Line = {
+    id: LineId
+    name: LineRow['name']
+    stations: StationId[]
+}
+
+type Lines = Line[]
+
+export type { Line, Lines, Stations, SegmentsFeatureCollection, SegmentFeature, StationId, LineId }

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -407,9 +407,7 @@ describe('Report Post Processing', () => {
     beforeAll(async () => {
         const transitService = new TransitNetworkDataService(db)
         stationsMap = await transitService.getStations()
-        linesMap = Object.fromEntries(
-            Object.entries(await transitService.getLines()).map(([key, value]) => [key, value ?? []])
-        )
+        linesMap = Object.fromEntries((await transitService.getLines()).map((line) => [line.id, line.stations]))
 
         const stationEntries = Object.entries(stationsMap)
 


### PR DESCRIPTION
## Summary

Change `GET /v0/transit/lines` from a `Record<lineId, stationIds[]>` to an array of `{ id, name, stations: string[] }` objects. The route now also exposes the human-readable line name from the `lines` table.

## Why

The previous shape did not expose the line name, and consumers had to derive ordering from object key iteration. Returning a sorted array with the full record makes the API self-describing and lets the frontend render line labels without a second lookup.

## Changes

- `transit/types.ts`: `Lines` is now `Line[]` where `Line = { id, name, stations }`.
- `transit/transit-network-data-service.ts`: `getLines` selects the line name and returns the new shape.
- `transit/transit-routes.ts`: response schema updated.
- `reports/post-process-report.ts`: `correctDirectionIfImplied` looks up by `lines.find(l => l.id === ...)`.
- `tests/postReport.test.ts`: adapt `linesMap` construction.

## Validation

- `bun test` — 86 pass.

## Breaking change

Frontend will be updated in a follow-up PR.