### PR TITLE
feat: configure segment color per route type in seed

### DIFF
--- a/packages/hono-backend/src/db/seed/config.ts
+++ b/packages/hono-backend/src/db/seed/config.ts
@@ -4,10 +4,13 @@ export const ROUTE_TYPE_PRIORITY = ['subway', 'tram', 'light_rail'] as const // 
 
 export type RouteType = (typeof ROUTE_TYPE_PRIORITY)[number]
 
-export const DEFAULT_ROUTE_COLORS: Record<RouteType, string> = {
-    subway: '#000000', // Fallback since we use the line color for subway lines.
-    tram: '#be1414',
-    light_rail: '#007734',
+// Route types listed here always get the configured color regardless of the
+// OSM relation tags (used to give all S-Bahn lines one shared green and all
+// Tram lines one shared red). Route types absent from this map fall back to
+// The OSM colour/color tag — best for subway lines with per-line branding.
+export const ROUTE_COLORS: Partial<Record<RouteType, string>> = {
+    tram: '#be1414', // Classic Berlin tram red (tram and metro tram M* lines).
+    light_rail: '#007734', // Berlin S-Bahn green (S2), applied to all S-Bahn lines.
 }
 
 export const SEED_CONFIG = {
@@ -72,5 +75,5 @@ export const SEED_CONFIG = {
 
     mergeThresholdMeters: 250, // The threshold in meters for merging proximate stations.
     geometrySimplificationTolerance: 0.00003, // Approx. 3m in latitude; keeps endpoints while reducing vertex count.
-    defaultRouteColors: DEFAULT_ROUTE_COLORS,
+    routeColors: ROUTE_COLORS,
 } as const

--- a/packages/hono-backend/src/db/seed/segments/index.ts
+++ b/packages/hono-backend/src/db/seed/segments/index.ts
@@ -367,15 +367,12 @@ const buildRouteGeometries = (elements: OsmElement[]): Map<number, RouteGeometry
 }
 
 const resolveColor = (tags: Record<string, string | undefined>): string => {
-    const explicit = tags.colour ?? tags.color
-    if (explicit !== undefined && explicit !== '') return explicit
-
     const routeType = tags.route as RouteType | undefined
-    if (routeType && routeType in SEED_CONFIG.defaultRouteColors) {
-        return SEED_CONFIG.defaultRouteColors[routeType]
-    }
+    const configured = routeType ? SEED_CONFIG.routeColors[routeType] : undefined
+    if (configured !== undefined) return configured
 
-    return '#000000'
+    const explicit = tags.colour ?? tags.color
+    return explicit !== undefined && explicit !== '' ? explicit : '#000000'
 }
 
 const buildSegmentRecords = (


### PR DESCRIPTION
## Summary

Make the seeder pick segment colors based on the OSM route type:

- **subway** — uses the OSM \`colour\`/\`color\` tag (per-line branding for U-Bahn).
- **light_rail** — always painted in the configured Berlin S-Bahn green (\`#007734\`).
- **tram** — always painted in the classic tram red (\`#be1414\`), covering trams and metro tram (M*) lines.

A single \`ROUTE_COLORS: Partial<Record<RouteType, string>>\` map drives this: route types listed there always get the configured color, route types absent from the map fall back to OSM, and missing OSM colors fall back to black.

## Why

Berlin S-Bahn relations have per-line colors in OSM (S1 pink, S3 turquoise, etc.) but the product wants them all painted in one shared green. Trams are similar — every tram line should look like a tram. U-Bahn lines, by contrast, want the per-line OSM color preserved.

## Validation

- \`bun test\` — 86 pass.
- Re-run the seed against the database to apply the new colors to existing rows.