### PR TITLE
fix: preserve user reports across re-seed

### DIFF
--- a/packages/hono-backend/src/db/seed/lines/index.ts
+++ b/packages/hono-backend/src/db/seed/lines/index.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm'
+import { inArray, notInArray, sql } from 'drizzle-orm'
 
 import { logger } from '../../../common/logger'
 import type { DbConnection } from '../../index'
@@ -33,9 +33,35 @@ export const seedLinesFromRelations = async (
     )
 
     await db.transaction(async (tx) => {
-        await tx.execute(sql`TRUNCATE lines CASCADE`)
-        await tx.insert(lines).values(lineRecords)
+        // Upsert instead of TRUNCATE CASCADE so reports referencing existing
+        // lines survive a re-seed.
+        await tx
+            .insert(lines)
+            .values(lineRecords)
+            .onConflictDoUpdate({
+                target: lines.id,
+                set: {
+                    name: sql`excluded.name`,
+                    isCircular: sql`excluded.is_circular`,
+                },
+            })
+
+        // line_stations is a join table not referenced by anything else, so
+        // it's safe to wipe and rebuild for the lines we are re-seeding.
+        const newLineIds = lineRecords.map((l) => l.id)
+        await tx.delete(lineStations).where(inArray(lineStations.lineId, newLineIds))
         await tx.insert(lineStations).values(lineStationRecords)
+
+        // Drop lines no longer in the snapshot, but keep ones still
+        // referenced by reports. Cascading FKs from segments and
+        // line_stations clean themselves up.
+        await tx.execute(sql`
+            DELETE FROM lines
+            WHERE ${notInArray(lines.id, newLineIds)}
+              AND NOT EXISTS (
+                  SELECT 1 FROM reports WHERE reports.line_id = lines.id
+              )
+        `)
     })
 
     logger.info(

--- a/packages/hono-backend/src/db/seed/lines/index.ts
+++ b/packages/hono-backend/src/db/seed/lines/index.ts
@@ -1,8 +1,9 @@
-import { inArray, notInArray, sql } from 'drizzle-orm'
+import { and, eq, inArray, notExists, notInArray, sql } from 'drizzle-orm'
 
 import { logger } from '../../../common/logger'
 import type { DbConnection } from '../../index'
 import { lines, lineStations } from '../../schema/lines'
+import { reports } from '../../schema/reports'
 import type { OsmRelation } from '../stations/overpass'
 
 import { buildLineVariants, type LineVariant } from './build-variants'
@@ -55,13 +56,17 @@ export const seedLinesFromRelations = async (
         // Drop lines no longer in the snapshot, but keep ones still
         // referenced by reports. Cascading FKs from segments and
         // line_stations clean themselves up.
-        await tx.execute(sql`
-            DELETE FROM lines
-            WHERE ${notInArray(lines.id, newLineIds)}
-              AND NOT EXISTS (
-                  SELECT 1 FROM reports WHERE reports.line_id = lines.id
-              )
-        `)
+        await tx.delete(lines).where(
+            and(
+                notInArray(lines.id, newLineIds),
+                notExists(
+                    tx
+                        .select({ ref: sql`1` })
+                        .from(reports)
+                        .where(eq(reports.lineId, lines.id))
+                )
+            )
+        )
     })
 
     logger.info(

--- a/packages/hono-backend/src/db/seed/segments/index.ts
+++ b/packages/hono-backend/src/db/seed/segments/index.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm'
+import { inArray, sql } from 'drizzle-orm'
 
 import { logger } from '../../../common/logger'
 import type { DbConnection } from '../../index'
@@ -476,9 +476,9 @@ export const seedSegmentsFromGeometry = async (
 
     await db.transaction(async (tx) => {
         // Upsert keyed on the natural (lineId, fromStationId, toStationId) tuple
-        // so existing segment ids stay stable across re-seeds. The serial 'id'
-        // column is what the risk model and the frontend's localStorage cache
-        // refer to, so churning ids on every seed would invalidate both.
+        // So existing segment ids stay stable across re-seeds. The serial 'id'
+        // Column is what the risk model and the frontend's localStorage cache
+        // Refer to, so churning ids on every seed would invalidate both.
         await tx
             .insert(segments)
             .values(simplifiedRecords)
@@ -492,9 +492,7 @@ export const seedSegmentsFromGeometry = async (
             })
 
         // Prune segments that no longer exist in the snapshot.
-        const newKeys = new Set(
-            simplifiedRecords.map((r) => `${r.lineId}|${r.fromStationId}|${r.toStationId}`)
-        )
+        const newKeys = new Set(simplifiedRecords.map((r) => `${r.lineId}|${r.fromStationId}|${r.toStationId}`))
         const existing = await tx
             .select({
                 id: segments.id,
@@ -507,7 +505,7 @@ export const seedSegmentsFromGeometry = async (
             .filter((row) => !newKeys.has(`${row.lineId}|${row.fromStationId}|${row.toStationId}`))
             .map((row) => row.id)
         if (obsoleteIds.length > 0) {
-            await tx.execute(sql`DELETE FROM segments WHERE id = ANY(${obsoleteIds})`)
+            await tx.delete(segments).where(inArray(segments.id, obsoleteIds))
         }
     })
 

--- a/packages/hono-backend/src/db/seed/segments/index.ts
+++ b/packages/hono-backend/src/db/seed/segments/index.ts
@@ -475,12 +475,44 @@ export const seedSegmentsFromGeometry = async (
     }
 
     await db.transaction(async (tx) => {
-        await tx.execute(sql`TRUNCATE segments RESTART IDENTITY`)
-        await tx.insert(segments).values(simplifiedRecords)
+        // Upsert keyed on the natural (lineId, fromStationId, toStationId) tuple
+        // so existing segment ids stay stable across re-seeds. The serial 'id'
+        // column is what the risk model and the frontend's localStorage cache
+        // refer to, so churning ids on every seed would invalidate both.
+        await tx
+            .insert(segments)
+            .values(simplifiedRecords)
+            .onConflictDoUpdate({
+                target: [segments.lineId, segments.fromStationId, segments.toStationId],
+                set: {
+                    position: sql`excluded.position`,
+                    color: sql`excluded.color`,
+                    coordinates: sql`excluded.coordinates`,
+                },
+            })
+
+        // Prune segments that no longer exist in the snapshot.
+        const newKeys = new Set(
+            simplifiedRecords.map((r) => `${r.lineId}|${r.fromStationId}|${r.toStationId}`)
+        )
+        const existing = await tx
+            .select({
+                id: segments.id,
+                lineId: segments.lineId,
+                fromStationId: segments.fromStationId,
+                toStationId: segments.toStationId,
+            })
+            .from(segments)
+        const obsoleteIds = existing
+            .filter((row) => !newKeys.has(`${row.lineId}|${row.fromStationId}|${row.toStationId}`))
+            .map((row) => row.id)
+        if (obsoleteIds.length > 0) {
+            await tx.execute(sql`DELETE FROM segments WHERE id = ANY(${obsoleteIds})`)
+        }
     })
 
     logger.info(
-        `[seed:segments] Inserted ${simplifiedRecords.length} segments ` +
+        `[seed:segments] Upserted ${simplifiedRecords.length} segments ` +
             `(${originalVertexCount} → ${simplifiedVertexCount} coordinates after simplification)`
     )
 }

--- a/packages/hono-backend/src/db/seed/stations/index.ts
+++ b/packages/hono-backend/src/db/seed/stations/index.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm'
+import { notInArray, sql } from 'drizzle-orm'
 
 import { logger } from '../../../common/logger'
 import type { DbConnection } from '../../index'
@@ -70,10 +70,35 @@ export const seedStationsFromElements = async (
     }))
 
     await db.transaction(async (tx) => {
-        await tx.execute(sql`TRUNCATE stations CASCADE`)
-        await tx.insert(stations).values(records)
+        // Upsert instead of TRUNCATE CASCADE so that reports referencing
+        // existing stations survive a re-seed.
+        await tx
+            .insert(stations)
+            .values(records)
+            .onConflictDoUpdate({
+                target: stations.id,
+                set: {
+                    name: sql`excluded.name`,
+                    lat: sql`excluded.lat`,
+                    lng: sql`excluded.lng`,
+                },
+            })
+
+        // Drop stations no longer in the snapshot, but keep ones still
+        // referenced by reports so we don't lose user data. Cascading FKs
+        // from segments and line_stations clean themselves up.
+        const newIds = records.map((r) => r.id)
+        await tx.execute(sql`
+            DELETE FROM stations
+            WHERE ${notInArray(stations.id, newIds)}
+              AND NOT EXISTS (
+                  SELECT 1 FROM reports
+                  WHERE reports.station_id = stations.id
+                     OR reports.direction_id = stations.id
+              )
+        `)
     })
-    logger.info(`[seed:stations] Inserted ${records.length} stations`)
+    logger.info(`[seed:stations] Upserted ${records.length} stations`)
 
     const nodeIdToStationId = new Map<number, string>()
     for (const [nodeId, code] of nodeIdToCode) {

--- a/packages/hono-backend/src/db/seed/stations/index.ts
+++ b/packages/hono-backend/src/db/seed/stations/index.ts
@@ -1,7 +1,8 @@
-import { notInArray, sql } from 'drizzle-orm'
+import { and, eq, notExists, notInArray, or, sql } from 'drizzle-orm'
 
 import { logger } from '../../../common/logger'
 import type { DbConnection } from '../../index'
+import { reports } from '../../schema/reports'
 import { stations } from '../../schema/stations'
 
 import { buildDataset } from './build-dataset'
@@ -71,7 +72,7 @@ export const seedStationsFromElements = async (
 
     await db.transaction(async (tx) => {
         // Upsert instead of TRUNCATE CASCADE so that reports referencing
-        // existing stations survive a re-seed.
+        // Existing stations survive a re-seed.
         await tx
             .insert(stations)
             .values(records)
@@ -85,18 +86,20 @@ export const seedStationsFromElements = async (
             })
 
         // Drop stations no longer in the snapshot, but keep ones still
-        // referenced by reports so we don't lose user data. Cascading FKs
-        // from segments and line_stations clean themselves up.
+        // Referenced by reports so we don't lose user data. Cascading FKs
+        // From segments and line_stations clean themselves up.
         const newIds = records.map((r) => r.id)
-        await tx.execute(sql`
-            DELETE FROM stations
-            WHERE ${notInArray(stations.id, newIds)}
-              AND NOT EXISTS (
-                  SELECT 1 FROM reports
-                  WHERE reports.station_id = stations.id
-                     OR reports.direction_id = stations.id
-              )
-        `)
+        await tx.delete(stations).where(
+            and(
+                notInArray(stations.id, newIds),
+                notExists(
+                    tx
+                        .select({ ref: sql`1` })
+                        .from(reports)
+                        .where(or(eq(reports.stationId, stations.id), eq(reports.directionId, stations.id)))
+                )
+            )
+        )
     })
     logger.info(`[seed:stations] Upserted ${records.length} stations`)
 

--- a/packages/hono-backend/tests/seed.test.ts
+++ b/packages/hono-backend/tests/seed.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+import { db, reports, stations } from '../src/db'
+import { seedBaseData } from '../src/db/seed/seed'
+
+describe('seedBaseData', () => {
+    beforeEach(async () => {
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        await db.delete(reports)
+    })
+
+    it('preserves existing reports across a re-seed', async () => {
+        const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
+        if (!station) throw new Error('expected at least one seeded station to exist')
+
+        const [inserted] = await db
+            .insert(reports)
+            .values({
+                stationId: station.id,
+                lineId: null,
+                directionId: null,
+                source: 'web_app',
+            })
+            .returning({ reportId: reports.reportId })
+
+        await seedBaseData(db)
+
+        const after = await db.select({ reportId: reports.reportId }).from(reports)
+        expect(after).toEqual([{ reportId: inserted.reportId }])
+    })
+})


### PR DESCRIPTION
## Summary

Switch the seeders for stations, lines, and segments from \`TRUNCATE ... CASCADE\` to upserts so user reports stop getting wiped on every re-seed.

## Why

The seed truncated \`stations\` and \`lines\` with \`CASCADE\`. PostgreSQL's \`TRUNCATE ... CASCADE\` ignores \`ON DELETE\` rules and nukes every row in any table that has a foreign key into the truncated table. \`reports\` has FKs into both (\`stationId\`, \`directionId\`, \`lineId\`), so every user-submitted report was deleted on each seed run.

## Approach

- **stations**: upsert by \`id\`. After upsert, delete rows no longer in the snapshot, but only when no report still references them — keeps user data intact even if a station is removed from OSM.
- **lines**: same pattern — upsert by \`id\`, then delete unreferenced obsolete lines.
- **line_stations**: not externally referenced, so the rows for re-seeded lines are wiped and rebuilt.
- **segments**: upsert keyed on the natural \`(lineId, fromStationId, toStationId)\` index so the serial \`id\` stays stable across re-seeds (the risk model and the frontend's localStorage cache both rely on those ids).

## Regression test

\`tests/seed.test.ts\` inserts a report and asserts it survives a subsequent \`seedBaseData\` call. Verified that the test fails against the previous TRUNCATE behaviour and passes with the upsert change.

## Validation

- \`bun test\` — 87 pass.