### PR TITLE
Expose Hono backend on localhost:3000

### DIFF
--- a/packages/hono-backend/compose-hono.test.yaml
+++ b/packages/hono-backend/compose-hono.test.yaml
@@ -29,7 +29,7 @@ services:
             SECURITY_MICROSERVICE_URL: http://localhost:4000
             CORS_ORIGINS: http://localhost:1871,http://127.0.0.1:1871
         ports:
-            - '80:3000'
+            - '3000:3000'
         volumes:
             - ./src:/app/src:ro
             - ./bunfig.toml:/app/bunfig.toml:ro


### PR DESCRIPTION
### Motivation
- Align the Hono test Docker Compose port mapping with the backend default `BACKEND_URL=http://localhost:3000` so local development (including the Telegram bot) can use the default URL without Docker-specific overrides.

### Description
- Update `packages/hono-backend/compose-hono.test.yaml` to change the `hono-bun` service port mapping from `'80:3000'` to `'3000:3000'` so host port `3000` forwards to container port `3000`.

### Testing
- Parsed the compose file with a small Python script (`yaml.safe_load`) which shows `services.bun.ports` as `['3000:3000']`, `git diff --check` passed, and attempts to run `docker compose -f packages/hono-backend/compose-hono.test.yaml up -d --build --force-recreate` and `curl http://localhost:3000/v0/transit/stations` could not be completed because Docker is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a05d3d27db0832dbb6ef20a9ee8f1a7)