### PR TITLE
Add isCircular field to transit line data model

### DIFF
--- a/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
+++ b/packages/hono-backend/src/modules/transit/transit-network-data-service.ts
@@ -69,6 +69,7 @@ export class TransitNetworkDataService {
                         lineId: lines.id,
                         lineName: lines.name,
                         lineType: lines.type,
+                        lineIsCircular: lines.isCircular,
                         stationId: lineStations.stationId,
                     })
                     .from(lines)
@@ -79,7 +80,13 @@ export class TransitNetworkDataService {
                 for (const row of joinedRows) {
                     let line = byId.get(row.lineId)
                     if (!line) {
-                        line = { id: row.lineId, name: row.lineName, type: row.lineType, stations: [] }
+                        line = {
+                            id: row.lineId,
+                            name: row.lineName,
+                            type: row.lineType,
+                            isCircular: row.lineIsCircular,
+                            stations: [],
+                        }
                         byId.set(row.lineId, line)
                     }
                     if (row.stationId !== null) {

--- a/packages/hono-backend/src/modules/transit/transit-routes.ts
+++ b/packages/hono-backend/src/modules/transit/transit-routes.ts
@@ -41,6 +41,7 @@ export const getLines = defineRoute<Env>()({
                 id: z.string(),
                 name: z.string(),
                 type: z.enum(ROUTE_TYPE_PRIORITY),
+                isCircular: z.boolean(),
                 stations: z.array(z.string()),
             })
         ),

--- a/packages/hono-backend/src/modules/transit/types.ts
+++ b/packages/hono-backend/src/modules/transit/types.ts
@@ -45,6 +45,7 @@ type Line = {
     id: LineId
     name: LineRow['name']
     type: LineRow['type']
+    isCircular: LineRow['isCircular']
     stations: StationId[]
 }
 


### PR DESCRIPTION
## Describe the issue:
The transit line data model was missing the `isCircular` field, which is available in the database but not being exposed through the API or used in the application layer.

## Explain how you solved the issue:
Added the `isCircular` field throughout the transit line data pipeline:
1. Updated the `Line` type definition in `types.ts` to include the `isCircular` field from `LineRow`
2. Modified the database query in `transit-network-data-service.ts` to select the `isCircular` column from the lines table
3. Updated the line object construction to include the `isCircular` property when creating new line instances
4. Added `isCircular` to the response schema validation in `transit-routes.ts` as a boolean field

## Additional notes or considerations:
This change ensures that circular route information is properly propagated from the database through the service layer to the API response, allowing clients to distinguish between circular and non-circular transit lines.

https://claude.ai/code/session_01J1WYbsCeP4NkMJ349aoNhu