### PR TITLE
docs: add AGENTS.md with contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,11 @@ Use Conventional Commit prefixes for both commit messages and PR titles:
 
 Example: `fix: return 404 instead of 500 when station id is unknown`
 
+## Hono backend conventions
+
+- **Throw `AppError` at service boundaries**, not raw `Error` or ad-hoc `c.json({ error: ... })`. `AppError` (see `packages/hono-backend/src/common/errors.ts`) carries a `statusCode` and an `internalCode`, and the central error handler strips descriptions in production so internal details don't leak. Domain-specific errors should be converted to `AppError` before they reach the response.
+- **Use the Pino logger from context** (`c.get('logger')`) instead of `console.log`. It's wired up in `packages/hono-backend/src/common/logger.ts` with daily rotation and pretty-printing in dev. Log structured objects (`logger.info({ reportId }, 'report created')`), not interpolated strings, so the JSON output stays queryable.
+
 ## City-agnostic code
 
 The codebase should not assume Berlin. Keep city-specific data (station lists, line colors, network names, timezone, language) in **config files** under `packages/hono-backend/src/db/seed/config.ts` and similar locations — never hard-coded in business logic. Config files are the only sanctioned escape hatch for city-specific values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+Guidance for AI agents (and humans) contributing to FreiFahren.
+
+## Testing
+
+Prefer **integration tests** over unit tests. Drive behavior through the public API surface so tests cover routing, validation, and persistence together.
+
+- **No manual DB inserts in tests.** To set up state, send a request to the API (e.g. `POST /reports`) instead of writing to the database directly. This keeps tests realistic and avoids coupling them to schema details.
+- **Mock time, don't backdate rows.** When a test needs "old" data, use `setSystemTime` from `bun:test` to move the clock, send the request, then move the clock forward — instead of inserting rows with old timestamps.
+- **Use `appRequestWithRedirect`** (from `packages/hono-backend/tests/test-utils.ts`) instead of `app.request` directly. It follows the version redirect so tests automatically exercise the latest API version without hard-coding `/v0/...` paths.
+- **Don't assert on exact error message strings.** Assert on status codes and structured error fields (codes, types). Exact wording is presentational and will churn.
+
+## Migrations
+
+When generating a Drizzle migration, give it a **descriptive name** that reflects the change (e.g. `add_reports_direction_index`), not the auto-generated codename (`tearful_slayback`). Rename the generated SQL file and update `drizzle/meta` accordingly.
+
+## Commits and PR titles
+
+Use Conventional Commit prefixes for both commit messages and PR titles:
+
+- `feat:` — new user-facing functionality
+- `fix:` — bug fix
+- `refactor:` — code change that neither fixes a bug nor adds a feature
+- `chore:` — tooling, dependencies, build, CI
+- `docs:` — documentation only
+- `test:` — adding or adjusting tests
+
+Example: `fix: return 404 instead of 500 when station id is unknown`
+
+## City-agnostic code
+
+The codebase should not assume Berlin. Keep city-specific data (station lists, line colors, network names, timezone, language) in **config files** under `packages/hono-backend/src/db/seed/config.ts` and similar locations — never hard-coded in business logic. Config files are the only sanctioned escape hatch for city-specific values.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](./AGENTS.md).


### PR DESCRIPTION
## Describe the issue:

The repository lacked centralized guidance for contributors (both AI agents and humans) on testing patterns, code conventions, and architectural decisions. This made it harder to maintain consistency across the codebase and onboard new contributors.

## Explain how you solved the issue:

Added `AGENTS.md` with comprehensive contribution guidelines covering:

- **Testing practices**: Preference for integration tests, guidance on avoiding manual DB inserts, mocking time instead of backdating rows, using `appRequestWithRedirect`, and asserting on structured error fields rather than exact messages
- **Migrations**: Naming conventions for Drizzle migrations (descriptive names instead of auto-generated codenames)
- **Commits and PR titles**: Conventional Commit prefixes (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`)
- **Hono backend conventions**: Using `AppError` at service boundaries and structured Pino logging instead of console.log
- **City-agnostic code**: Keeping city-specific data in config files, never hard-coded in business logic

Also added `CLAUDE.md` as a redirect to `AGENTS.md` for discoverability.

## Additional notes or considerations:

This is a documentation-only change that codifies existing patterns and best practices observed in the codebase. It serves as a reference for maintaining code quality and consistency going forward.

https://claude.ai/code/session_016v7xQgNQynHSsmXYGkBQie