### PR TITLE
feat(tile-server): enable Cloudflare edge caching with deploy-time bust

### DIFF
--- a/packages/tile-server/Dockerfile
+++ b/packages/tile-server/Dockerfile
@@ -7,6 +7,7 @@
 
 ARG OSM_URL=https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
 ARG STYLE_BASE_URL=https://tiles.freifahren.org
+ARG BUILD_SHA=
 
 # ---------- Stage 1: download OSM extract ----------
 FROM alpine:3.20 AS osm-source
@@ -28,6 +29,7 @@ RUN mkdir -p /out \
 # ---------- Stage 3: rewrite MapLibre style ----------
 FROM node:20-alpine AS style
 ARG STYLE_BASE_URL
+ARG BUILD_SHA
 WORKDIR /work
 COPY styles/ ./styles/
 COPY source/freifahren-style.json ./source/freifahren-style.json
@@ -35,7 +37,8 @@ RUN mkdir -p /out \
  && node styles/rewrite-style.mjs \
       source/freifahren-style.json \
       /out/freifahren-dark.json \
-      "$STYLE_BASE_URL"
+      "$STYLE_BASE_URL" \
+      "$BUILD_SHA"
 
 # ---------- Stage 4: final Martin image ----------
 FROM ghcr.io/maplibre/martin:latest

--- a/packages/tile-server/README.md
+++ b/packages/tile-server/README.md
@@ -86,13 +86,22 @@ This writes:
 tileserver/styles/freifahren-dark.json
 ```
 
-The rewrite script updates the vector tile source to use Martin's TileJSON endpoint and removes glyph/sprite dependent layers for the initial no-assets deployment.
+The rewrite script replaces the vector tile source with a `tiles[]` URL template pointing at Martin and removes glyph/sprite dependent layers for the initial no-assets deployment.
 
 For production URLs, run:
 
 ```sh
 npm run rewrite-style:prod
 ```
+
+The script accepts an optional 4th positional argument used as a cache-bust token. When set, it is appended to each tile URL as `?v=<token>`:
+
+```sh
+node styles/rewrite-style.mjs source/freifahren-style.json out.json https://tiles.freifahren.org abc123
+# → tiles: ["https://tiles.freifahren.org/freifahren/{z}/{x}/{y}?v=abc123"]
+```
+
+This is how the Dockerfile threads the deploy SHA into the style — see [Caching](#caching).
 
 ## Serve Locally
 
@@ -135,7 +144,24 @@ Deployment is fully automated via the `Dockerfile` in this package. On every pus
 
 1. Downloads the Berlin OSM extract from Geofabrik.
 2. Runs Tilemaker to produce `freifahren-berlin.mbtiles`.
-3. Runs `rewrite-style` against the committed `source/freifahren-style.json` with the production base URL.
+3. Runs `rewrite-style` against the committed `source/freifahren-style.json` with the production base URL and the build's `BUILD_SHA` (cache-bust token — see [Caching](#caching)).
 4. Bakes the `.mbtiles`, the rewritten style JSON, and `martin/config.yaml` into a Martin image.
 
 No manual artifact upload is required — `git push` is the deploy.
+
+The image accepts two build args:
+
+| Arg              | Purpose                                                        |
+| ---------------- | -------------------------------------------------------------- |
+| `STYLE_BASE_URL` | Base URL baked into the style's tile templates.                |
+| `BUILD_SHA`      | Cache-bust token appended to tile URLs as `?v=`. Empty by default. |
+
+Coolify must pass `BUILD_SHA` as a build arg (e.g. `BUILD_SHA=${SOURCE_COMMIT}` in the service's Build Variables). Without it, the token is empty and tile URLs don't change between deploys, which means Cloudflare keeps serving old cached tiles until the 1-year TTL expires or someone purges manually.
+
+## Caching
+
+`tiles.freifahren.org` sits behind Cloudflare, and tile responses are aggressively cached at the edge — tiles are baked into the image at build time, so they're identical for every user until the next deploy.
+
+Deploy-time invalidation works via the `BUILD_SHA` token: each deploy bakes a different SHA into the style, so the `?v=<sha>` on every tile URL changes. Browsers and the edge see new URLs after a redeploy and fetch fresh tiles from Martin; old cache entries stay valid but unreferenced and age out on their own. No manual purge required.
+
+The actual cache rules live in the Cloudflare dashboard, not in this repo. To inspect or change caching behavior, check the rules under the `freifahren.org` zone (Caching → Cache Rules, and Rules → Overview).

--- a/packages/tile-server/styles/rewrite-style.mjs
+++ b/packages/tile-server/styles/rewrite-style.mjs
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-const [, , inputPath, outputPath, baseUrl = 'http://localhost:8090'] = process.argv
+const [, , inputPath, outputPath, baseUrl = 'http://localhost:8090', cacheBust = ''] = process.argv
 
 if (!inputPath || !outputPath) {
     console.error('Usage: node rewrite-style.mjs <input-style.json> <output-style.json> [base-url]')
@@ -20,9 +20,14 @@ if (!inputSourceName) {
 delete style.glyphs
 delete style.sprite
 
+// `?v=<cacheBust>` invalidates Cloudflare's 1-year edge cache on each deploy.
+const tileUrl = cacheBust
+    ? `${baseUrl}/${sourceName}/{z}/{x}/{y}?v=${cacheBust}`
+    : `${baseUrl}/${sourceName}/{z}/{x}/{y}`
+
 style.sources[sourceName] = {
     type: 'vector',
-    url: `${baseUrl}/${sourceName}`,
+    tiles: [tileUrl],
     maxzoom: 14,
     attribution:
         "<a href='https://www.openstreetmap.org/copyright' target='_blank'>&copy; OpenStreetMap contributors</a>",


### PR DESCRIPTION
Closes FRE-583.

## Summary

- Cuts tile latency from ~380 ms to ~20–40 ms by making vector tiles cacheable at Cloudflare's edge.
- Adds a `BUILD_SHA` build arg that bakes a deploy-specific cache-bust token (`?v=<sha>`) into every tile URL in the style, so redeploys with new tile content invalidate the year-long edge cache automatically — no manual purge.
- Switches the style's vector source from Martin's TileJSON `url` to a `tiles[]` template (so the cache-bust token reaches every tile request, not just the metadata fetch).

## Cloudflare changes (already configured in the dashboard)

- Cache Rule on tile paths: eligible for cache, Edge TTL + Browser TTL = 1 year.
- Response Header Transform Rule: writes `Cache-Control: public, max-age=31536000, immutable` on tile responses.

Rules live in the `freifahren.org` zone — see the new Caching section in `packages/tile-server/README.md`.

## Coolify

Coolify needs to pass `BUILD_SHA` as a build arg (e.g. `BUILD_SHA=\${SOURCE_COMMIT}` in the service's Build Variables). Without it, the token is empty and tile URLs don't change between deploys.

## Test plan

- [x] Verified locally that `rewrite-style.mjs` emits a valid style with and without the cache-bust token.
- [x] Confirmed against prod: two consecutive `curl -I https://tiles.freifahren.org/freifahren/12/2200/1346` requests yield `cf-cache-status: MISS` → `HIT` with the expected `cache-control` header.
- [ ] After merge + redeploy: confirm Coolify passes `BUILD_SHA` (style JSON should show a non-empty `?v=` on tile URLs).
- [ ] After a subsequent redeploy: confirm frontend picks up regenerated tiles without manual purge.