### PR TITLE
feat: soften multi-line risk dampening with sqrt divisor

### DIFF
--- a/packages/hono-backend/src/modules/risk/risk_model.py
+++ b/packages/hono-backend/src/modules/risk/risk_model.py
@@ -107,7 +107,9 @@ class RiskPredictor:
 
         base_risk = 0.8  # High base risk for directed reports
         if len(report.lines) > 1:
-            base_risk /= len(report.lines)
+            # Use sqrt as a softer dampener so multi-line stations still
+            # surface at least some risk above the green threshold.
+            base_risk /= math.sqrt(len(report.lines))
         return base_risk * self._calculate_temporal_decay(
             time_diff, ttl=1000, strength=0.2, shift=0.4
         )
@@ -120,7 +122,7 @@ class RiskPredictor:
             base_risk = 0.2  # Lower risk when direction is known
 
         if len(report.lines) > 1:
-            base_risk /= len(report.lines)
+            base_risk /= math.sqrt(len(report.lines))
 
         return base_risk * self._calculate_temporal_decay(
             time_diff, ttl=2000, strength=0.3, shift=0.4
@@ -130,7 +132,7 @@ class RiskPredictor:
         """Calculate line-wide risk based on report type and temporal decay."""
         base_risk = 0.1 if report.station_id is None else 0.05
         if len(report.lines) > 1:
-            base_risk /= len(report.lines)
+            base_risk /= math.sqrt(len(report.lines))
         return base_risk * self._calculate_temporal_decay(
             time_diff, ttl=4000, strength=0.3, shift=0.2
         )

--- a/packages/hono-backend/tests/getRisk.test.ts
+++ b/packages/hono-backend/tests/getRisk.test.ts
@@ -472,7 +472,7 @@ describe('GET /v0/risk report type handling', () => {
         const riskyOnA = Object.keys(multiBody.segments_risk).filter((sid) => baselineIdsA.has(sid))
         expect(riskyOnA.length).toBeGreaterThan(0)
 
-        // Risk on lineA segments should be roughly half of the single-line baseline (divided by 2 lines)
+        // Multi-line risk is dampened (by sqrt of the line count) but still lower than the single-line baseline.
         const multiMaxRiskOnA = Math.max(
             ...Object.entries(multiBody.segments_risk)
                 .filter(([sid]) => baselineIdsA.has(sid))
@@ -480,6 +480,36 @@ describe('GET /v0/risk report type handling', () => {
             0
         )
         expect(multiMaxRiskOnA).toBeLessThan(baselineMaxRisk)
+    })
+
+    it('a report at a station with many connections still produces non-green risk', async () => {
+        // Linear dampening (1/N) made high-degree hubs like Alexanderplatz disappear under the
+        // green threshold. With the softer sqrt dampening the model is expected to surface at
+        // least some yellow/red segments instead of nothing.
+        const { TransitNetworkDataService } = await import('../src/modules/transit/transit-network-data-service')
+        const service = new TransitNetworkDataService(db)
+        const stationsMap = await service.getStations()
+
+        const hub = Object.entries(stationsMap).reduce<[string, (typeof stationsMap)[string]] | null>(
+            (best, entry) => (best === null || entry[1].lines.length > best[1].lines.length ? entry : best),
+            null
+        )
+        if (hub === null) return
+        const [hubStationId, hubData] = hub
+        if (hubData.lines.length < 4) return // skip if the seeded data has no high-degree hub
+
+        await postRiskReport({ stationId: hubStationId, source: 'telegram' })
+
+        const response = await getRisk()
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as RiskResponse
+        const colors = Object.values(body.segments_risk).map((s) => s.color)
+        expect(colors.length).toBeGreaterThan(0)
+        for (const c of colors) {
+            expect(VALID_COLORS).toContain(c)
+            expect(c).not.toBe(GREEN)
+        }
     })
 })
 


### PR DESCRIPTION
## Summary
- Replace `base_risk /= len(report.lines)` with `base_risk /= sqrt(len(report.lines))` in the three risk components of `risk_model.py`. Linear dampening made high-degree hubs (e.g. Alexanderplatz with 13 lines) drop below the 0.2 green threshold, so reports there produced zero visible risk on the map. The softer sqrt curve keeps single-line behaviour identical while letting multi-line stations surface yellow segments.
- Add an integration test in `getRisk.test.ts` that picks the highest-degree station in the seeded data, submits a report with only `stationId` (no line, no direction — the worst case for dampening), and asserts the response contains non-green segments.
- Update the comment in the existing 2-line test that claimed "divided by 2 lines" — the ratio is now ~1/√2.

### Risk-color impact for an undirected report (peak segment)
| Lines | Old divisor | Old risk | New divisor | New risk | Old color | New color |
|------:|------------:|---------:|------------:|---------:|-----------|-----------|
| 2     | 2           | 0.50     | 1.41        | 0.71     | Red       | Red       |
| 4     | 4           | 0.25     | 2.00        | 0.50     | Yellow    | Yellow    |
| 6     | 6           | 0.17     | 2.45        | 0.41     | Green (lost) | Yellow |
| 13    | 13          | 0.077    | 3.61        | 0.28     | Green (lost) | Yellow |

## Test plan
- [x] `DATABASE_URL=…freifahren_test bun test tests/getRisk.test.ts` — the existing 16 risk tests still pass, and the new "many connections" test passes
- [x] On a deploy: post a report at Alexanderplatz with no `lineId`/`directionId`, then GET `/v0/risk` and confirm at least some segments are returned (previously empty)