### PR TITLE
fix: drop orphan stations during seeding

### DIFF
--- a/packages/hono-backend/src/db/seed/seed.ts
+++ b/packages/hono-backend/src/db/seed/seed.ts
@@ -1,5 +1,10 @@
+import { and, eq, notExists, or, sql } from 'drizzle-orm'
+
 import { logger } from '../../common/logger'
 import type { DbConnection } from '../index'
+import { lineStations } from '../schema/lines'
+import { reports } from '../schema/reports'
+import { stations } from '../schema/stations'
 
 import { seedLinesFromRelations } from './lines'
 import { seedSegmentsFromGeometry } from './segments/index'
@@ -27,6 +32,43 @@ const extractRouteRelations = (elements: OsmElement[]): OsmRelation[] => {
     return out
 }
 
+// Stations that ended up with no line_stations row (e.g. duplicate Alexanderplatz
+// Or Hauptbahnhof nodes from different upstream sources) are unreachable in the
+// Transit graph and cause NO_PATH_FOUND errors if a report references them.
+// Drop them, except where a report still points at the id — keeping user data
+// Alive trumps a clean graph.
+const pruneOrphanStations = async (db: DbConnection): Promise<void> => {
+    const dropped = await db
+        .delete(stations)
+        .where(
+            and(
+                notExists(
+                    db
+                        .select({ ref: sql`1` })
+                        .from(lineStations)
+                        .where(eq(lineStations.stationId, stations.id))
+                ),
+                notExists(
+                    db
+                        .select({ ref: sql`1` })
+                        .from(reports)
+                        .where(or(eq(reports.stationId, stations.id), eq(reports.directionId, stations.id)))
+                )
+            )
+        )
+        .returning({ id: stations.id, name: stations.name })
+
+    if (dropped.length === 0) {
+        logger.info('[seed:prune] No orphan stations found')
+        return
+    }
+
+    logger.warn(`[seed:prune] Dropped ${dropped.length} orphan station(s) with no line associations:`)
+    for (const row of dropped) {
+        logger.warn(`[seed:prune]   ${row.id} (${row.name})`)
+    }
+}
+
 export const seedBaseData = async (db: DbConnection) => {
     logger.info('[seed] Loading bundled stations snapshot...')
     const stationElements = await loadSnapshot<OsmElement[]>('stations')
@@ -42,6 +84,9 @@ export const seedBaseData = async (db: DbConnection) => {
     logger.info('[seed] Seeding lines...')
     const routeRelations = extractRouteRelations(stationElements)
     const variants = await seedLinesFromRelations(db, routeRelations, nodeIdToStationId)
+
+    logger.info('[seed] Pruning orphan stations...')
+    await pruneOrphanStations(db)
 
     logger.info('[seed] Seeding segments...')
     await seedSegmentsFromGeometry(db, variants, stationCoordinates, routeGeometryElements)


### PR DESCRIPTION
## Summary

- Stations without any `line_stations` row are unreachable in the transit graph and cause `NO_PATH_FOUND` (422) errors when a report references them.
- The seeding pipeline currently emits 9 such orphans (querying `next.freifahren.org/v0/transit/stations`):
  - **Exact-name duplicates** of a properly-wired twin: `n2094266776` Alexanderplatz, `n262882408` Zum Seeblick
  - **Near-name duplicates** from a different upstream source: `n3104815009` S+U Hauptbahnhof, `BZEP` Zepernick (b Bernau), `BFD` Fredersdorf (b Berlin)
  - **True orphans** with no twin (real seed bugs to investigate): Janitzkystraße, Falkenberger Straße/Berliner Allee, Herweghstraße, Am Faulen See
- Add a prune step after `seedLinesFromRelations` that drops any station with no `line_stations` row, skipping ones still referenced by a report so user data survives a re-seed.
- Warn-log each dropped `id (name)` so the true-orphan cases stay visible instead of being silently swallowed.

## Test plan

- [x] Apply local DB migrations and run `bun test tests/seed.test.ts` — first run should log 9 dropped stations, subsequent runs 0.
- [x] Hit `/v0/transit/distance?from=n29494292&to=n2094266776` against a freshly seeded DB — should return 404 `STATION_NOT_FOUND` (orphan gone) rather than 422 `NO_PATH_FOUND`.
- [x] Confirm no existing report rows are lost across a re-seed (existing `seed.test.ts` covers this).