### PR TITLE
feat: query transit data and render lines + stations on map

### DIFF
--- a/packages/frontend-next/src/api/queryClient.ts
+++ b/packages/frontend-next/src/api/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: Infinity,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/packages/frontend-next/src/api/transit.ts
+++ b/packages/frontend-next/src/api/transit.ts
@@ -1,0 +1,77 @@
+import { useQuery } from '@tanstack/react-query';
+import type { Feature, FeatureCollection, LineString, Point } from 'geojson';
+
+import { requireEnv } from '@/lib/utils';
+
+const API_URL = requireEnv('VITE_API_URL');
+
+export type Station = {
+  name: string;
+  coordinates: { latitude: number; longitude: number };
+  lines: string[];
+};
+
+type StationId = string;
+export type Stations = Record<StationId, Station>;
+
+export type LineType = 'subway' | 'suburban' | 'tram' | 'bus' | 'ferry';
+
+export type Line = {
+  id: string;
+  name: string;
+  type: LineType;
+  isCircular: boolean;
+  stations: StationId[];
+};
+
+export type SegmentProperties = {
+  line: string;
+  from: StationId;
+  to: StationId;
+  color: string;
+};
+
+export type Segment = Feature<LineString, SegmentProperties>;
+export type Segments = FeatureCollection<LineString, SegmentProperties>;
+
+export type StationPointProps = { id: string; name: string };
+
+export function stationsToGeoJSON(stations: Stations): FeatureCollection<Point, StationPointProps> {
+  return {
+    type: 'FeatureCollection',
+    features: Object.entries(stations).map(([id, station]) => ({
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [station.coordinates.longitude, station.coordinates.latitude],
+      },
+      properties: { id, name: station.name },
+    })),
+  };
+}
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${API_URL}${path}`);
+  if (!response.ok) {
+    throw new Error(`Request to ${path} failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+export const useStations = () =>
+  useQuery({
+    queryKey: ['transit', 'stations'],
+    queryFn: () => fetchJson<Stations>('/v0/transit/stations'),
+  });
+
+export const useLines = () =>
+  useQuery({
+    queryKey: ['transit', 'lines'],
+    queryFn: () => fetchJson<Line[]>('/v0/transit/lines'),
+  });
+
+export const useSegments = () =>
+  useQuery({
+    queryKey: ['transit', 'segments'],
+    queryFn: () => fetchJson<Segments>('/v0/transit/segments'),
+  });

--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -5,6 +5,9 @@ import { Map as MapGL } from 'react-map-gl/maplibre';
 
 import { requireEnv } from '@/lib/utils';
 
+import { SegmentsLayer } from './SegmentsLayer';
+import { StationsLayer } from './StationsLayer';
+
 const MAP_STYLE_URL = requireEnv('VITE_MAP_STYLE_URL');
 
 const INITIAL_VIEW = {
@@ -20,7 +23,10 @@ export function Map() {
         initialViewState={INITIAL_VIEW}
         mapStyle={MAP_STYLE_URL}
         attributionControl={{ compact: true }}
-      />
+      >
+        <SegmentsLayer />
+        <StationsLayer />
+      </MapGL>
     </div>
   );
 }

--- a/packages/frontend-next/src/components/map/SegmentsLayer.tsx
+++ b/packages/frontend-next/src/components/map/SegmentsLayer.tsx
@@ -1,0 +1,22 @@
+import { Layer, Source } from 'react-map-gl/maplibre';
+
+import { useSegments } from '@/api/transit';
+
+export function SegmentsLayer() {
+  const { data: segments } = useSegments();
+
+  if (!segments) return null;
+
+  return (
+    <Source id="segments" type="geojson" data={segments}>
+      <Layer
+        id="segments-line"
+        type="line"
+        paint={{
+          'line-color': ['get', 'color'],
+          'line-width': 3,
+        }}
+      />
+    </Source>
+  );
+}

--- a/packages/frontend-next/src/components/map/StationsLayer.tsx
+++ b/packages/frontend-next/src/components/map/StationsLayer.tsx
@@ -1,0 +1,24 @@
+import { Layer, Source } from 'react-map-gl/maplibre';
+
+import { stationsToGeoJSON, useStations } from '@/api/transit';
+
+export function StationsLayer() {
+  const { data: stations } = useStations();
+
+  if (!stations) return null;
+
+  return (
+    <Source id="stations" type="geojson" data={stationsToGeoJSON(stations)}>
+      <Layer
+        id="stations-circle"
+        type="circle"
+        paint={{
+          'circle-radius': 2,
+          'circle-color': '#ffffff',
+          'circle-stroke-color': '#000000',
+          'circle-stroke-width': 1,
+        }}
+      />
+    </Source>
+  );
+}

--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -1,7 +1,8 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from './api/queryClient';
 import { routeTree } from './routeTree.gen';
 import './index.css';
 
@@ -12,8 +13,6 @@ declare module '@tanstack/react-router' {
     router: typeof router;
   }
 }
-
-const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- Add typed transit API hooks (`useStations`, `useLines`, `useSegments`) targeting `/v0/transit/*` on the hono backend, with `staleTime: Infinity` since the data is essentially static within a session
- Move query client setup into `src/api/queryClient.ts` and consume it in `main.tsx`
- Render segments and stations as MapLibre layers via two self-contained components (`SegmentsLayer`, `StationsLayer`) — each calls its own hook and renders its own `Source` + `Layer`
- Co-locate `stationsToGeoJSON` with the transit types in `api/transit.ts`

## ETag caching
The hono backend already sends `ETag` headers on `/v0/transit/*` (see `hono-backend/src/index.ts`). The browser's built-in HTTP cache handles `If-None-Match` automatically — no manual ETag/localStorage juggling in the frontend.

## Test plan
- [x] `bun run dev` in both `hono-backend` and `frontend-next` → map shows colored line segments and station dots
- [x] DevTools network tab → second visit to `/v0/transit/*` returns 304s from the browser cache
- [x] `bun run build` succeeds