### PR TITLE
feat: station search bar

### DIFF
--- a/packages/frontend-next/components.json
+++ b/packages/frontend-next/components.json
@@ -10,7 +10,7 @@
     "cssVariables": true,
     "prefix": ""
   },
-  "iconLibrary": "hugeicons",
+  "iconLibrary": "lucide-react",
   "rtl": false,
   "aliases": {
     "components": "@/components",

--- a/packages/frontend-next/src/components/map/StationDetail.tsx
+++ b/packages/frontend-next/src/components/map/StationDetail.tsx
@@ -1,8 +1,9 @@
 import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-import { type Line, type Segments, type Station, useLines, useSegments } from '@/api/transit';
+import { type Station, useLines } from '@/api/transit';
 import { LineBadge } from '@/components/transit/LineBadge';
+import { resolveStationLineNames } from '@/components/transit/displayLines';
 import { Backdrop } from '@/components/ui/backdrop';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -14,50 +15,10 @@ type StationDetailProps = {
   onClose: () => void;
 };
 
-function buildLineColors(segments: Segments | undefined): Map<string, string> {
-  const colors = new Map<string, string>();
-  if (!segments) return colors;
-  for (const feature of segments.features) {
-    const { line, color } = feature.properties;
-    if (!colors.has(line)) colors.set(line, color);
-  }
-  return colors;
-}
-
-function buildLineNames(lines: Line[] | undefined): Map<string, string> {
-  const names = new Map<string, string>();
-  if (!lines) return names;
-  for (const line of lines) names.set(line.id, line.name);
-  return names;
-}
-
-type DisplayLine = { name: string; color: string | undefined };
-
-function resolveDisplayLines(
-  lineIds: Station['lines'],
-  lineNames: Map<string, string>,
-  lineColors: Map<string, string>,
-): DisplayLine[] {
-  const seen = new Set<string>();
-  const result: DisplayLine[] = [];
-  for (const id of lineIds) {
-    const name = lineNames.get(id) ?? id;
-    if (seen.has(name)) continue;
-    seen.add(name);
-    result.push({ name, color: lineColors.get(id) });
-  }
-  return result;
-}
-
 export function StationDetail({ station, onClose }: StationDetailProps) {
   const { t } = useTranslation(NAMESPACE);
-  const { data: segments } = useSegments();
   const { data: lines } = useLines();
-  const displayLines = resolveDisplayLines(
-    station.lines,
-    buildLineNames(lines),
-    buildLineColors(segments),
-  );
+  const lineNames = resolveStationLineNames(station.lines, lines);
 
   return (
     <>
@@ -75,8 +36,8 @@ export function StationDetail({ station, onClose }: StationDetailProps) {
             </Button>
           </CardContent>
           <CardContent className="flex flex-wrap gap-1.5">
-            {displayLines.map(({ name, color }) => (
-              <LineBadge key={name} name={name} color={color} />
+            {lineNames.map((name) => (
+              <LineBadge key={name} name={name} />
             ))}
           </CardContent>
           <CardContent className="mt-2">

--- a/packages/frontend-next/src/components/map/StationSearch.i18n.ts
+++ b/packages/frontend-next/src/components/map/StationSearch.i18n.ts
@@ -1,0 +1,15 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'stationSearch';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  placeholder: 'Search for a station...',
+  clear: 'Clear search',
+  noResults: 'No stations found',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  placeholder: 'Nach einer Station suchen...',
+  clear: 'Suche leeren',
+  noResults: 'Keine Stationen gefunden',
+});

--- a/packages/frontend-next/src/components/map/StationSearch.tsx
+++ b/packages/frontend-next/src/components/map/StationSearch.tsx
@@ -1,0 +1,115 @@
+import { useNavigate } from '@tanstack/react-router';
+import { Search, X } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { type Station, useLines, useStations } from '@/api/transit';
+import { LineBadge } from '@/components/transit/LineBadge';
+import { resolveStationLineNames } from '@/components/transit/displayLines';
+import { Backdrop } from '@/components/ui/backdrop';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { Route as StationDetailRoute } from '@/routes/stations/$stationId';
+
+import { NAMESPACE } from './StationSearch.i18n';
+
+const MAX_RESULTS = 8;
+
+function matchStations(stations: Station[], query: string): Station[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [];
+  const results: Station[] = [];
+  for (const station of stations) {
+    if (station.name.toLowerCase().includes(needle)) {
+      results.push(station);
+      if (results.length === MAX_RESULTS) break;
+    }
+  }
+  return results;
+}
+
+export function StationSearch() {
+  const { t } = useTranslation(NAMESPACE);
+  const navigate = useNavigate();
+  const { data: stations } = useStations();
+  const { data: lines } = useLines();
+  const [query, setQuery] = useState('');
+
+  const stationList = stations ? Object.values(stations) : [];
+  const results = matchStations(stationList, query);
+  const hasQuery = query.length > 0;
+  const showResults = query.trim().length > 0;
+
+  const selectStation = (station: Station) => {
+    setQuery('');
+    navigate({ to: StationDetailRoute.to, params: { stationId: station.id } });
+  };
+
+  return (
+    <>
+      {showResults && (
+        <Backdrop
+          aria-label={t('clear')}
+          onClose={() => setQuery('')}
+          className="z-10 bg-transparent"
+        />
+      )}
+      <div className="pointer-events-none fixed inset-x-0 top-0 z-20 flex justify-center p-3">
+        <div className="pointer-events-auto w-full max-w-md">
+          <div className="bg-card text-card-foreground ring-foreground/10 flex h-9 items-center gap-1 rounded-lg pr-1 pl-3 ring-1">
+            <Search className="text-muted-foreground size-3 shrink-0" />
+            <Input
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={t('placeholder')}
+              aria-label={t('placeholder')}
+              className="h-full flex-1 border-0 bg-transparent px-0 text-xs shadow-none focus-visible:ring-0 md:text-xs dark:bg-transparent"
+            />
+            {hasQuery && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => setQuery('')}
+                aria-label={t('clear')}
+              >
+                <X />
+              </Button>
+            )}
+          </div>
+          {showResults && (
+            <Card className="animate-in fade-in slide-in-from-top-2 mt-2 max-h-[60vh] gap-0 overflow-auto p-1 duration-150">
+              {results.length === 0 ? (
+                <div className="text-muted-foreground px-3 py-4 text-xs">{t('noResults')}</div>
+              ) : (
+                results.map((station) => {
+                  const lineNames = resolveStationLineNames(station.lines, lines);
+                  return (
+                    <button
+                      key={station.id}
+                      type="button"
+                      onClick={() => selectStation(station)}
+                      className={cn(
+                        'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-3 rounded-md px-2 py-2 text-left outline-none',
+                      )}
+                    >
+                      <span className="shrink-0 text-xs">{station.name}</span>
+                      <div className="ml-auto flex min-w-0 gap-1 overflow-hidden">
+                        {lineNames.map((name) => (
+                          <LineBadge key={name} name={name} />
+                        ))}
+                      </div>
+                    </button>
+                  );
+                })
+              )}
+            </Card>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/frontend-next/src/components/map/StationSearch.tsx
+++ b/packages/frontend-next/src/components/map/StationSearch.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from '@tanstack/react-router';
 import { Search, X } from 'lucide-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { type Station, useLines, useStations } from '@/api/transit';
@@ -36,34 +36,42 @@ export function StationSearch() {
   const { data: stations } = useStations();
   const { data: lines } = useLines();
   const [query, setQuery] = useState('');
+  const [isFocused, setIsFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const stationList = stations ? Object.values(stations) : [];
   const results = matchStations(stationList, query);
   const hasQuery = query.length > 0;
   const showResults = query.trim().length > 0;
+  const isActive = isFocused || hasQuery;
+
+  const dismiss = () => {
+    setQuery('');
+    inputRef.current?.blur();
+  };
 
   const selectStation = (station: Station) => {
     setQuery('');
+    inputRef.current?.blur();
     navigate({ to: StationDetailRoute.to, params: { stationId: station.id } });
   };
 
   return (
     <>
-      {showResults && (
-        <Backdrop
-          aria-label={t('clear')}
-          onClose={() => setQuery('')}
-          className="z-10 bg-transparent"
-        />
+      {isActive && (
+        <Backdrop aria-label={t('clear')} onClose={dismiss} className="z-10 bg-transparent" />
       )}
       <div className="pointer-events-none fixed inset-x-0 top-0 z-20 flex justify-center p-3">
         <div className="pointer-events-auto w-full max-w-md">
           <div className="bg-card text-card-foreground ring-foreground/10 flex h-9 items-center gap-1 rounded-lg pr-1 pl-3 ring-1">
             <Search className="text-muted-foreground size-3 shrink-0" />
             <Input
+              ref={inputRef}
               type="text"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
               placeholder={t('placeholder')}
               aria-label={t('placeholder')}
               className="h-full flex-1 border-0 bg-transparent px-0 text-xs shadow-none focus-visible:ring-0 md:text-xs dark:bg-transparent"

--- a/packages/frontend-next/src/components/transit/LineBadge.tsx
+++ b/packages/frontend-next/src/components/transit/LineBadge.tsx
@@ -1,13 +1,34 @@
+import { useLines, useSegments } from '@/api/transit';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 
 type LineBadgeProps = {
   name: string;
-  color?: string;
   className?: string;
 };
 
-export function LineBadge({ name, color, className }: LineBadgeProps) {
+function findLineColor(
+  name: string,
+  lines: ReturnType<typeof useLines>['data'],
+  segments: ReturnType<typeof useSegments>['data'],
+): string | undefined {
+  if (!lines || !segments) return undefined;
+  const lineIds = new Set<string>();
+  for (const line of lines) {
+    if (line.name === name) lineIds.add(line.id);
+  }
+  if (lineIds.size === 0) return undefined;
+  for (const feature of segments.features) {
+    if (lineIds.has(feature.properties.line)) return feature.properties.color;
+  }
+  return undefined;
+}
+
+export function LineBadge({ name, className }: LineBadgeProps) {
+  const { data: lines } = useLines();
+  const { data: segments } = useSegments();
+  const color = findLineColor(name, lines, segments);
+
   return (
     <Badge
       className={cn('h-6 rounded-sm px-2 text-xs font-semibold text-white', className)}

--- a/packages/frontend-next/src/components/transit/displayLines.ts
+++ b/packages/frontend-next/src/components/transit/displayLines.ts
@@ -1,0 +1,19 @@
+import type { Line, Station } from '@/api/transit';
+
+export function resolveStationLineNames(
+  lineIds: Station['lines'],
+  lines: Line[] | undefined,
+): string[] {
+  const nameById = new Map<string, string>();
+  if (lines) for (const line of lines) nameById.set(line.id, line.name);
+
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const id of lineIds) {
+    const name = nameById.get(id) ?? id;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    names.push(name);
+  }
+  return names;
+}

--- a/packages/frontend-next/src/components/ui/input.tsx
+++ b/packages/frontend-next/src/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'border-input bg-input/20 file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-7 w-full min-w-0 rounded-md border px-2 py-0.5 text-sm transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-xs/relaxed file:font-medium focus-visible:ring-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-2 md:text-xs/relaxed',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/packages/frontend-next/src/routes/__root.tsx
+++ b/packages/frontend-next/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router';
 
 import { MapView } from '@/components/map/Map';
+import { StationSearch } from '@/components/map/StationSearch';
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -10,6 +11,7 @@ function RootComponent() {
   return (
     <>
       <MapView />
+      <StationSearch />
       <Outlet />
     </>
   );


### PR DESCRIPTION
## Describe the issue:

Per FRE-606, users need a way to find a station by name without panning the map. Adds a search bar fixed at the top of the map and reuses the existing routed station detail.

## Explain how you solved the issue:

- New \`components/map/StationSearch.tsx\`: shadcn \`Input\` styled into a pill with a \`lucide-react\` \`Search\` icon, fixed at the top center of the map. \`type=\"text\"\` plus a custom \`Button\` (ghost \`icon-sm\` with the lucide \`X\`) replaces the native browser clear so it fits the shadcn aesthetic.
- Filtering happens client-side: case-insensitive substring match over station names (capped at 8 results). Results render in a \`Card\` dropdown with the station name on the left (intrinsic width, never clipped) and a horizontally clipping line-badge row on the right.
- Selecting a result clears the query and \`navigate\`s to \`/stations/\$stationId\` via the typed \`StationDetailRoute.to\` getter.
- When the search has a query, the reusable \`Backdrop\` is rendered with \`bg-transparent\` so clicking anywhere outside the search closes it. The search wrapper sits at \`z-20\` over the \`z-10\` backdrop.
- Refactored \`LineBadge\` to look its color up internally from \`useLines\` + \`useSegments\` given just the line name — callers no longer need to thread \`lineColors\` / \`lineNames\` maps. The shared helper in \`components/transit/displayLines.ts\` was trimmed to just \`resolveStationLineNames\`.
- Per-component i18n bundle (\`StationSearch.i18n.ts\`) for the placeholder, clear label, and no-results state, with English defaults and German translations.

Stacked on top of #516.

## Additional notes or considerations:

- Keyboard navigation (arrow keys / Enter) for the result list isn't wired up yet — clicking only. Can add in a follow-up if needed.
- shadcn install also pulled in unrelated \`command\`/\`dialog\`/\`input-group\`/\`textarea\` components plus \`cmdk\`; removed them and \`bun remove cmdk\` so only \`input\` lands here.