### PR TITLE
feat: implement contribution modal and update environment configuration

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -63,9 +63,11 @@ services:
     build:
       context: ./packages/frontend
       dockerfile: Dockerfile.frontend
+      args:
+        VITE_API_URL: http://localhost:8080
+        VITE_STRIPE_BUY_BUTTON_ID: ${VITE_STRIPE_BUY_BUTTON_ID:-}
+        VITE_STRIPE_PUBLISHABLE_KEY: ${VITE_STRIPE_PUBLISHABLE_KEY:-}
     container_name: frontend
-    env_file:
-      - ./packages/frontend/.env
     ports:
       - "3000:3000"
     depends_on:

--- a/packages/frontend/.dockerignore
+++ b/packages/frontend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+build
+.git
+.env
+.env.*
+*.log
+.DS_Store
+coverage

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,0 +1,6 @@
+VITE_JAWG_ACCESS_TOKEN=
+VITE_API_URL=http://localhost:8080
+VITE_STRIPE_BUY_BUTTON_ID=buy_btn_xxx
+VITE_STRIPE_PUBLISHABLE_KEY=pk_live_xxx
+SENTRY_AUTH_TOKEN=
+NAVIGATION_SERVICE_URL=https://api.transitous.org/api/v1/

--- a/packages/frontend/Dockerfile.frontend
+++ b/packages/frontend/Dockerfile.frontend
@@ -1,36 +1,28 @@
-# Build stage
-FROM node:18 as build
+FROM node:20 AS build
 
-# Set working directory
+ARG VITE_API_URL=http://localhost:8080
+ARG VITE_STRIPE_BUY_BUTTON_ID=
+ARG VITE_STRIPE_PUBLISHABLE_KEY=
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_STRIPE_BUY_BUTTON_ID=$VITE_STRIPE_BUY_BUTTON_ID
+ENV VITE_STRIPE_PUBLISHABLE_KEY=$VITE_STRIPE_PUBLISHABLE_KEY
+
 WORKDIR /app
 
-# Copy package files
 COPY package.json package-lock.json ./
+RUN npm ci --legacy-peer-deps
 
-# Install dependencies
-RUN npm install serve && \
-    npm install && \
-    npm install --legacy-peer-deps
-
-# Copy the rest of the application
 COPY . .
-
-# Build the application
 RUN npm run build
 
-# Production stage
-FROM node:18-slim
+FROM node:20-slim
 
 WORKDIR /app
 
-# Install serve
 RUN npm install -g serve
 
-# Copy built assets from builder stage
-COPY --from=build /app/build ./build
+COPY --from=build /app/dist ./dist
 
-# Expose port 3000
 EXPOSE 3000
 
-# Start the application
-CMD ["npx", "serve", "-s", "build", "-l", "3000"] 
+CMD ["serve", "-s", "dist", "-l", "3000"]

--- a/packages/frontend/public/icons/copy.svg
+++ b/packages/frontend/public/icons/copy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-copy-icon lucide-copy"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>

--- a/packages/frontend/public/locales/de.json
+++ b/packages/frontend/public/locales/de.json
@@ -19,6 +19,7 @@
     "UtilModal": {
         "title": "Informationen",
         "feedback-button": "Kontakt",
+        "contribution": "Beitrag leisten",
         "impressum": "Impressum",
         "privacy": "Datenschutz",
         "terms": "Nutzungsbedingungen",
@@ -251,5 +252,17 @@
     },
     "SearchBar": {
         "placeholder": "Suche nach einer Station..."
+    },
+    "ContributionModal": {
+        "title": "Danke, dass du dabei bist.",
+        "description": "Magst du mehr der Mission beitragen? Dann unterstütze uns doch gerne hier:",
+        "tabStripe": "Karte",
+        "tabBank": "Banküberweisung",
+        "bankHolder": "Kontoinhaber",
+        "bankReference": "Verwendungszweck",
+        "bankReferenceValue": "Beitrag FreiFahren",
+        "copy": "Kopieren",
+        "copied": "Kopiert",
+        "dismiss": "Nicht wieder anzeigen"
     }
 }

--- a/packages/frontend/public/locales/en.json
+++ b/packages/frontend/public/locales/en.json
@@ -19,11 +19,12 @@
     "UtilModal": {
         "title": "Information",
         "feedback-button": "Contact",
+        "contribution": "Contribute",
         "impressum": "Legal notice",
         "privacy": "Privacy Policy",
         "terms": "Terms of Use",
-        "analytics-opted-in": "anonyme analytics - Click to disable",
-        "analytics-opted-out": "anonyme analytics - Click to enable"
+        "analytics-opted-in": "anonymous analytics - Click to disable",
+        "analytics-opted-out": "anonymous analytics - Click to enable"
     },
     "ContactSection": {
         "title": "Contact us",
@@ -254,5 +255,17 @@
     },
     "SearchBar": {
         "placeholder": "Search for a station..."
+    },
+    "ContributionModal": {
+        "title": "Thanks for being part of this.",
+        "description": "Want to contribute more to the mission? Then feel free to support us here:",
+        "tabStripe": "Card",
+        "tabBank": "Bank Transfer",
+        "bankHolder": "Account holder",
+        "bankReference": "Reference",
+        "bankReferenceValue": "Contribution FreiFahren",
+        "copy": "Copy",
+        "copied": "Copied",
+        "dismiss": "Don't show again"
     }
 }

--- a/packages/frontend/src/components/Modals/ContributionModal/ContributionModal.css
+++ b/packages/frontend/src/components/Modals/ContributionModal/ContributionModal.css
@@ -1,0 +1,159 @@
+.contribution-modal-shell {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    z-index: 10;
+    width: min(95vw, 420px);
+    transform: translate(-50%, -50%);
+    overflow: visible;
+}
+
+.contribution-modal-shell .small-button.close-button {
+    position: absolute;
+    top: -30px;
+    right: 10px;
+}
+
+.contribution-modal-panel {
+    max-height: 80dvh;
+    overflow-x: hidden;
+    overflow-y: auto;
+    border-radius: var(--borderRadius-default, 8px);
+    border: 1px solid #000;
+    background-color: var(--color-background);
+    box-shadow: var(--boxShadow-default);
+    color: #000;
+    /* padding: var(--padding-s, 12px) var(--padding-m, 16px); */
+}
+
+.contribution-modal-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--margin-m);
+    padding: var(--margin-s) var(--margin-m);
+}
+
+.contribution-modal-content h1 {
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.contribution-modal-content > p {
+    font-size: 0.95rem;
+    color: var(--color-gray-on-dark-background);
+    margin: 0;
+}
+
+.contribution-tabs {
+    display: flex;
+    gap: 0;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.contribution-tab {
+    flex: 1;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: transparent;
+    color: var(--color-gray-on-dark-background);
+    border: none;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+.contribution-tab.active {
+    background: var(--color-primary, #fff);
+    color: var(--color-background, #000);
+}
+
+.contribution-stripe {
+    display: flex;
+    justify-content: center;
+    min-height: 80px;
+}
+
+.contribution-bank {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+}
+
+.contribution-bank-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.4rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.contribution-bank-label {
+    font-weight: 500;
+    color: var(--color-gray-on-dark-background);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.contribution-bank-value-group {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    min-width: 0;
+    flex: 1;
+}
+
+.contribution-bank-value {
+    text-align: right;
+    word-break: break-all;
+}
+
+.contribution-copy-button {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 6px;
+    color: var(--color-primary, #fff);
+    cursor: pointer;
+    padding: 0;
+}
+
+.contribution-copy-button--copied {
+    color: var(--color-risk-0, #7cc7ab);
+    border-color: var(--color-risk-0, #7cc7ab);
+}
+
+.contribution-copy-icon {
+    width: 1rem;
+    height: 1rem;
+}
+
+.contribution-copy-button:hover {
+    opacity: 0.85;
+}
+
+.contribution-dismiss {
+    background: transparent;
+    border: none;
+    font-size: 0.8rem;
+    color: var(--color-gray-on-dark-background);
+    cursor: pointer;
+    text-decoration: underline;
+    padding: 0;
+    text-align: center;
+    width: 100%;
+}
+
+.contribution-dismiss:hover {
+    opacity: 0.7;
+}

--- a/packages/frontend/src/components/Modals/ContributionModal/ContributionModal.tsx
+++ b/packages/frontend/src/components/Modals/ContributionModal/ContributionModal.tsx
@@ -1,0 +1,137 @@
+import './ContributionModal.css'
+
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import CloseButton from 'src/components/Buttons/CloseButton/CloseButton'
+
+export const CONTRIBUTION_MODAL_DISMISSED_KEY = 'contributionModalDismissed'
+
+const BANK_HOLDER = 'FreiFahren e.V.'
+const BANK_IBAN = 'DE73 8306 5408 0007 0044 60'
+const BANK_BIC = 'GENODEF1SLR'
+
+interface ContributionModalProps {
+    onClose: () => void
+    onDismissPermanently: () => void
+}
+
+type BankFieldId = 'holder' | 'iban' | 'bic' | 'reference'
+
+const stripeBuyButtonId = import.meta.env.VITE_STRIPE_BUY_BUTTON_ID
+const stripePublishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+const hasStripeConfig = stripeBuyButtonId !== '' && stripePublishableKey !== ''
+
+const ContributionModal = ({ onClose, onDismissPermanently }: ContributionModalProps) => {
+    const { t } = useTranslation()
+    const [activeTab, setActiveTab] = useState<'stripe' | 'bank'>(hasStripeConfig ? 'stripe' : 'bank')
+    const [copiedFieldId, setCopiedFieldId] = useState<BankFieldId | null>(null)
+
+    useEffect(() => {
+        if (document.querySelector('script[src="https://js.stripe.com/v3/buy-button.js"]')) return
+
+        const script = document.createElement('script')
+        script.src = 'https://js.stripe.com/v3/buy-button.js'
+        script.async = true
+        document.head.appendChild(script)
+    }, [])
+
+    const handleDismissPermanently = () => {
+        localStorage.setItem(CONTRIBUTION_MODAL_DISMISSED_KEY, 'true')
+        onDismissPermanently()
+    }
+
+    const copyBankValue = async (fieldId: BankFieldId, value: string) => {
+        try {
+            await navigator.clipboard.writeText(value)
+            setCopiedFieldId(fieldId)
+            window.setTimeout(() => setCopiedFieldId(null), 2000)
+        } catch {
+            setCopiedFieldId(null)
+        }
+    }
+
+    const bankReferenceValue = t('ContributionModal.bankReferenceValue')
+
+    const copyAriaLabel = (rowLabel: string, fieldId: BankFieldId) =>
+        copiedFieldId === fieldId
+            ? `${t('ContributionModal.copied')}: ${rowLabel}`
+            : `${t('ContributionModal.copy')}: ${rowLabel}`
+
+    const bankRows: { id: BankFieldId; label: string; value: string }[] = [
+        { id: 'holder', label: t('ContributionModal.bankHolder'), value: BANK_HOLDER },
+        { id: 'iban', label: 'IBAN', value: BANK_IBAN },
+        { id: 'bic', label: 'BIC', value: BANK_BIC },
+        { id: 'reference', label: t('ContributionModal.bankReference'), value: bankReferenceValue },
+    ]
+
+    return (
+        <div className="contribution-modal-shell block animate-popup">
+            <CloseButton handleClose={onClose} />
+            <div className="contribution-modal-panel">
+                <div className="contribution-modal-content">
+                    <h1>{t('ContributionModal.title')}</h1>
+                    <p>{t('ContributionModal.description')}</p>
+                    <div className="contribution-tabs">
+                        {hasStripeConfig ? (
+                            <button
+                                type="button"
+                                className={`contribution-tab ${activeTab === 'stripe' ? 'active' : ''}`}
+                                onClick={() => setActiveTab('stripe')}
+                            >
+                                {t('ContributionModal.tabStripe')}
+                            </button>
+                        ) : null}
+                        <button
+                            type="button"
+                            className={`contribution-tab ${activeTab === 'bank' ? 'active' : ''}`}
+                            onClick={() => setActiveTab('bank')}
+                        >
+                            {t('ContributionModal.tabBank')}
+                        </button>
+                    </div>
+                    {activeTab === 'stripe' && hasStripeConfig ? (
+                        <div className="contribution-stripe">
+                            <stripe-buy-button
+                                buy-button-id={stripeBuyButtonId}
+                                publishable-key={stripePublishableKey}
+                            />
+                        </div>
+                    ) : null}
+                    {activeTab === 'bank' ? (
+                        <div className="contribution-bank">
+                            {bankRows.map((row) => (
+                                <div key={row.id} className="contribution-bank-row">
+                                    <span className="contribution-bank-label">{row.label}</span>
+                                    <div className="contribution-bank-value-group">
+                                        <span className="contribution-bank-value">{row.value}</span>
+                                        <button
+                                            type="button"
+                                            className={`contribution-copy-button${copiedFieldId === row.id ? ' contribution-copy-button--copied' : ''}`}
+                                            onClick={() => copyBankValue(row.id, row.value)}
+                                            aria-label={copyAriaLabel(row.label, row.id)}
+                                        >
+                                            {copiedFieldId === row.id ? (
+                                                <img
+                                                    src="/icons/risk-0.svg"
+                                                    alt=""
+                                                    className="contribution-copy-icon no-filter"
+                                                />
+                                            ) : (
+                                                <img src="/icons/copy.svg" alt="" className="contribution-copy-icon" />
+                                            )}
+                                        </button>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    ) : null}
+                    <button type="button" className="contribution-dismiss" onClick={handleDismissPermanently}>
+                        {t('ContributionModal.dismiss')}
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export { ContributionModal }

--- a/packages/frontend/src/components/Modals/ReportSummaryModal/ReportSummaryModal.tsx
+++ b/packages/frontend/src/components/Modals/ReportSummaryModal/ReportSummaryModal.tsx
@@ -13,17 +13,18 @@ import { ReportItem } from '../ReportsModal/ReportItem'
 interface ReportSummaryModalProps {
     openAnimationClass?: string
     reportData: Report
-    handleCloseModal: () => void
+    onCloseModal: () => void
     numberOfUsers: number
 }
 
 const ReportSummaryModal: React.FC<ReportSummaryModalProps> = ({
     openAnimationClass,
     reportData,
-    handleCloseModal,
+    onCloseModal,
     numberOfUsers,
 }) => {
     const { t } = useTranslation()
+    const handleClose = onCloseModal
     const animatedCount = useCountAnimation(numberOfUsers, 1.5 * 1000)
 
     const [showFeedback, setShowFeedback] = useState<boolean>(false)
@@ -49,7 +50,7 @@ const ReportSummaryModal: React.FC<ReportSummaryModalProps> = ({
                 </span>
                 <p>{t('ReportSummaryModal.description')}</p>
                 <span className="disclaimer">{t('ReportSummaryModal.syncText')}</span>
-                <button className="action h-10 w-full rounded-sm" onClick={handleCloseModal} type="button">
+                <button className="action h-10 w-full rounded-sm" onClick={handleClose} type="button">
                     {t('ReportSummaryModal.button')}
                 </button>
             </div>

--- a/packages/frontend/src/components/Modals/UtilModal/UtilModal.tsx
+++ b/packages/frontend/src/components/Modals/UtilModal/UtilModal.tsx
@@ -12,11 +12,12 @@ import { LegalDisclaimer } from '../LegalDisclaimer'
 interface UtilModalProps {
     className: string
     children?: React.ReactNode
+    onOpenContribution?: () => void
 }
 
 const GITHUB_ICON = `/icons/github.svg`
 
-const UtilModal: React.FC<UtilModalProps> = ({ className, children }) => {
+const UtilModal: React.FC<UtilModalProps> = ({ className, children, onOpenContribution }) => {
     const { t } = useTranslation()
     const [isOptedOut, updateOptOut] = useAnalyticsOptOut()
 
@@ -43,6 +44,13 @@ const UtilModal: React.FC<UtilModalProps> = ({ className, children }) => {
                             <img src={GITHUB_ICON} alt="GitHub Icon" />
                         </button>
                     </div>
+                    <button
+                        className="action h-10 w-full rounded-sm"
+                        onClick={() => onOpenContribution?.()}
+                        type="button"
+                    >
+                        {t('UtilModal.contribution')}
+                    </button>
                     <div className="links-row">
                         <Link to="/Datenschutz">{t('UtilModal.privacy')}</Link>
                         <button className="text-button" onClick={() => setIsLegalDisclaimerOpen(true)} type="button">

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -4,6 +4,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ReportsModalButton } from 'src/components/Buttons/ReportsModalButton/ReportsModalButton'
+import {
+    CONTRIBUTION_MODAL_DISMISSED_KEY,
+    ContributionModal,
+} from 'src/components/Modals/ContributionModal/ContributionModal'
 import MarketingModal from 'src/components/Modals/MarketingModal/MarketingModal'
 import NavigationModal from 'src/components/Modals/NavigationModal/NavigationModal'
 import { ReportsModal } from 'src/components/Modals/ReportsModal/ReportsModal'
@@ -68,10 +72,31 @@ const App = () => {
 
     const [showSummary, setShowSummary] = useState<boolean>(false)
     const [reportedData, setReportedData] = useState<Report | null>(null)
+
+    const [showContributionModal, setShowContributionModal] = useState<boolean>(false)
+    const contributionShownThisSessionRef = useRef(false)
+
+    const openContributionModal = () => {
+        if (contributionShownThisSessionRef.current) return
+        if (localStorage.getItem(CONTRIBUTION_MODAL_DISMISSED_KEY) === 'true') return
+        contributionShownThisSessionRef.current = true
+        setShowContributionModal(true)
+    }
+
+    useEffect(() => {
+        const timeout = setTimeout(openContributionModal, 3 * 60 * 1000)
+        return () => clearTimeout(timeout)
+    }, [])
+
     const handleReportFormSubmit = (reportedDataForm: Report) => {
         setAppUIState((prevState) => ({ ...prevState, isReportFormOpen: false }))
         setShowSummary(true)
         setReportedData(reportedDataForm)
+    }
+
+    const handleCloseSummaryModal = () => {
+        setShowSummary(false)
+        openContributionModal()
     }
 
     const {
@@ -80,6 +105,11 @@ const App = () => {
         openModal: openUtilModal,
         closeModal: closeUtilModal,
     } = useModalAnimation()
+
+    const openContributionModalFromUtil = () => {
+        closeUtilModal()
+        setShowContributionModal(true)
+    }
 
     const toggleUtilModal = () => {
         if (isUtilOpen) {
@@ -104,6 +134,7 @@ const App = () => {
             isInfoModalOpenFromHook ||
             appUIState.isListModalOpen ||
             showSummary ||
+            showContributionModal ||
             isUtilOpen,
         [
             appUIState.isReportFormOpen,
@@ -111,6 +142,7 @@ const App = () => {
             isInfoModalOpenFromHook,
             appUIState.isListModalOpen,
             showSummary,
+            showContributionModal,
             isUtilOpen,
         ]
     )
@@ -367,7 +399,10 @@ const App = () => {
                 </>
             ) : null}
             {isUtilOpen ? (
-                <UtilModal className={`open ${isUtilAnimatingOut ? 'slide-out' : 'slide-in'}`}>
+                <UtilModal
+                    className={`open ${isUtilAnimatingOut ? 'slide-out' : 'slide-in'}`}
+                    onOpenContribution={openContributionModalFromUtil}
+                >
                     <CloseButton handleClose={closeUtilModal} />
                 </UtilModal>
             ) : null}
@@ -376,10 +411,19 @@ const App = () => {
                     <ReportSummaryModal
                         reportData={reportedData}
                         openAnimationClass="open center-animation"
-                        handleCloseModal={() => setShowSummary(false)}
+                        handleCloseModal={handleCloseSummaryModal}
                         numberOfUsers={numberOfUsers}
                     />
-                    <Backdrop handleClick={() => setShowSummary(false)} />
+                    <Backdrop handleClick={handleCloseSummaryModal} />
+                </>
+            ) : null}
+            {showContributionModal ? (
+                <>
+                    <ContributionModal
+                        onClose={() => setShowContributionModal(false)}
+                        onDismissPermanently={() => setShowContributionModal(false)}
+                    />
+                    <Backdrop handleClick={() => setShowContributionModal(false)} />
                 </>
             ) : null}
             {appUIState.isReportFormOpen ? (

--- a/packages/frontend/src/pages/App/App.tsx
+++ b/packages/frontend/src/pages/App/App.tsx
@@ -106,7 +106,7 @@ const App = () => {
         closeModal: closeUtilModal,
     } = useModalAnimation()
 
-    const openContributionModalFromUtil = () => {
+    const handleOpenContribution = () => {
         closeUtilModal()
         setShowContributionModal(true)
     }
@@ -401,7 +401,7 @@ const App = () => {
             {isUtilOpen ? (
                 <UtilModal
                     className={`open ${isUtilAnimatingOut ? 'slide-out' : 'slide-in'}`}
-                    onOpenContribution={openContributionModalFromUtil}
+                    onOpenContribution={handleOpenContribution}
                 >
                     <CloseButton handleClose={closeUtilModal} />
                 </UtilModal>
@@ -411,10 +411,10 @@ const App = () => {
                     <ReportSummaryModal
                         reportData={reportedData}
                         openAnimationClass="open center-animation"
-                        handleCloseModal={handleCloseSummaryModal}
+                        onCloseModal={handleCloseSummaryModal}
                         numberOfUsers={numberOfUsers}
                     />
-                    <Backdrop handleClick={handleCloseSummaryModal} />
+                    <Backdrop handleClick={() => handleCloseSummaryModal()} />
                 </>
             ) : null}
             {showContributionModal ? (

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -1,7 +1,18 @@
 /// <reference types="vite/client" />
 
+declare namespace React.JSX {
+    interface IntrinsicElements {
+        'stripe-buy-button': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+            'buy-button-id': string
+            'publishable-key': string
+        }
+    }
+}
+
 interface ImportMetaEnv {
     readonly VITE_API_URL: string
+    readonly VITE_STRIPE_BUY_BUTTON_ID: string
+    readonly VITE_STRIPE_PUBLISHABLE_KEY: string
     readonly VITE_MAP_STYLE_URL?: string
     readonly VITE_MAP_CENTER_LNG: string
     readonly VITE_MAP_CENTER_LAT: string

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -1,10 +1,14 @@
 /// <reference types="vite/client" />
 
-declare namespace React.JSX {
-    interface IntrinsicElements {
-        'stripe-buy-button': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
-            'buy-button-id': string
-            'publishable-key': string
+import type { DetailedHTMLProps, HTMLAttributes } from 'react'
+
+declare module 'react' {
+    namespace JSX {
+        interface IntrinsicElements {
+            'stripe-buy-button': DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> & {
+                'buy-button-id': string
+                'publishable-key': string
+            }
         }
     }
 }


### PR DESCRIPTION
- Add a new ContributionModal component for user contributions, including options for Stripe and bank transfers.
- Update Dockerfile to use Node 20 and pass environment variables for Stripe configuration.
- Create .dockerignore to exclude unnecessary files from the Docker build context.
- Introduce .env.example for environment variable documentation.
- Modify compose.yaml to include new build arguments for frontend service.
- Enhance localization files (en.json, de.json) with contribution-related text.
- Add a copy icon SVG for the contribution modal.
- Update UtilModal to include a button for opening the ContributionModal.

## Summary

This PR adds a **Contribution** popup to the legacy web app (`packages/frontend`) so users can support FreiFahren via Stripe or bank transfer.

- **`ContributionModal`** with two tabs: Stripe Buy Button (via `<stripe-buy-button>`) and bank details (holder, IBAN, BIC, reference) with per-field copy icons (`/icons/copy.svg`, checkmark feedback via `risk-0.svg`).
- **When it appears:** once per session after a 3 min timer on load, after closing the report summary modal, or manually from the Util modal (“Beitrag leisten” / “Contribute”) — the Util path bypasses the “don’t show again” preference.
- **Dismissal:** “Nicht wieder anzeigen” persists `contributionModalDismissed` in `localStorage`.
- **Stripe config** via `VITE_STRIPE_BUY_BUTTON_ID` and `VITE_STRIPE_PUBLISHABLE_KEY` (documented in `.env.example`; no secret keys in the frontend).
- **Docker/build fixes:** `.dockerignore` (fixes esbuild/`node_modules` clash), Node 20, correct `dist` output path, build args for `VITE_API_URL` and Stripe vars in `compose.yaml`.

## Test plan

- [ ] Copy `packages/frontend/.env.example` → `.env`, set Stripe vars, run `npm run dev` — Stripe tab renders the buy button.
- [ ] Bank tab: copy each field; icon switches to checkmark briefly.
- [ ] Wait 3min on first visit — modal opens; close with X vs “Nicht wieder anzeigen” — reload verifies permanent dismiss only for the latter.
- [ ] Submit a report → close summary → contribution modal opens (if not dismissed).
- [ ] Util modal → “Beitrag leisten” opens contribution modal even when dismissed via localStorage.
- [ ] `docker compose build frontend` with `VITE_STRIPE_*` set (root `.env` or exports) — app loads on `:3000`, API calls hit `VITE_API_URL`, Stripe tab works in the built image.
- [ ] Close button sits fully above the modal (not clipped).

## Notes for reviewers

- Publishable Stripe keys are intentionally client-side; only `pk_*` and buy button ID belong in `VITE_*` env vars.
- Timed trigger is currently **5 seconds** (likely for local testing) — confirm whether production should use a longer delay (e.g. 3 minutes) before merge.
- Bank IBAN/BIC are hardcoded in the component; update there or move to config if they change.