### PR TITLE
Fix transit line type validation and seeding

### DIFF
--- a/packages/hono-backend/src/db/seed/lines/index.ts
+++ b/packages/hono-backend/src/db/seed/lines/index.ts
@@ -44,6 +44,7 @@ export const seedLinesFromRelations = async (
                 target: lines.id,
                 set: {
                     name: sql`excluded.name`,
+                    type: sql`excluded.type`,
                     isCircular: sql`excluded.is_circular`,
                 },
             })

--- a/packages/hono-backend/src/modules/transit/transit-routes.ts
+++ b/packages/hono-backend/src/modules/transit/transit-routes.ts
@@ -29,6 +29,16 @@ export const getStations = defineRoute<Env>()({
     },
 })
 
+const linesResponseSchema = z.array(
+    z.object({
+        id: z.string(),
+        name: z.string(),
+        type: z.enum(ROUTE_TYPE_PRIORITY),
+        isCircular: z.boolean(),
+        stations: z.array(z.string()),
+    })
+)
+
 export const getLines = defineRoute<Env>()({
     method: 'get' as const,
     path: '/lines',
@@ -36,19 +46,14 @@ export const getLines = defineRoute<Env>()({
         summary: 'List lines',
         description: 'Returns all transit lines in the network.',
         tags: ['transit'],
-        responseSchema: z.array(
-            z.object({
-                id: z.string(),
-                name: z.string(),
-                type: z.enum(ROUTE_TYPE_PRIORITY),
-                isCircular: z.boolean(),
-                stations: z.array(z.string()),
-            })
-        ),
+        responseSchema: linesResponseSchema,
     },
     handler: async (c) => {
         const transitNetworkDataService = c.get('transitNetworkDataService')
-        return c.json(await transitNetworkDataService.getLines())
+        // Validate the output so an out-of-enum line type (e.g. a stale
+        // "unknown") fails loudly here instead of leaking to clients.
+        const lines = linesResponseSchema.parse(await transitNetworkDataService.getLines())
+        return c.json(lines)
     },
 })
 


### PR DESCRIPTION
## Describe the issue:

The transit lines endpoint was not validating the response schema, allowing stale or invalid line types (e.g., "unknown") to leak to clients. Additionally, the line type was not being updated during the database seeding process, which could result in outdated data persisting in the database.

## Explain how you solved the issue:

1. **Extracted response schema**: Moved the `linesResponseSchema` definition outside the route handler to enable reuse for validation.

2. **Added output validation**: The `getLines` handler now explicitly validates the service response against the schema using `linesResponseSchema.parse()`. This ensures that invalid line types fail loudly at the API boundary rather than being silently returned to clients.

3. **Fixed seeding**: Updated the `seedLinesFromRelations` upsert operation to include `type` in the update clause, ensuring that line type changes are properly persisted to the database during seeding.

## Additional notes or considerations:

These changes improve data integrity by:
- Preventing invalid enum values from reaching API consumers
- Ensuring the database seeding process fully updates line records, not just name and circular status
- Making the validation logic explicit and reusable

https://claude.ai/code/session_01DQkt64NAL3DNs6Hmj4khDr