### PR TITLE
fix: remap reports from orphan stations during reseed

### DIFF
--- a/packages/hono-backend/src/db/seed/seed.ts
+++ b/packages/hono-backend/src/db/seed/seed.ts
@@ -1,4 +1,4 @@
-import { and, eq, notExists, or, sql } from 'drizzle-orm'
+import { and, eq, exists, inArray, notExists, or, sql, type InferSelectModel } from 'drizzle-orm'
 
 import { logger } from '../../common/logger'
 import type { DbConnection } from '../index'
@@ -6,9 +6,11 @@ import { lineStations } from '../schema/lines'
 import { reports } from '../schema/reports'
 import { stations } from '../schema/stations'
 
+import { SEED_CONFIG } from './config'
 import { seedLinesFromRelations } from './lines'
 import { seedSegmentsFromGeometry } from './segments/index'
 import { seedStationsFromElements } from './stations'
+import { haversine, stationNamesMatch } from './stations/merge-proximate'
 import type { OsmElement, OsmRelation } from './stations/overpass'
 
 type OsmSnapshotKind = 'stations' | 'route_geometries'
@@ -32,11 +34,214 @@ const extractRouteRelations = (elements: OsmElement[]): OsmRelation[] => {
     return out
 }
 
+type OrphanStation = InferSelectModel<typeof stations>
+
+type ReplacementCandidate = OrphanStation & {
+    lineIds: string[]
+}
+
+type ReplacementCandidateRow = OrphanStation & {
+    lineId: string
+}
+
+const getReplacementCandidates = async (db: DbConnection, orphan: OrphanStation): Promise<ReplacementCandidate[]> => {
+    const rows: ReplacementCandidateRow[] = await db
+        .select({
+            id: stations.id,
+            name: stations.name,
+            lat: stations.lat,
+            lng: stations.lng,
+            lineId: lineStations.lineId,
+        })
+        .from(stations)
+        .innerJoin(lineStations, eq(lineStations.stationId, stations.id))
+
+    const byId = new Map<string, ReplacementCandidate>()
+    for (const row of rows) {
+        if (row.id === orphan.id) continue
+        if (stationNamesMatch(orphan.name, row.name) === false) continue
+        const distanceMeters = haversine(
+            { latitude: orphan.lat, longitude: orphan.lng },
+            { latitude: row.lat, longitude: row.lng }
+        )
+        if (distanceMeters > SEED_CONFIG.mergeThresholdMeters) continue
+
+        const candidate = byId.get(row.id) ?? {
+            id: row.id,
+            name: row.name,
+            lat: row.lat,
+            lng: row.lng,
+            lineIds: [],
+        }
+        candidate.lineIds.push(row.lineId)
+        byId.set(row.id, candidate)
+    }
+
+    return Array.from(byId.values())
+}
+
+const logUnresolvedOrphanReportReferences = ({
+    orphan,
+    reportIds,
+    lineId,
+    candidates,
+}: {
+    orphan: OrphanStation
+    reportIds: number[]
+    lineId: string | null
+    candidates: ReplacementCandidate[]
+}) => {
+    const candidateIds = candidates.map((candidate) => candidate.id).sort()
+    logger.warn(
+        {
+            orphanStationId: orphan.id,
+            orphanStationName: orphan.name,
+            reportIds,
+            reportCount: reportIds.length,
+            lineId,
+            candidateIds,
+        },
+        '[seed:repair] Could not remap orphan station report references'
+    )
+}
+
+const remapReportReferences = async ({
+    db,
+    orphan,
+    field,
+    candidates,
+}: {
+    db: DbConnection
+    orphan: OrphanStation
+    field: 'stationId' | 'directionId'
+    candidates: ReplacementCandidate[]
+}): Promise<number> => {
+    const reportRows = await db
+        .select({ reportId: reports.reportId, lineId: reports.lineId })
+        .from(reports)
+        .where(eq(reports[field], orphan.id))
+
+    const reportIdsByLineId = new Map<string | null, number[]>()
+    for (const report of reportRows) {
+        const group = reportIdsByLineId.get(report.lineId) ?? []
+        group.push(report.reportId)
+        reportIdsByLineId.set(report.lineId, group)
+    }
+
+    let remapped = 0
+    for (const [lineId, reportIds] of reportIdsByLineId) {
+        const lineCandidates =
+            lineId === null ? candidates : candidates.filter((candidate) => candidate.lineIds.includes(lineId))
+
+        if (lineCandidates.length !== 1) {
+            logUnresolvedOrphanReportReferences({ orphan, reportIds, lineId, candidates: lineCandidates })
+            continue
+        }
+
+        const [candidate] = lineCandidates
+        const updated = await db
+            .update(reports)
+            .set({ [field]: candidate.id })
+            .where(inArray(reports.reportId, reportIds))
+            .returning({ reportId: reports.reportId })
+
+        remapped += updated.length
+        logger.info(
+            {
+                orphanStationId: orphan.id,
+                replacementStationId: candidate.id,
+                reportCount: updated.length,
+                reportField: field,
+                lineId,
+            },
+            '[seed:repair] Remapped orphan station report references'
+        )
+    }
+
+    return remapped
+}
+
+const deleteReportsForOrphanStations = async (db: DbConnection): Promise<number> => {
+    const orphanIds = await db
+        .select({ id: stations.id })
+        .from(stations)
+        .where(
+            notExists(
+                db
+                    .select({ ref: sql`1` })
+                    .from(lineStations)
+                    .where(eq(lineStations.stationId, stations.id))
+            )
+        )
+
+    if (orphanIds.length === 0) return 0
+
+    const ids = orphanIds.map((row) => row.id)
+    const deleted = await db
+        .delete(reports)
+        .where(or(inArray(reports.stationId, ids), inArray(reports.directionId, ids)))
+        .returning({ reportId: reports.reportId })
+
+    if (deleted.length > 0) {
+        logger.warn(
+            {
+                reportCount: deleted.length,
+                orphanStationIds: ids,
+                reportIds: deleted.map((row) => row.reportId),
+            },
+            '[seed:repair] Deleted reports still referencing orphan stations'
+        )
+    }
+
+    return deleted.length
+}
+
+const repairReportsForOrphanStations = async (db: DbConnection): Promise<void> => {
+    const orphanRows = await db
+        .select({
+            id: stations.id,
+            name: stations.name,
+            lat: stations.lat,
+            lng: stations.lng,
+        })
+        .from(stations)
+        .where(
+            and(
+                notExists(
+                    db
+                        .select({ ref: sql`1` })
+                        .from(lineStations)
+                        .where(eq(lineStations.stationId, stations.id))
+                ),
+                exists(
+                    db
+                        .select({ ref: sql`1` })
+                        .from(reports)
+                        .where(or(eq(reports.stationId, stations.id), eq(reports.directionId, stations.id)))
+                )
+            )
+        )
+
+    if (orphanRows.length === 0) {
+        logger.info('[seed:repair] No referenced orphan stations found')
+        return
+    }
+
+    let remapped = 0
+    for (const orphan of orphanRows) {
+        const candidates = await getReplacementCandidates(db, orphan)
+        remapped += await remapReportReferences({ db, orphan, field: 'stationId', candidates })
+        remapped += await remapReportReferences({ db, orphan, field: 'directionId', candidates })
+    }
+
+    const deleted = await deleteReportsForOrphanStations(db)
+    logger.info({ orphanStationCount: orphanRows.length, remapped, deleted }, '[seed:repair] Finished orphan repair')
+}
+
 // Stations that ended up with no line_stations row (e.g. duplicate Alexanderplatz
 // Or Hauptbahnhof nodes from different upstream sources) are unreachable in the
 // Transit graph and cause NO_PATH_FOUND errors if a report references them.
-// Drop them, except where a report still points at the id — keeping user data
-// Alive trumps a clean graph.
+// Drop any that are no longer referenced after the report repair step.
 const pruneOrphanStations = async (db: DbConnection): Promise<void> => {
     const dropped = await db
         .delete(stations)
@@ -84,6 +289,9 @@ export const seedBaseData = async (db: DbConnection) => {
     logger.info('[seed] Seeding lines...')
     const routeRelations = extractRouteRelations(stationElements)
     const variants = await seedLinesFromRelations(db, routeRelations, nodeIdToStationId)
+
+    logger.info('[seed] Repairing orphan station report references...')
+    await repairReportsForOrphanStations(db)
 
     logger.info('[seed] Pruning orphan stations...')
     await pruneOrphanStations(db)

--- a/packages/hono-backend/src/db/seed/stations/merge-proximate.ts
+++ b/packages/hono-backend/src/db/seed/stations/merge-proximate.ts
@@ -9,7 +9,7 @@ export interface Coordinates {
 }
 
 /** Compute the great-circle distance between two coordinate pairs in meters. */
-const haversine = (a: Coordinates, b: Coordinates): number => {
+export const haversine = (a: Coordinates, b: Coordinates): number => {
     const toRad = (deg: number) => (deg * Math.PI) / 180
     const lat1 = toRad(a.latitude)
     const lon1 = toRad(a.longitude)
@@ -52,14 +52,14 @@ const pickRepresentative = (group: string[], dataset: StationDataset): string =>
 // Extract the core station name by stripping common transit prefixes and suffixes.
 // Works across cities: "S+U Alexanderplatz/Gontardstraße" → "alexanderplatz"
 // "Gare de Lyon - Diderot" → "gare de lyon"
-const coreName = (name: string): string =>
+export const coreName = (name: string): string =>
     name
         .toLowerCase()
         .split(/[/\-–—]/) // Split on slash or dash variants
         .map((p) => p.trim())[0] // Take the first part (main name)
 
 // Check if two stations share the same core name.
-const namesMatch = (a: string, b: string): boolean => {
+export const stationNamesMatch = (a: string, b: string): boolean => {
     const ca = coreName(a)
     const cb = coreName(b)
     return ca === cb || ca.includes(cb) || cb.includes(ca)
@@ -124,7 +124,7 @@ export const mergeProximate = (dataset: StationDataset): MergeResult => {
             const oEntry = dataset.get(codes[j])!
             if (
                 haversine(sEntry.coordinates, oEntry.coordinates) <= threshold &&
-                namesMatch(sEntry.name, oEntry.name)
+                stationNamesMatch(sEntry.name, oEntry.name)
             ) {
                 uf.union(codes[i], codes[j])
             }

--- a/packages/hono-backend/tests/seed.test.ts
+++ b/packages/hono-backend/tests/seed.test.ts
@@ -1,34 +1,161 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { asc, eq } from 'drizzle-orm'
 
-import { db, reports, stations } from '../src/db'
+import { createApp } from '../src'
+import { db, lineStations, reports, stations } from '../src/db'
 import { seedBaseData } from '../src/db/seed/seed'
+import { sendReportRequest } from './test-utils'
+
+const temporaryStationIds = ['test-orphan-1', 'test-orphan-2'] as const
 
 describe('seedBaseData', () => {
     beforeEach(async () => {
         await db.delete(reports)
+        await db.delete(stations).where(eq(stations.id, temporaryStationIds[0]))
+        await db.delete(stations).where(eq(stations.id, temporaryStationIds[1]))
     })
 
     afterEach(async () => {
         await db.delete(reports)
+        await db.delete(stations).where(eq(stations.id, temporaryStationIds[0]))
+        await db.delete(stations).where(eq(stations.id, temporaryStationIds[1]))
     })
 
     it('preserves existing reports across a re-seed', async () => {
-        const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
+        const [station] = await db.select({ id: lineStations.stationId }).from(lineStations).limit(1)
         if (!station) throw new Error('expected at least one seeded station to exist')
 
-        const [inserted] = await db
-            .insert(reports)
-            .values({
-                stationId: station.id,
-                lineId: null,
-                directionId: null,
-                source: 'web_app',
-            })
-            .returning({ reportId: reports.reportId })
+        const response = await sendReportRequest({ stationId: station.id, lineId: null, directionId: null })
+        expect(response.status).toBe(200)
+        const inserted = (await response.json()) as { reportId: number }
 
         await seedBaseData(db)
 
         const after = await db.select({ reportId: reports.reportId }).from(reports)
         expect(after).toEqual([{ reportId: inserted.reportId }])
+    })
+
+    it('remaps reports from a referenced orphan station to a proximate live station', async () => {
+        const [lineStation] = await db
+            .select({
+                lineId: lineStations.lineId,
+                stationId: lineStations.stationId,
+                order: lineStations.order,
+                stationName: stations.name,
+                lat: stations.lat,
+                lng: stations.lng,
+            })
+            .from(lineStations)
+            .innerJoin(stations, eq(stations.id, lineStations.stationId))
+            .orderBy(asc(lineStations.lineId), asc(lineStations.order))
+            .limit(1)
+        if (!lineStation) throw new Error('expected seeded line station to exist')
+
+        await db.insert(stations).values({
+            id: temporaryStationIds[0],
+            name: lineStation.stationName,
+            lat: lineStation.lat,
+            lng: lineStation.lng,
+        })
+        await db.insert(lineStations).values({
+            lineId: lineStation.lineId,
+            stationId: temporaryStationIds[0],
+            order: 10_000,
+        })
+
+        const routeApp = createApp(db)
+        const stationResponse = await sendReportRequest(
+            { stationId: temporaryStationIds[0], lineId: lineStation.lineId, directionId: null },
+            routeApp
+        )
+        expect(stationResponse.status).toBe(200)
+        const stationReport = (await stationResponse.json()) as { reportId: number }
+
+        const directionResponse = await sendReportRequest(
+            {
+                stationId: lineStation.stationId,
+                lineId: lineStation.lineId,
+                directionId: temporaryStationIds[0],
+            },
+            routeApp
+        )
+        expect(directionResponse.status).toBe(200)
+        const directionReport = (await directionResponse.json()) as { reportId: number }
+
+        await db.delete(lineStations).where(eq(lineStations.stationId, temporaryStationIds[0]))
+
+        await seedBaseData(db)
+
+        const after = await db.select().from(reports).orderBy(asc(reports.reportId))
+        expect(after).toEqual([
+            expect.objectContaining({
+                reportId: stationReport.reportId,
+                stationId: lineStation.stationId,
+                directionId: null,
+            }),
+            expect.objectContaining({
+                reportId: directionReport.reportId,
+                stationId: lineStation.stationId,
+                directionId: lineStation.stationId,
+            }),
+        ])
+
+        const staleStations = await db
+            .select({ id: stations.id })
+            .from(stations)
+            .where(eq(stations.id, temporaryStationIds[0]))
+        expect(staleStations).toEqual([])
+    })
+
+    it('deletes reports that still reference unresolved orphan stations', async () => {
+        const [lineStation] = await db
+            .select({
+                lineId: lineStations.lineId,
+                stationId: lineStations.stationId,
+                order: lineStations.order,
+                stationName: stations.name,
+                lat: stations.lat,
+                lng: stations.lng,
+            })
+            .from(lineStations)
+            .innerJoin(stations, eq(stations.id, lineStations.stationId))
+            .orderBy(asc(lineStations.lineId), asc(lineStations.order))
+            .limit(1)
+        if (!lineStation) throw new Error('expected seeded line station to exist')
+
+        await db.insert(stations).values({
+            id: temporaryStationIds[1],
+            name: 'Unmatched test station',
+            lat: lineStation.lat,
+            lng: lineStation.lng,
+        })
+        await db.insert(lineStations).values({
+            lineId: lineStation.lineId,
+            stationId: temporaryStationIds[1],
+            order: 10_001,
+        })
+
+        const response = await sendReportRequest(
+            { stationId: temporaryStationIds[1], lineId: lineStation.lineId, directionId: null },
+            createApp(db)
+        )
+        expect(response.status).toBe(200)
+        const inserted = (await response.json()) as { reportId: number }
+
+        await db.delete(lineStations).where(eq(lineStations.stationId, temporaryStationIds[1]))
+
+        await seedBaseData(db)
+
+        const after = await db
+            .select({ reportId: reports.reportId })
+            .from(reports)
+            .where(eq(reports.reportId, inserted.reportId))
+        expect(after).toEqual([])
+
+        const staleStations = await db
+            .select({ id: stations.id })
+            .from(stations)
+            .where(eq(stations.id, temporaryStationIds[1]))
+        expect(staleStations).toEqual([])
     })
 })


### PR DESCRIPTION
## Summary

Fixes FRE-609 by adding a conservative reseed repair pass before orphan station pruning.

- Remap report `station_id` and `direction_id` references from line-less orphan stations to a single clear live replacement.
- Reuse seed station name/distance matching rules and require line-serving candidates when reports carry a `line_id`.
- Log unresolved or ambiguous orphan references, then delete reports that still point at orphan stations so pruning can remove stale station rows.
- Add integration-style seed tests that create reports through the API.

## Validation

- `./node_modules/.bin/eslint src/db/seed/seed.ts --ext .ts`
- `bunx tsc --noEmit --skipLibCheck`
- Previously ran full backend suite against local Postgres: `91 pass, 0 fail`
