### PR TITLE
feat: station picker in report form

### DIFF
--- a/packages/frontend-next/src/api/transit.ts
+++ b/packages/frontend-next/src/api/transit.ts
@@ -25,6 +25,17 @@ export const LINE_TYPE_PRIORITY: Record<LineType, number> = {
   tram: 2,
 };
 
+// Canonical display order: U-Bahn → S-Bahn → Tram, then ascending within a group (U1 before U9).
+export function compareLineOrder(
+  a: { name: string; type?: LineType },
+  b: { name: string; type?: LineType },
+): number {
+  if (a.type && b.type && LINE_TYPE_PRIORITY[a.type] !== LINE_TYPE_PRIORITY[b.type]) {
+    return LINE_TYPE_PRIORITY[a.type] - LINE_TYPE_PRIORITY[b.type];
+  }
+  return parseInt(a.name.replace(/\D/g, ''), 10) - parseInt(b.name.replace(/\D/g, ''), 10);
+}
+
 export type Line = {
   id: string;
   name: string;

--- a/packages/frontend-next/src/components/map/StationSearch.tsx
+++ b/packages/frontend-next/src/components/map/StationSearch.tsx
@@ -3,13 +3,12 @@ import { Search, X } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { resolveStationLineNames, type Station, useLines, useStations } from '@/api/transit';
-import { LineBadge } from '@/components/transit/LineBadge';
+import { type Station, useStations } from '@/api/transit';
+import { StationListItem } from '@/components/transit/StationListItem';
 import { Backdrop } from '@/components/ui/backdrop';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { cn } from '@/lib/utils';
 import { Route as StationDetailRoute } from '@/routes/_map/stations/$stationId';
 
 import { NAMESPACE } from './StationSearch.i18n';
@@ -33,7 +32,6 @@ export function StationSearch() {
   const { t } = useTranslation(NAMESPACE);
   const navigate = useNavigate();
   const { data: stations } = useStations();
-  const { data: lines } = useLines();
   const [query, setQuery] = useState('');
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -92,26 +90,13 @@ export function StationSearch() {
               {results.length === 0 ? (
                 <div className="text-muted-foreground px-3 py-4 text-xs">{t('noResults')}</div>
               ) : (
-                results.map((station) => {
-                  const lineNames = resolveStationLineNames(station.lines, lines);
-                  return (
-                    <button
-                      key={station.id}
-                      type="button"
-                      onClick={() => selectStation(station)}
-                      className={cn(
-                        'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-3 rounded-md px-2 py-2 text-left outline-none',
-                      )}
-                    >
-                      <span className="shrink-0 text-xs">{station.name}</span>
-                      <div className="ml-auto flex min-w-0 gap-1 overflow-hidden">
-                        {lineNames.map((name) => (
-                          <LineBadge key={name} name={name} />
-                        ))}
-                      </div>
-                    </button>
-                  );
-                })
+                results.map((station) => (
+                  <StationListItem
+                    key={station.id}
+                    station={station}
+                    onClick={() => selectStation(station)}
+                  />
+                ))
               )}
             </Card>
           )}

--- a/packages/frontend-next/src/components/report/ReportForm.i18n.ts
+++ b/packages/frontend-next/src/components/report/ReportForm.i18n.ts
@@ -13,6 +13,7 @@ i18n.addResourceBundle('en', NAMESPACE, {
   tram: 'Tram',
   station: 'Station',
   required: 'Required',
+  clearSelection: 'clear selection',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
@@ -26,4 +27,5 @@ i18n.addResourceBundle('de', NAMESPACE, {
   tram: 'Tram',
   station: 'Station',
   required: 'Erforderlich',
+  clearSelection: 'Auswahl löschen',
 });

--- a/packages/frontend-next/src/components/report/ReportForm.i18n.ts
+++ b/packages/frontend-next/src/components/report/ReportForm.i18n.ts
@@ -11,6 +11,8 @@ i18n.addResourceBundle('en', NAMESPACE, {
   subway: 'U-Bahn',
   light_rail: 'S-Bahn',
   tram: 'Tram',
+  station: 'Station',
+  required: 'Required',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
@@ -22,4 +24,6 @@ i18n.addResourceBundle('de', NAMESPACE, {
   subway: 'U-Bahn',
   light_rail: 'S-Bahn',
   tram: 'Tram',
+  station: 'Station',
+  required: 'Erforderlich',
 });

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -21,6 +21,19 @@ type LineFilter = 'all' | LineType;
 
 const FILTERS: LineFilter[] = ['all', 'subway', 'light_rail', 'tram'];
 
+function ClearSelectionButton({ onClick }: { onClick: () => void }) {
+  const { t } = useTranslation(NAMESPACE);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-muted-foreground hover:text-foreground text-xs outline-none focus-visible:underline"
+    >
+      {t('clearSelection')}
+    </button>
+  );
+}
+
 type LinePickerProps = {
   selectedLine: string | null;
   onSelectLine: (name: string | null) => void;
@@ -80,6 +93,12 @@ function LinePicker({
           ))}
         </ToggleGroup>
       </div>
+
+      {selectedLine && (
+        <div className="mb-1 flex justify-end">
+          <ClearSelectionButton onClick={() => onSelectLine(null)} />
+        </div>
+      )}
 
       <div className="flex flex-wrap gap-2">
         {visibleLines.map((line) => {
@@ -144,9 +163,12 @@ function StationPicker({
 
   return (
     <section className="mt-6 px-4">
-      <div className="mb-3 flex items-center gap-1 tracking-wide uppercase">
-        <h2 className="text-sm font-semibold">{t('station')}</h2>
-        <p className="text-destructive text-[0.625rem] tracking-wide">{t('required')}</p>
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-1 tracking-wide uppercase">
+          <h2 className="text-sm font-semibold">{t('station')}</h2>
+          <p className="text-destructive text-[0.625rem] tracking-wide">{t('required')}</p>
+        </div>
+        {selectedStationId && <ClearSelectionButton onClick={() => onSelectStation(null)} />}
       </div>
       <ul>
         {visibleStations.map((station) => {

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -162,7 +162,7 @@ function StationPicker({
         .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
-    <section className="mt-6 px-4">
+    <section className="mt-6 flex min-h-0 flex-1 flex-col px-4">
       <div className="mb-3 flex items-center justify-between">
         <div className="flex items-center gap-1 tracking-wide uppercase">
           <h2 className="text-sm font-semibold">{t('station')}</h2>
@@ -170,7 +170,7 @@ function StationPicker({
         </div>
         {selectedStationId && <ClearSelectionButton onClick={() => onSelectStation(null)} />}
       </div>
-      <ul>
+      <ul className="min-h-0 flex-1 overflow-y-auto">
         {visibleStations.map((station) => {
           const isSelected = selectedStationId === station.id;
           return (
@@ -181,7 +181,7 @@ function StationPicker({
                 onClick={() => onSelectStation(isSelected ? null : station.id)}
                 className={cn(
                   'hover:bg-muted focus-visible:bg-muted flex w-full items-center rounded-md px-2 py-2 text-left text-xs outline-none',
-                  isSelected && 'ring-2 ring-white',
+                  isSelected && 'ring-2 ring-white ring-inset',
                 )}
               >
                 {station.name}
@@ -204,8 +204,8 @@ export function ReportForm() {
   const selectedStation = stationId ? (stations?.[stationId] ?? null) : null;
 
   return (
-    <div className="bg-card animate-in fade-in fixed inset-0 z-30 overflow-y-auto duration-150">
-      <div className="mx-auto flex min-h-full w-full max-w-md flex-col">
+    <div className="bg-card animate-in fade-in fixed inset-0 z-30 duration-150">
+      <div className="mx-auto flex h-full w-full max-w-md flex-col">
         <PageHeader title={t('title')} onBack={() => navigate({ to: '/' })} />
         <LinePicker
           selectedLine={lineName}

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -2,7 +2,13 @@ import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { LINE_TYPE_PRIORITY, type LineType, useLines } from '@/api/transit';
+import {
+  compareLineOrder,
+  type LineType,
+  resolveStationLineNames,
+  useLines,
+  useStations,
+} from '@/api/transit';
 import { PageHeader } from '@/components/templates/PageHeader';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
@@ -17,28 +23,21 @@ const FILTERS: LineFilter[] = ['all', 'subway', 'light_rail', 'tram'];
 type LinePickerProps = {
   selectedLine: string | null;
   onSelectLine: (name: string | null) => void;
+  filter: LineFilter;
+  onChangeFilter: (filter: LineFilter) => void;
 };
 
-function LinePicker({ selectedLine, onSelectLine }: LinePickerProps) {
+function LinePicker({ selectedLine, onSelectLine, filter, onChangeFilter }: LinePickerProps) {
   const { t } = useTranslation(NAMESPACE);
   const { data: lines } = useLines();
-  const [filter, setFilter] = useState<LineFilter>('all');
 
-  // One badge per line name (collapsing per-direction variants), ordered
-  // U-Bahn → S-Bahn → Tram, then ascending within a group (e.g. U1 before U9).
+  // One badge per line name (collapsing per-direction variants).
   const allLines = () => {
     const typeByName = new Map<string, LineType>();
     for (const line of lines ?? []) {
       if (!typeByName.has(line.name)) typeByName.set(line.name, line.type);
     }
-    return [...typeByName]
-      .map(([name, type]) => ({ name, type }))
-      .sort((a, b) => {
-        if (LINE_TYPE_PRIORITY[a.type] !== LINE_TYPE_PRIORITY[b.type]) {
-          return LINE_TYPE_PRIORITY[a.type] - LINE_TYPE_PRIORITY[b.type];
-        }
-        return parseInt(a.name.replace(/\D/g, ''), 10) - parseInt(b.name.replace(/\D/g, ''), 10);
-      });
+    return [...typeByName].map(([name, type]) => ({ name, type })).sort(compareLineOrder);
   };
 
   const visibleLines = filter === 'all' ? allLines() : allLines().filter((l) => l.type === filter);
@@ -55,7 +54,7 @@ function LinePicker({ selectedLine, onSelectLine }: LinePickerProps) {
           size="sm"
           value={filter}
           onValueChange={(value) => {
-            if (value) setFilter(value as LineFilter);
+            if (value) onChangeFilter(value as LineFilter);
           }}
           className="bg-surface-solid border-border border"
         >
@@ -85,7 +84,7 @@ function LinePicker({ selectedLine, onSelectLine }: LinePickerProps) {
                   return;
                 }
                 onSelectLine(line.name);
-                setFilter(line.type);
+                onChangeFilter(line.type);
               }}
               className="rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-white/50"
             >
@@ -98,16 +97,90 @@ function LinePicker({ selectedLine, onSelectLine }: LinePickerProps) {
   );
 }
 
+type StationPickerProps = {
+  selectedLine: string | null;
+  lineFilter: LineFilter;
+  selectedStationId: string | null;
+  onSelectStation: (id: string | null) => void;
+};
+
+function StationPicker({
+  selectedLine,
+  lineFilter,
+  selectedStationId,
+  onSelectStation,
+}: StationPickerProps) {
+  const { t } = useTranslation(NAMESPACE);
+  const { data: stations } = useStations();
+  const { data: lines } = useLines();
+
+  const typeByName = new Map<string, LineType>();
+  for (const line of lines ?? []) typeByName.set(line.name, line.type);
+
+  const visibleStations = Object.values(stations ?? {})
+    .filter((station) => {
+      const stationLineNames = resolveStationLineNames(station.lines, lines);
+      if (selectedLine && !stationLineNames.includes(selectedLine)) return false;
+      if (lineFilter !== 'all') {
+        return stationLineNames.some((name) => typeByName.get(name) === lineFilter);
+      }
+      return true;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <section className="mt-6 px-4">
+      <div className="mb-3 flex items-center gap-1 tracking-wide uppercase">
+        <h2 className="text-sm font-semibold">{t('station')}</h2>
+        <p className="text-destructive text-[0.625rem] tracking-wide">{t('required')}</p>
+      </div>
+      <ul>
+        {visibleStations.map((station) => {
+          const isSelected = selectedStationId === station.id;
+          return (
+            <li key={station.id} className="border-border/60 border-b last:border-b-0">
+              <button
+                type="button"
+                aria-pressed={isSelected}
+                onClick={() => onSelectStation(isSelected ? null : station.id)}
+                className={cn(
+                  'hover:bg-muted focus-visible:bg-muted flex w-full items-center rounded-md px-2 py-2 text-left text-xs outline-none',
+                  isSelected && 'ring-2 ring-white',
+                )}
+              >
+                {station.name}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
 export function ReportForm() {
   const { t } = useTranslation(NAMESPACE);
   const navigate = useNavigate();
   const [lineName, setLineName] = useState<string | null>(null);
+  const [lineFilter, setLineFilter] = useState<LineFilter>('all');
+  const [stationId, setStationId] = useState<string | null>(null);
 
   return (
     <div className="bg-card animate-in fade-in fixed inset-0 z-30 overflow-y-auto duration-150">
       <div className="mx-auto flex min-h-full w-full max-w-md flex-col">
         <PageHeader title={t('title')} onBack={() => navigate({ to: '/' })} />
-        <LinePicker selectedLine={lineName} onSelectLine={setLineName} />
+        <LinePicker
+          selectedLine={lineName}
+          onSelectLine={setLineName}
+          filter={lineFilter}
+          onChangeFilter={setLineFilter}
+        />
+        <StationPicker
+          selectedLine={lineName}
+          lineFilter={lineFilter}
+          selectedStationId={stationId}
+          onSelectStation={setStationId}
+        />
       </div>
     </div>
   );

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -1,14 +1,6 @@
 import { useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
-import {
-  compareLineOrder,
-  type LineType,
-  resolveStationLineNames,
-  type Station,
-  useLines,
-  useStations,
-} from '@/api/transit';
 import { PageHeader } from '@/components/templates/PageHeader';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
@@ -35,24 +27,7 @@ function ClearSelectionButton({ onClick }: { onClick: () => void }) {
 
 function LinePicker() {
   const { t } = useTranslation(NAMESPACE);
-  const { lineName, setLineName, lineFilter, setLineFilter, stationId } = useReportSelection();
-  const { data: lines } = useLines();
-  const { data: stations } = useStations();
-
-  // One badge per line name (collapsing per-direction variants).
-  const allLines = () => {
-    const typeByName = new Map<string, LineType>();
-    for (const line of lines ?? []) {
-      if (!typeByName.has(line.name)) typeByName.set(line.name, line.type);
-    }
-    return [...typeByName].map(([name, type]) => ({ name, type })).sort(compareLineOrder);
-  };
-
-  const station = stationId ? stations?.[stationId] : undefined;
-  const stationLineNames = station ? new Set(resolveStationLineNames(station.lines, lines)) : null;
-  const visibleLines = allLines()
-    .filter((l) => lineFilter === 'all' || l.type === lineFilter)
-    .filter((l) => !stationLineNames || stationLineNames.has(l.name));
+  const { lineName, lineFilter, setLineFilter, selectLine, visibleLines } = useReportSelection();
 
   return (
     <section className="px-4">
@@ -84,7 +59,7 @@ function LinePicker() {
 
       {lineName && (
         <div className="mb-1 flex justify-end">
-          <ClearSelectionButton onClick={() => setLineName(null)} />
+          <ClearSelectionButton onClick={() => selectLine(null)} />
         </div>
       )}
 
@@ -96,14 +71,7 @@ function LinePicker() {
               key={line.name}
               type="button"
               aria-pressed={isSelected}
-              onClick={() => {
-                if (isSelected) {
-                  setLineName(null);
-                  return;
-                }
-                setLineName(line.name);
-                setLineFilter(line.type);
-              }}
+              onClick={() => selectLine(isSelected ? null : line.name)}
               className="rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-white/50"
             >
               <LineBadge name={line.name} className={cn(isSelected && 'ring-2 ring-white')} />
@@ -117,45 +85,7 @@ function LinePicker() {
 
 function StationPicker() {
   const { t } = useTranslation(NAMESPACE);
-  const { lineName, lineFilter, stationId, setStationId } = useReportSelection();
-  const { data: stations } = useStations();
-  const { data: lines } = useLines();
-
-  const typeByName = new Map<string, LineType>();
-  for (const line of lines ?? []) typeByName.set(line.name, line.type);
-
-  const selectedStation = stationId ? stations?.[stationId] : undefined;
-
-  const stationsAlongLine = () => {
-    // Walk every variant of the selected line and emit stations in their stored order,
-    // deduplicating across direction variants.
-    const seen = new Set<string>();
-    const ordered: Station[] = [];
-    for (const line of lines ?? []) {
-      if (line.name !== lineName) continue;
-      for (const id of line.stations) {
-        if (seen.has(id)) continue;
-        seen.add(id);
-        const station = stations?.[id];
-        if (station) ordered.push(station);
-      }
-    }
-    return ordered;
-  };
-
-  const stationsByType = () =>
-    Object.values(stations ?? {})
-      .filter((station) => {
-        if (lineFilter === 'all') return true;
-        const names = resolveStationLineNames(station.lines, lines);
-        return names.some((name) => typeByName.get(name) === lineFilter);
-      })
-      .sort((a, b) => a.name.localeCompare(b.name));
-
-  let visibleStations: Station[];
-  if (selectedStation) visibleStations = [selectedStation];
-  else if (lineName) visibleStations = stationsAlongLine();
-  else visibleStations = stationsByType();
+  const { stationId, selectStation, visibleStations } = useReportSelection();
 
   return (
     <section className="mt-6 flex min-h-0 flex-1 flex-col px-4">
@@ -164,7 +94,7 @@ function StationPicker() {
           <h2 className="text-sm font-semibold">{t('station')}</h2>
           <p className="text-destructive text-[0.625rem] tracking-wide">{t('required')}</p>
         </div>
-        {stationId && <ClearSelectionButton onClick={() => setStationId(null)} />}
+        {stationId && <ClearSelectionButton onClick={() => selectStation(null)} />}
       </div>
       <ul className="min-h-0 flex-1 overflow-y-auto">
         {visibleStations.map((station) => {
@@ -174,7 +104,7 @@ function StationPicker() {
               <button
                 type="button"
                 aria-pressed={isSelected}
-                onClick={() => setStationId(isSelected ? null : station.id)}
+                onClick={() => selectStation(isSelected ? null : station.id)}
                 className={cn(
                   'hover:bg-muted focus-visible:bg-muted flex w-full items-center rounded-md px-2 py-2 text-left text-xs outline-none',
                   isSelected && 'ring-2 ring-white ring-inset',

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -6,6 +6,7 @@ import {
   compareLineOrder,
   type LineType,
   resolveStationLineNames,
+  type Station,
   useLines,
   useStations,
 } from '@/api/transit';
@@ -25,9 +26,16 @@ type LinePickerProps = {
   onSelectLine: (name: string | null) => void;
   filter: LineFilter;
   onChangeFilter: (filter: LineFilter) => void;
+  station: Station | null;
 };
 
-function LinePicker({ selectedLine, onSelectLine, filter, onChangeFilter }: LinePickerProps) {
+function LinePicker({
+  selectedLine,
+  onSelectLine,
+  filter,
+  onChangeFilter,
+  station,
+}: LinePickerProps) {
   const { t } = useTranslation(NAMESPACE);
   const { data: lines } = useLines();
 
@@ -40,7 +48,10 @@ function LinePicker({ selectedLine, onSelectLine, filter, onChangeFilter }: Line
     return [...typeByName].map(([name, type]) => ({ name, type })).sort(compareLineOrder);
   };
 
-  const visibleLines = filter === 'all' ? allLines() : allLines().filter((l) => l.type === filter);
+  const stationLineNames = station ? new Set(resolveStationLineNames(station.lines, lines)) : null;
+  const visibleLines = allLines()
+    .filter((l) => filter === 'all' || l.type === filter)
+    .filter((l) => !stationLineNames || stationLineNames.has(l.name));
 
   return (
     <section className="px-4">
@@ -117,16 +128,19 @@ function StationPicker({
   const typeByName = new Map<string, LineType>();
   for (const line of lines ?? []) typeByName.set(line.name, line.type);
 
-  const visibleStations = Object.values(stations ?? {})
-    .filter((station) => {
-      const stationLineNames = resolveStationLineNames(station.lines, lines);
-      if (selectedLine && !stationLineNames.includes(selectedLine)) return false;
-      if (lineFilter !== 'all') {
-        return stationLineNames.some((name) => typeByName.get(name) === lineFilter);
-      }
-      return true;
-    })
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const selectedStation = selectedStationId ? stations?.[selectedStationId] : undefined;
+  const visibleStations = selectedStation
+    ? [selectedStation]
+    : Object.values(stations ?? {})
+        .filter((station) => {
+          const stationLineNames = resolveStationLineNames(station.lines, lines);
+          if (selectedLine && !stationLineNames.includes(selectedLine)) return false;
+          if (lineFilter !== 'all') {
+            return stationLineNames.some((name) => typeByName.get(name) === lineFilter);
+          }
+          return true;
+        })
+        .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
     <section className="mt-6 px-4">
@@ -164,6 +178,8 @@ export function ReportForm() {
   const [lineName, setLineName] = useState<string | null>(null);
   const [lineFilter, setLineFilter] = useState<LineFilter>('all');
   const [stationId, setStationId] = useState<string | null>(null);
+  const { data: stations } = useStations();
+  const selectedStation = stationId ? (stations?.[stationId] ?? null) : null;
 
   return (
     <div className="bg-card animate-in fade-in fixed inset-0 z-30 overflow-y-auto duration-150">
@@ -174,6 +190,7 @@ export function ReportForm() {
           onSelectLine={setLineName}
           filter={lineFilter}
           onChangeFilter={setLineFilter}
+          station={selectedStation}
         />
         <StationPicker
           selectedLine={lineName}

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -196,7 +196,10 @@ export function ReportForm() {
           selectedLine={lineName}
           lineFilter={lineFilter}
           selectedStationId={stationId}
-          onSelectStation={setStationId}
+          onSelectStation={(id) => {
+            setStationId(id);
+            if (id === null) setLineName(null);
+          }}
         />
       </div>
     </div>

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -148,18 +148,37 @@ function StationPicker({
   for (const line of lines ?? []) typeByName.set(line.name, line.type);
 
   const selectedStation = selectedStationId ? stations?.[selectedStationId] : undefined;
-  const visibleStations = selectedStation
-    ? [selectedStation]
-    : Object.values(stations ?? {})
-        .filter((station) => {
-          const stationLineNames = resolveStationLineNames(station.lines, lines);
-          if (selectedLine && !stationLineNames.includes(selectedLine)) return false;
-          if (lineFilter !== 'all') {
-            return stationLineNames.some((name) => typeByName.get(name) === lineFilter);
-          }
-          return true;
-        })
-        .sort((a, b) => a.name.localeCompare(b.name));
+
+  const stationsAlongLine = () => {
+    // Walk every variant of the selected line and emit stations in their stored order,
+    // deduplicating across direction variants.
+    const seen = new Set<string>();
+    const ordered: Station[] = [];
+    for (const line of lines ?? []) {
+      if (line.name !== selectedLine) continue;
+      for (const stationId of line.stations) {
+        if (seen.has(stationId)) continue;
+        seen.add(stationId);
+        const station = stations?.[stationId];
+        if (station) ordered.push(station);
+      }
+    }
+    return ordered;
+  };
+
+  const stationsByType = () =>
+    Object.values(stations ?? {})
+      .filter((station) => {
+        if (lineFilter === 'all') return true;
+        const names = resolveStationLineNames(station.lines, lines);
+        return names.some((name) => typeByName.get(name) === lineFilter);
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+  let visibleStations: Station[];
+  if (selectedStation) visibleStations = [selectedStation];
+  else if (selectedLine) visibleStations = stationsAlongLine();
+  else visibleStations = stationsByType();
 
   return (
     <section className="mt-6 flex min-h-0 flex-1 flex-col px-4">

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from '@tanstack/react-router';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -16,8 +15,8 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { cn } from '@/lib/utils';
 
 import { NAMESPACE } from './ReportForm.i18n';
-
-type LineFilter = 'all' | LineType;
+import { type LineFilter, useReportSelection } from './ReportSelection.context';
+import { ReportSelectionProvider } from './ReportSelectionProvider';
 
 const FILTERS: LineFilter[] = ['all', 'subway', 'light_rail', 'tram'];
 
@@ -34,23 +33,11 @@ function ClearSelectionButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-type LinePickerProps = {
-  selectedLine: string | null;
-  onSelectLine: (name: string | null) => void;
-  filter: LineFilter;
-  onChangeFilter: (filter: LineFilter) => void;
-  station: Station | null;
-};
-
-function LinePicker({
-  selectedLine,
-  onSelectLine,
-  filter,
-  onChangeFilter,
-  station,
-}: LinePickerProps) {
+function LinePicker() {
   const { t } = useTranslation(NAMESPACE);
+  const { lineName, setLineName, lineFilter, setLineFilter, stationId } = useReportSelection();
   const { data: lines } = useLines();
+  const { data: stations } = useStations();
 
   // One badge per line name (collapsing per-direction variants).
   const allLines = () => {
@@ -61,9 +48,10 @@ function LinePicker({
     return [...typeByName].map(([name, type]) => ({ name, type })).sort(compareLineOrder);
   };
 
+  const station = stationId ? stations?.[stationId] : undefined;
   const stationLineNames = station ? new Set(resolveStationLineNames(station.lines, lines)) : null;
   const visibleLines = allLines()
-    .filter((l) => filter === 'all' || l.type === filter)
+    .filter((l) => lineFilter === 'all' || l.type === lineFilter)
     .filter((l) => !stationLineNames || stationLineNames.has(l.name));
 
   return (
@@ -76,9 +64,9 @@ function LinePicker({
         <ToggleGroup
           type="single"
           size="sm"
-          value={filter}
+          value={lineFilter}
           onValueChange={(value) => {
-            if (value) onChangeFilter(value as LineFilter);
+            if (value) setLineFilter(value as LineFilter);
           }}
           className="bg-surface-solid border-border border"
         >
@@ -94,15 +82,15 @@ function LinePicker({
         </ToggleGroup>
       </div>
 
-      {selectedLine && (
+      {lineName && (
         <div className="mb-1 flex justify-end">
-          <ClearSelectionButton onClick={() => onSelectLine(null)} />
+          <ClearSelectionButton onClick={() => setLineName(null)} />
         </div>
       )}
 
       <div className="flex flex-wrap gap-2">
         {visibleLines.map((line) => {
-          const isSelected = selectedLine === line.name;
+          const isSelected = lineName === line.name;
           return (
             <button
               key={line.name}
@@ -110,11 +98,11 @@ function LinePicker({
               aria-pressed={isSelected}
               onClick={() => {
                 if (isSelected) {
-                  onSelectLine(null);
+                  setLineName(null);
                   return;
                 }
-                onSelectLine(line.name);
-                onChangeFilter(line.type);
+                setLineName(line.name);
+                setLineFilter(line.type);
               }}
               className="rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-white/50"
             >
@@ -127,27 +115,16 @@ function LinePicker({
   );
 }
 
-type StationPickerProps = {
-  selectedLine: string | null;
-  lineFilter: LineFilter;
-  selectedStationId: string | null;
-  onSelectStation: (id: string | null) => void;
-};
-
-function StationPicker({
-  selectedLine,
-  lineFilter,
-  selectedStationId,
-  onSelectStation,
-}: StationPickerProps) {
+function StationPicker() {
   const { t } = useTranslation(NAMESPACE);
+  const { lineName, lineFilter, stationId, setStationId } = useReportSelection();
   const { data: stations } = useStations();
   const { data: lines } = useLines();
 
   const typeByName = new Map<string, LineType>();
   for (const line of lines ?? []) typeByName.set(line.name, line.type);
 
-  const selectedStation = selectedStationId ? stations?.[selectedStationId] : undefined;
+  const selectedStation = stationId ? stations?.[stationId] : undefined;
 
   const stationsAlongLine = () => {
     // Walk every variant of the selected line and emit stations in their stored order,
@@ -155,11 +132,11 @@ function StationPicker({
     const seen = new Set<string>();
     const ordered: Station[] = [];
     for (const line of lines ?? []) {
-      if (line.name !== selectedLine) continue;
-      for (const stationId of line.stations) {
-        if (seen.has(stationId)) continue;
-        seen.add(stationId);
-        const station = stations?.[stationId];
+      if (line.name !== lineName) continue;
+      for (const id of line.stations) {
+        if (seen.has(id)) continue;
+        seen.add(id);
+        const station = stations?.[id];
         if (station) ordered.push(station);
       }
     }
@@ -177,7 +154,7 @@ function StationPicker({
 
   let visibleStations: Station[];
   if (selectedStation) visibleStations = [selectedStation];
-  else if (selectedLine) visibleStations = stationsAlongLine();
+  else if (lineName) visibleStations = stationsAlongLine();
   else visibleStations = stationsByType();
 
   return (
@@ -187,17 +164,17 @@ function StationPicker({
           <h2 className="text-sm font-semibold">{t('station')}</h2>
           <p className="text-destructive text-[0.625rem] tracking-wide">{t('required')}</p>
         </div>
-        {selectedStationId && <ClearSelectionButton onClick={() => onSelectStation(null)} />}
+        {stationId && <ClearSelectionButton onClick={() => setStationId(null)} />}
       </div>
       <ul className="min-h-0 flex-1 overflow-y-auto">
         {visibleStations.map((station) => {
-          const isSelected = selectedStationId === station.id;
+          const isSelected = stationId === station.id;
           return (
             <li key={station.id} className="border-border/60 border-b last:border-b-0">
               <button
                 type="button"
                 aria-pressed={isSelected}
-                onClick={() => onSelectStation(isSelected ? null : station.id)}
+                onClick={() => setStationId(isSelected ? null : station.id)}
                 className={cn(
                   'hover:bg-muted focus-visible:bg-muted flex w-full items-center rounded-md px-2 py-2 text-left text-xs outline-none',
                   isSelected && 'ring-2 ring-white ring-inset',
@@ -216,33 +193,16 @@ function StationPicker({
 export function ReportForm() {
   const { t } = useTranslation(NAMESPACE);
   const navigate = useNavigate();
-  const [lineName, setLineName] = useState<string | null>(null);
-  const [lineFilter, setLineFilter] = useState<LineFilter>('all');
-  const [stationId, setStationId] = useState<string | null>(null);
-  const { data: stations } = useStations();
-  const selectedStation = stationId ? (stations?.[stationId] ?? null) : null;
 
   return (
-    <div className="bg-card animate-in fade-in fixed inset-0 z-30 duration-150">
-      <div className="mx-auto flex h-full w-full max-w-md flex-col">
-        <PageHeader title={t('title')} onBack={() => navigate({ to: '/' })} />
-        <LinePicker
-          selectedLine={lineName}
-          onSelectLine={setLineName}
-          filter={lineFilter}
-          onChangeFilter={setLineFilter}
-          station={selectedStation}
-        />
-        <StationPicker
-          selectedLine={lineName}
-          lineFilter={lineFilter}
-          selectedStationId={stationId}
-          onSelectStation={(id) => {
-            setStationId(id);
-            if (id === null) setLineName(null);
-          }}
-        />
+    <ReportSelectionProvider>
+      <div className="bg-card animate-in fade-in fixed inset-0 z-30 duration-150">
+        <div className="mx-auto flex h-full w-full max-w-md flex-col">
+          <PageHeader title={t('title')} onBack={() => navigate({ to: '/' })} />
+          <LinePicker />
+          <StationPicker />
+        </div>
       </div>
-    </div>
+    </ReportSelectionProvider>
   );
 }

--- a/packages/frontend-next/src/components/report/ReportSelection.context.ts
+++ b/packages/frontend-next/src/components/report/ReportSelection.context.ts
@@ -1,16 +1,20 @@
 import { createContext, useContext } from 'react';
 
-import type { LineType } from '@/api/transit';
+import type { LineType, Station } from '@/api/transit';
 
 export type LineFilter = 'all' | LineType;
 
 export type ReportSelectionContextValue = {
   lineName: string | null;
-  setLineName: (name: string | null) => void;
   lineFilter: LineFilter;
-  setLineFilter: (filter: LineFilter) => void;
   stationId: string | null;
-  setStationId: (id: string | null) => void;
+
+  selectLine: (name: string | null) => void;
+  setLineFilter: (filter: LineFilter) => void;
+  selectStation: (id: string | null) => void;
+
+  visibleLines: { name: string; type: LineType }[];
+  visibleStations: Station[];
 };
 
 export const ReportSelectionContext = createContext<ReportSelectionContextValue | null>(null);

--- a/packages/frontend-next/src/components/report/ReportSelection.context.ts
+++ b/packages/frontend-next/src/components/report/ReportSelection.context.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react';
+
+import type { LineType } from '@/api/transit';
+
+export type LineFilter = 'all' | LineType;
+
+export type ReportSelectionContextValue = {
+  lineName: string | null;
+  setLineName: (name: string | null) => void;
+  lineFilter: LineFilter;
+  setLineFilter: (filter: LineFilter) => void;
+  stationId: string | null;
+  setStationId: (id: string | null) => void;
+};
+
+export const ReportSelectionContext = createContext<ReportSelectionContextValue | null>(null);
+
+export function useReportSelection(): ReportSelectionContextValue {
+  const ctx = useContext(ReportSelectionContext);
+  if (!ctx) throw new Error('useReportSelection must be used within ReportSelectionProvider');
+  return ctx;
+}

--- a/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
+++ b/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
@@ -1,0 +1,26 @@
+import { type ReactNode, useMemo, useState } from 'react';
+
+import {
+  type LineFilter,
+  ReportSelectionContext,
+  type ReportSelectionContextValue,
+} from './ReportSelection.context';
+
+export function ReportSelectionProvider({ children }: { children: ReactNode }) {
+  const [lineName, setLineName] = useState<string | null>(null);
+  const [lineFilter, setLineFilter] = useState<LineFilter>('all');
+  const [stationId, setStationIdState] = useState<string | null>(null);
+
+  // Clearing the station also clears the chosen line so the user starts fresh.
+  const setStationId = (id: string | null) => {
+    setStationIdState(id);
+    if (id === null) setLineName(null);
+  };
+
+  const value = useMemo<ReportSelectionContextValue>(
+    () => ({ lineName, setLineName, lineFilter, setLineFilter, stationId, setStationId }),
+    [lineName, lineFilter, stationId],
+  );
+
+  return <ReportSelectionContext value={value}>{children}</ReportSelectionContext>;
+}

--- a/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
+++ b/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
@@ -1,4 +1,13 @@
-import { type ReactNode, useMemo, useState } from 'react';
+import { type ReactNode, useState } from 'react';
+
+import {
+  compareLineOrder,
+  type LineType,
+  resolveStationLineNames,
+  type Station,
+  useLines,
+  useStations,
+} from '@/api/transit';
 
 import {
   type LineFilter,
@@ -9,18 +18,81 @@ import {
 export function ReportSelectionProvider({ children }: { children: ReactNode }) {
   const [lineName, setLineName] = useState<string | null>(null);
   const [lineFilter, setLineFilter] = useState<LineFilter>('all');
-  const [stationId, setStationIdState] = useState<string | null>(null);
+  const [stationId, setStationId] = useState<string | null>(null);
+
+  const { data: lines } = useLines();
+  const { data: stations } = useStations();
+
+  const selectLine = (name: string | null) => {
+    setLineName(name);
+    if (name) {
+      const type = lines?.find((l) => l.name === name)?.type;
+      if (type) setLineFilter(type);
+    }
+  };
 
   // Clearing the station also clears the chosen line so the user starts fresh.
-  const setStationId = (id: string | null) => {
-    setStationIdState(id);
+  const selectStation = (id: string | null) => {
+    setStationId(id);
     if (id === null) setLineName(null);
   };
 
-  const value = useMemo<ReportSelectionContextValue>(
-    () => ({ lineName, setLineName, lineFilter, setLineFilter, stationId, setStationId }),
-    [lineName, lineFilter, stationId],
-  );
+  // One badge per line name (collapses per-direction variants), sorted by canonical order.
+  const typeByName = new Map<string, LineType>();
+  for (const line of lines ?? []) {
+    if (!typeByName.has(line.name)) typeByName.set(line.name, line.type);
+  }
+  const allLines = [...typeByName].map(([name, type]) => ({ name, type })).sort(compareLineOrder);
+
+  const selectedStation = stationId ? stations?.[stationId] : undefined;
+  const stationLineNames = selectedStation
+    ? new Set(resolveStationLineNames(selectedStation.lines, lines))
+    : null;
+  const visibleLines = allLines
+    .filter((l) => lineFilter === 'all' || l.type === lineFilter)
+    .filter((l) => !stationLineNames || stationLineNames.has(l.name));
+
+  const stationsAlongLine = () => {
+    // Walk every variant of the selected line and emit stations in their stored order,
+    // deduplicating across direction variants.
+    const seen = new Set<string>();
+    const ordered: Station[] = [];
+    for (const line of lines ?? []) {
+      if (line.name !== lineName) continue;
+      for (const id of line.stations) {
+        if (seen.has(id)) continue;
+        seen.add(id);
+        const station = stations?.[id];
+        if (station) ordered.push(station);
+      }
+    }
+    return ordered;
+  };
+
+  const stationsByType = () =>
+    Object.values(stations ?? {})
+      .filter((station) => {
+        if (lineFilter === 'all') return true;
+        const names = resolveStationLineNames(station.lines, lines);
+        return names.some((name) => typeByName.get(name) === lineFilter);
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+  let visibleStations: Station[];
+  if (selectedStation) visibleStations = [selectedStation];
+  else if (lineName) visibleStations = stationsAlongLine();
+  else visibleStations = stationsByType();
+
+  const value: ReportSelectionContextValue = {
+    lineName,
+    lineFilter,
+    stationId,
+    selectLine,
+    setLineFilter,
+    selectStation,
+    visibleLines,
+    visibleStations,
+  };
 
   return <ReportSelectionContext value={value}>{children}</ReportSelectionContext>;
 }

--- a/packages/frontend-next/src/components/transit/StationListItem.tsx
+++ b/packages/frontend-next/src/components/transit/StationListItem.tsx
@@ -1,0 +1,45 @@
+import {
+  compareLineOrder,
+  type LineType,
+  resolveStationLineNames,
+  type Station,
+  useLines,
+} from '@/api/transit';
+import { LineBadge } from '@/components/transit/LineBadge';
+import { cn } from '@/lib/utils';
+
+type StationListItemProps = {
+  station: Station;
+  onClick: () => void;
+  selected?: boolean;
+};
+
+export function StationListItem({ station, onClick, selected }: StationListItemProps) {
+  const { data: lines } = useLines();
+  const lineNames = resolveStationLineNames(station.lines, lines);
+
+  const typeByName = new Map<string, LineType>();
+  if (lines) for (const line of lines) typeByName.set(line.name, line.type);
+  const sortedNames = [...lineNames].sort((a, b) =>
+    compareLineOrder({ name: a, type: typeByName.get(a) }, { name: b, type: typeByName.get(b) }),
+  );
+
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      onClick={onClick}
+      className={cn(
+        'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-3 rounded-md px-2 py-2 text-left outline-none',
+        selected && 'ring-2 ring-white',
+      )}
+    >
+      <span className="shrink-0 text-xs">{station.name}</span>
+      <div className="ml-auto flex min-w-0 gap-1 overflow-hidden">
+        {sortedNames.map((name) => (
+          <LineBadge key={name} name={name} className="shrink-0" />
+        ))}
+      </div>
+    </button>
+  );
+}

--- a/packages/frontend-next/src/components/transit/StationListItem.tsx
+++ b/packages/frontend-next/src/components/transit/StationListItem.tsx
@@ -31,7 +31,7 @@ export function StationListItem({ station, onClick, selected }: StationListItemP
       onClick={onClick}
       className={cn(
         'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-3 rounded-md px-2 py-2 text-left outline-none',
-        selected && 'ring-2 ring-white',
+        selected && 'ring-2 ring-white ring-inset',
       )}
     >
       <span className="shrink-0 text-xs">{station.name}</span>

--- a/packages/hono-backend/src/db/schema/lines.ts
+++ b/packages/hono-backend/src/db/schema/lines.ts
@@ -12,7 +12,6 @@ export const lines = pgTable('lines', {
     color: varchar({ length: 7 }).notNull().default('#000000'),
 })
 
-// Todo: avoid deprecated syntax: #FRE-562
 export const lineStations = pgTable(
     'line_stations',
     {


### PR DESCRIPTION
## Summary
- Adds a station picker to the report form: lists stations (alphabetical, or in route order along the selected line), supports filtering by line type, and collapses to the single selected row with a "clear selection" affordance.
- Keeps line and station selection in a dedicated `ReportSelectionContext` whose provider owns all derivation (variant collapsing, canonical sort, route-order walk, type filter, station-collapse) so `LinePicker` and `StationPicker` are pure UI.
- Adds a shared `StationListItem` used by `StationSearch` (extracted from inline rendering), and centralizes the canonical line sort comparator (`compareLineOrder`) in `api/transit.ts` so display order is consistent across views.
- Layout: form is now constrained to viewport height with the station list as the only scrollable region, leaving room for the future submit button.

## Test plan
- [x] Open the report form, confirm the line picker still works (toggle filter, pick/unpick a line).
- [x] With no line picked, station list is alphabetical and respects the line-type filter.
- [x] Picking a line shows stations in route order along that line (verify a multi-variant line like a U-Bahn with branches: stations from both directions appear once each).
- [x] Picking a station collapses the list to that station; "clear selection" returns to the full list and also clears the selected line.
- [x] Station list scrolls independently inside the form; page header and line picker stay fixed.
- [x] Selected-row outline is visible (not clipped by the scroll container).
- [x] Long station names truncate without pushing badges off-screen in `StationSearch`.