### PR TITLE
feat: direction picker in report form

### DIFF
--- a/packages/frontend-next/src/components/report/ReportForm.i18n.ts
+++ b/packages/frontend-next/src/components/report/ReportForm.i18n.ts
@@ -14,6 +14,7 @@ i18n.addResourceBundle('en', NAMESPACE, {
   station: 'Station',
   required: 'Required',
   clearSelection: 'clear selection',
+  direction: 'Direction',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
@@ -28,4 +29,5 @@ i18n.addResourceBundle('de', NAMESPACE, {
   station: 'Station',
   required: 'Erforderlich',
   clearSelection: 'Auswahl löschen',
+  direction: 'Richtung',
 });

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from '@tanstack/react-router';
+import { ChevronRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { PageHeader } from '@/components/templates/PageHeader';
@@ -88,7 +89,15 @@ function StationPicker() {
   const { stationId, selectStation, visibleStations } = useReportSelection();
 
   return (
-    <section className="mt-6 flex min-h-0 flex-1 flex-col px-4">
+    <section
+      className={cn(
+        'mt-6 flex flex-col px-4',
+        // While the user is still browsing, the list fills the form and scrolls inside.
+        // Once a station is picked the list collapses to a single row so the direction
+        // picker (and the future submit button) stay visible.
+        !stationId && 'min-h-0 flex-1',
+      )}
+    >
       <div className="mb-3 flex items-center justify-between">
         <div className="flex items-center gap-1 tracking-wide uppercase">
           <h2 className="text-sm font-semibold">{t('station')}</h2>
@@ -96,7 +105,7 @@ function StationPicker() {
         </div>
         {stationId && <ClearSelectionButton onClick={() => selectStation(null)} />}
       </div>
-      <ul className="min-h-0 flex-1 overflow-y-auto">
+      <ul className={cn(!stationId && 'min-h-0 flex-1 overflow-y-auto')}>
         {visibleStations.map((station) => {
           const isSelected = stationId === station.id;
           return (
@@ -120,6 +129,42 @@ function StationPicker() {
   );
 }
 
+function DirectionPicker() {
+  const { t } = useTranslation(NAMESPACE);
+  const { directionStationId, selectDirection, directionOptions } = useReportSelection();
+
+  if (directionOptions.length === 0) return null;
+
+  return (
+    <section className="mt-6 px-4">
+      <div className="mb-3 flex items-center gap-1 tracking-wide uppercase">
+        <h2 className="text-sm font-semibold">{t('direction')}</h2>
+        <p className="text-muted-foreground text-[0.625rem] tracking-wide">{t('optional')}</p>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        {directionOptions.map((station) => {
+          const isSelected = directionStationId === station.id;
+          return (
+            <button
+              key={station.id}
+              type="button"
+              aria-pressed={isSelected}
+              onClick={() => selectDirection(isSelected ? null : station.id)}
+              className={cn(
+                'border-border bg-surface-solid hover:bg-muted flex items-center gap-2 rounded-md border px-2 py-1.5 text-left text-sm outline-none',
+                isSelected && 'ring-2 ring-white ring-inset',
+              )}
+            >
+              <ChevronRight className="text-muted-foreground size-4 shrink-0" />
+              <span className="truncate">{station.name}</span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 export function ReportForm() {
   const { t } = useTranslation(NAMESPACE);
   const navigate = useNavigate();
@@ -131,6 +176,7 @@ export function ReportForm() {
           <PageHeader title={t('title')} onBack={() => navigate({ to: '/' })} />
           <LinePicker />
           <StationPicker />
+          <DirectionPicker />
         </div>
       </div>
     </ReportSelectionProvider>

--- a/packages/frontend-next/src/components/report/ReportSelection.context.ts
+++ b/packages/frontend-next/src/components/report/ReportSelection.context.ts
@@ -8,13 +8,16 @@ export type ReportSelectionContextValue = {
   lineName: string | null;
   lineFilter: LineFilter;
   stationId: string | null;
+  directionStationId: string | null;
 
   selectLine: (name: string | null) => void;
   setLineFilter: (filter: LineFilter) => void;
   selectStation: (id: string | null) => void;
+  selectDirection: (id: string | null) => void;
 
   visibleLines: { name: string; type: LineType }[];
   visibleStations: Station[];
+  directionOptions: Station[];
 };
 
 export const ReportSelectionContext = createContext<ReportSelectionContextValue | null>(null);

--- a/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
+++ b/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
@@ -90,18 +90,26 @@ export function ReportSelectionProvider({ children }: { children: ReactNode }) {
   else if (lineName) visibleStations = stationsAlongLine();
   else visibleStations = stationsByType();
 
-  // Direction picker shows the two endpoint stations of the selected line.
-  // For lines with multiple direction variants (U1, U1-a, U1-b …) pick the canonical "-a" variant
-  // and fall back to the only variant when there is just one.
+  // Direction picker exposes every endpoint reachable from the selected station along the
+  // chosen line. If the station sits on a single variant we get the two termini of that variant;
+  // if it sits on multiple variants (e.g. a branching trunk) we surface every endpoint across
+  // those variants, deduplicated. The variant a chosen endpoint belongs to can be resolved at
+  // submit time from (lineName, stationId, directionStationId).
   const directionOptions: Station[] = [];
   if (lineName && selectedStation) {
-    const variants = (lines ?? []).filter((l) => l.name === lineName);
-    const variant = variants.find((l) => l.id.endsWith('-a')) ?? variants[0];
-    if (variant && variant.stations.length >= 2) {
-      const first = stations?.[variant.stations[0]];
-      const last = stations?.[variant.stations[variant.stations.length - 1]];
-      if (first) directionOptions.push(first);
-      if (last && last.id !== first?.id) directionOptions.push(last);
+    const seen = new Set<string>();
+    for (const variant of lines ?? []) {
+      if (variant.name !== lineName) continue;
+      if (!variant.stations.includes(selectedStation.id)) continue;
+      if (variant.stations.length < 2) continue;
+      const endpointIds = [variant.stations[0], variant.stations[variant.stations.length - 1]];
+      for (const id of endpointIds) {
+        if (seen.has(id)) continue;
+        const endpoint = stations?.[id];
+        if (!endpoint) continue;
+        seen.add(id);
+        directionOptions.push(endpoint);
+      }
     }
   }
 

--- a/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
+++ b/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
@@ -19,12 +19,14 @@ export function ReportSelectionProvider({ children }: { children: ReactNode }) {
   const [lineName, setLineName] = useState<string | null>(null);
   const [lineFilter, setLineFilter] = useState<LineFilter>('all');
   const [stationId, setStationId] = useState<string | null>(null);
+  const [directionStationId, setDirectionStationId] = useState<string | null>(null);
 
   const { data: lines } = useLines();
   const { data: stations } = useStations();
 
   const selectLine = (name: string | null) => {
     setLineName(name);
+    setDirectionStationId(null);
     if (name) {
       const type = lines?.find((l) => l.name === name)?.type;
       if (type) setLineFilter(type);
@@ -34,7 +36,12 @@ export function ReportSelectionProvider({ children }: { children: ReactNode }) {
   // Clearing the station also clears the chosen line so the user starts fresh.
   const selectStation = (id: string | null) => {
     setStationId(id);
+    setDirectionStationId(null);
     if (id === null) setLineName(null);
+  };
+
+  const selectDirection = (id: string | null) => {
+    setDirectionStationId(id);
   };
 
   // One badge per line name (collapses per-direction variants), sorted by canonical order.
@@ -83,15 +90,33 @@ export function ReportSelectionProvider({ children }: { children: ReactNode }) {
   else if (lineName) visibleStations = stationsAlongLine();
   else visibleStations = stationsByType();
 
+  // Direction picker shows the two endpoint stations of the selected line.
+  // For lines with multiple direction variants (U1, U1-a, U1-b …) pick the canonical "-a" variant
+  // and fall back to the only variant when there is just one.
+  const directionOptions: Station[] = [];
+  if (lineName && selectedStation) {
+    const variants = (lines ?? []).filter((l) => l.name === lineName);
+    const variant = variants.find((l) => l.id.endsWith('-a')) ?? variants[0];
+    if (variant && variant.stations.length >= 2) {
+      const first = stations?.[variant.stations[0]];
+      const last = stations?.[variant.stations[variant.stations.length - 1]];
+      if (first) directionOptions.push(first);
+      if (last && last.id !== first?.id) directionOptions.push(last);
+    }
+  }
+
   const value: ReportSelectionContextValue = {
     lineName,
     lineFilter,
     stationId,
+    directionStationId,
     selectLine,
     setLineFilter,
     selectStation,
+    selectDirection,
     visibleLines,
     visibleStations,
+    directionOptions,
   };
 
   return <ReportSelectionContext value={value}>{children}</ReportSelectionContext>;


### PR DESCRIPTION
## Summary
- Adds a `DirectionPicker` component shown after a station is selected. Renders endpoint stations as side-by-side buttons (grid).
- Extends `ReportSelectionContext` with `directionStationId`, `selectDirection`, and a derived `directionOptions`. Direction selection is cleared whenever the line or station changes.
- `directionOptions` lists every endpoint reachable along the selected line by walking each variant that contains the selected station and collecting its two termini, deduplicated. Stations on a single variant show two options; stations shared between variants surface every endpoint, so the actual variant id can be resolved from (lineName, stationId, directionStationId) at submit time.
- `StationPicker` is `flex-1` (scrollable) only while no station is picked; once collapsed it sits at natural height so the direction picker (and the future submit button) stay visible.
- i18n: adds `direction` ("Direction" / "Richtung"). The existing `optional` label is reused.

## Test plan
- [ ] Pick a line and a mid-line station: direction picker shows the two termini.
- [ ] Pick a terminus station: both termini still render (one of them is the user's station).
- [ ] Pick a station that lies on multiple variants of the same line (e.g. a branching trunk on U-Bahn or S-Bahn): every distinct endpoint across those variants appears, deduplicated.
- [ ] Changing the station or the line clears any previously selected direction.
- [ ] Tapping the selected direction again deselects it; direction stays optional.
- [ ] No direction picker shown when no line is selected, only a station.