### PR TITLE
feat: submit report from report form

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -1,0 +1,75 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { requireEnv } from '@/lib/utils';
+
+import { type Line, useLines } from './transit';
+
+const API_URL = requireEnv('VITE_API_URL');
+
+export type SubmitReportInput = {
+  stationId: string;
+  lineName?: string | null;
+  directionStationId?: string | null;
+};
+
+export type SubmitReportResponse = {
+  reportId: number;
+  stationId: string;
+  lineId: string | null;
+  directionId: string | null;
+  timestamp: string;
+};
+
+/**
+ * Pick the concrete `lines.id` variant to submit from the user's high-level selection.
+ * Narrows by station membership first, then by terminus when a direction was picked.
+ *
+ * HACK: when the selection still matches multiple variants we fall back to the canonical
+ * "-a" variant. Reporting should instead accept multiple candidate lines so the backend
+ * can disambiguate from other signals — tracked in
+ * https://linear.app/freifahren/issue/FRE-585/accept-multiple-candidate-lines-for-ambiguous-reports
+ */
+function resolveLineId(input: SubmitReportInput, lines: Line[] | undefined): string | null {
+  if (!input.lineName || !lines) return null;
+
+  const candidates = lines.filter(
+    (l) => l.name === input.lineName && l.stations.includes(input.stationId),
+  );
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0].id;
+
+  if (input.directionStationId) {
+    const narrowed = candidates.filter((l) => {
+      const first = l.stations[0];
+      const last = l.stations[l.stations.length - 1];
+      return first === input.directionStationId || last === input.directionStationId;
+    });
+    if (narrowed.length === 1) return narrowed[0].id;
+    if (narrowed.length > 1) {
+      return narrowed.find((l) => l.id.endsWith('-a'))?.id ?? narrowed[0].id;
+    }
+  }
+
+  return candidates.find((l) => l.id.endsWith('-a'))?.id ?? candidates[0].id;
+}
+
+export function useSubmitReport() {
+  const { data: lines } = useLines();
+  return useMutation({
+    mutationFn: async (input: SubmitReportInput): Promise<SubmitReportResponse> => {
+      const lineId = resolveLineId(input, lines);
+      const response = await fetch(`${API_URL}/v0/reports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          stationId: input.stationId,
+          lineId,
+          directionId: input.directionStationId ?? null,
+          source: 'web_app',
+        }),
+      });
+      if (!response.ok) throw new Error(`Report submission failed: ${response.status}`);
+      return response.json();
+    },
+  });
+}

--- a/packages/frontend-next/src/components/report/ReportForm.i18n.ts
+++ b/packages/frontend-next/src/components/report/ReportForm.i18n.ts
@@ -32,6 +32,6 @@ i18n.addResourceBundle('de', NAMESPACE, {
   required: 'Erforderlich',
   clearSelection: 'Auswahl löschen',
   direction: 'Richtung',
-  submit: 'Sichtung absenden',
+  submit: 'Melden',
   disclaimer: 'Anonym an alle Freifahren-Nutzer geteilt.',
 });

--- a/packages/frontend-next/src/components/report/ReportForm.i18n.ts
+++ b/packages/frontend-next/src/components/report/ReportForm.i18n.ts
@@ -15,6 +15,8 @@ i18n.addResourceBundle('en', NAMESPACE, {
   required: 'Required',
   clearSelection: 'clear selection',
   direction: 'Direction',
+  submit: 'Submit report',
+  disclaimer: 'Shared anonymously with all Freifahren users.',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
@@ -30,4 +32,6 @@ i18n.addResourceBundle('de', NAMESPACE, {
   required: 'Erforderlich',
   clearSelection: 'Auswahl löschen',
   direction: 'Richtung',
+  submit: 'Sichtung absenden',
+  disclaimer: 'Anonym an alle Freifahren-Nutzer geteilt.',
 });

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -2,8 +2,10 @@ import { useNavigate } from '@tanstack/react-router';
 import { ChevronRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { useSubmitReport } from '@/api/reports';
 import { PageHeader } from '@/components/templates/PageHeader';
 import { LineBadge } from '@/components/transit/LineBadge';
+import { Button } from '@/components/ui/button';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { cn } from '@/lib/utils';
 
@@ -165,6 +167,40 @@ function DirectionPicker() {
   );
 }
 
+function SubmitFooter() {
+  const { t } = useTranslation(NAMESPACE);
+  const { stationId, lineName, directionStationId } = useReportSelection();
+  const submitReport = useSubmitReport();
+
+  const canSubmit = stationId !== null;
+  const disabled = !canSubmit || submitReport.isPending;
+
+  const handleSubmit = () => {
+    if (!stationId) return;
+    submitReport.mutate({ stationId, lineName, directionStationId });
+  };
+
+  return (
+    <footer className="mt-auto px-4 pt-6 pb-4">
+      <Button
+        type="button"
+        size="lg"
+        disabled={disabled}
+        onClick={handleSubmit}
+        className={cn(
+          'h-12 w-full rounded-lg text-sm font-medium',
+          canSubmit
+            ? 'bg-accent-bright text-primary-foreground hover:bg-accent-press shadow-[0_6px_16px_rgba(214,59,59,0.28)]'
+            : 'bg-surface-solid text-muted-foreground border-border border',
+        )}
+      >
+        {t('submit')}
+      </Button>
+      <p className="text-muted-foreground mt-2 text-center text-[0.6875rem]">{t('disclaimer')}</p>
+    </footer>
+  );
+}
+
 export function ReportForm() {
   const { t } = useTranslation(NAMESPACE);
   const navigate = useNavigate();
@@ -177,6 +213,7 @@ export function ReportForm() {
           <LinePicker />
           <StationPicker />
           <DirectionPicker />
+          <SubmitFooter />
         </div>
       </div>
     </ReportSelectionProvider>


### PR DESCRIPTION
## Summary
- Adds a `useSubmitReport` hook (`src/api/reports.ts`) that POSTs to `/v0/reports` with `source: 'web_app'` and derives the concrete `lines.id` variant from the user's high-level selection.
- `resolveLineId` narrows by station membership first, then by terminus when a direction was picked. When the selection still matches multiple variants it falls back to the canonical `-a` variant with a `// HACK` comment pointing at [FRE-585](https://linear.app/freifahren/issue/FRE-585/accept-multiple-candidate-lines-for-ambiguous-reports).
- Adds a `SubmitFooter` in `ReportForm.tsx`, always visible at the bottom (`mt-auto`):
  - Grayed (`bg-surface-solid`, muted text) while no station is picked.
  - Red (`bg-accent-bright` / `hover:bg-accent-press`, same palette as the floating `ReportButton`) once a station is selected.
  - Disabled while the mutation is `isPending` so the user can't double-submit.
- i18n: adds `submit` ("Submit report" / "Sichtung absenden") and `disclaimer` strings.

## Test plan
- [ ] Open the report form: submit button is visible at the bottom, grayed out, disabled.
- [ ] Pick a station: button turns red and becomes clickable.
- [ ] Tap submit: request fires; button stays disabled until the response returns (no double submission possible).
- [ ] Pick a station that lies on only one variant: submitted `lineId` is that variant id.
- [ ] Pick a station on multiple variants + a direction whose terminus is unique to one variant: submitted `lineId` matches the disambiguated variant.
- [ ] Pick an ambiguous selection (multiple matching variants, direction does not disambiguate): submitted `lineId` falls back to the `-a` variant.
- [ ] Skip the line entirely (station only): submitted `lineId` and `directionId` are `null`; report still accepted by the backend.