### PR TITLE
feat: query and render reports on the map

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -1,8 +1,25 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { requireEnv } from '@/lib/utils';
 
-import { type Line, useLines } from './transit';
+import { fetchJson, type Line, useLines } from './transit';
+
+export type Report = {
+  timestamp: string;
+  stationId: string;
+  directionId: string | null;
+  lineId: string | null;
+  isPredicted: boolean;
+};
+
+export const useReports = () =>
+  useQuery({
+    queryKey: ['reports'],
+    queryFn: () => fetchJson<Report[]>('/v0/reports'),
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
+    staleTime: 30_000,
+  });
 
 const API_URL = requireEnv('VITE_API_URL');
 

--- a/packages/frontend-next/src/api/transit.ts
+++ b/packages/frontend-next/src/api/transit.ts
@@ -89,7 +89,7 @@ export function resolveStationLineNames(
   return names;
 }
 
-async function fetchJson<T>(path: string): Promise<T> {
+export async function fetchJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_URL}${path}`);
   if (!response.ok) {
     throw new Error(`Request to ${path} failed: ${response.status}`);

--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -5,6 +5,7 @@ import { Map as MapGL } from 'react-map-gl/maplibre';
 
 import { requireEnv } from '@/lib/utils';
 
+import { ReportsLayer } from './ReportsLayer';
 import { SegmentsLayer } from './SegmentsLayer';
 import { STATIONS_LAYER_ID, StationsLayer } from './StationsLayer';
 import { useStationSelection } from '../../hooks/useStationSelection';
@@ -31,6 +32,7 @@ export function MapView() {
       >
         <SegmentsLayer />
         <StationsLayer selectedStation={selectedStation} />
+        <ReportsLayer />
       </MapGL>
     </div>
   );

--- a/packages/frontend-next/src/components/map/ReportMarker.tsx
+++ b/packages/frontend-next/src/components/map/ReportMarker.tsx
@@ -6,7 +6,7 @@ import type { Station } from '@/api/transit';
 
 const FADE_DURATION_MS = 60 * 60 * 1000;
 const MIN_OPACITY = 0.2;
-const PULSE_AGE_MS = 60 * 1000;
+const PULSE_AGE_MS = 60 * 15 * 1000;
 const RECOMPUTE_INTERVAL_MS = 30 * 1000;
 
 type ReportMarkerProps = {
@@ -40,11 +40,11 @@ export function ReportMarker({ report, station }: ReportMarkerProps) {
       longitude={station.coordinates.longitude}
       opacity={opacity.toString()}
     >
-      <span className="relative block h-5 w-5 pointer-events-none">
+      <span className="pointer-events-none relative block h-5 w-5">
         {shouldPulse && (
-          <span className="absolute inset-0 rounded-full bg-destructive opacity-75 animate-ping" />
+          <span className="bg-destructive absolute inset-0 animate-ping rounded-full opacity-75" />
         )}
-        <span className="relative block h-5 w-5 rounded-full border-2 border-white bg-destructive shadow-sm" />
+        <span className="bg-destructive relative block h-5 w-5 rounded-full border-2 border-white shadow-sm" />
       </span>
     </Marker>
   );

--- a/packages/frontend-next/src/components/map/ReportMarker.tsx
+++ b/packages/frontend-next/src/components/map/ReportMarker.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { Marker } from 'react-map-gl/maplibre';
+
+import type { Report } from '@/api/reports';
+import type { Station } from '@/api/transit';
+
+const FADE_DURATION_MS = 60 * 60 * 1000;
+const MIN_OPACITY = 0.2;
+const PULSE_AGE_MS = 60 * 1000;
+const RECOMPUTE_INTERVAL_MS = 30 * 1000;
+
+type ReportMarkerProps = {
+  report: Report;
+  station: Station;
+};
+
+function computeOpacity(timestamp: string, nowMs: number): number {
+  const age = nowMs - new Date(timestamp).getTime();
+  if (age >= FADE_DURATION_MS) return 0;
+  return Math.max(MIN_OPACITY, 1 - age / FADE_DURATION_MS);
+}
+
+export function ReportMarker({ report, station }: ReportMarkerProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), RECOMPUTE_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const opacity = computeOpacity(report.timestamp, now);
+  if (opacity <= 0) return null;
+
+  const age = now - new Date(report.timestamp).getTime();
+  const shouldPulse = age < PULSE_AGE_MS;
+
+  return (
+    <Marker
+      latitude={station.coordinates.latitude}
+      longitude={station.coordinates.longitude}
+      opacity={opacity.toString()}
+    >
+      <span className="relative block h-5 w-5 pointer-events-none">
+        {shouldPulse && (
+          <span className="absolute inset-0 rounded-full bg-destructive opacity-75 animate-ping" />
+        )}
+        <span className="relative block h-5 w-5 rounded-full border-2 border-white bg-destructive shadow-sm" />
+      </span>
+    </Marker>
+  );
+}

--- a/packages/frontend-next/src/components/map/ReportsLayer.tsx
+++ b/packages/frontend-next/src/components/map/ReportsLayer.tsx
@@ -1,0 +1,23 @@
+import { useReports } from '@/api/reports';
+import { useStations } from '@/api/transit';
+
+import { ReportMarker } from './ReportMarker';
+
+export function ReportsLayer() {
+  const { data: reports } = useReports();
+  const { data: stations } = useStations();
+
+  if (!reports || !stations) return null;
+
+  return (
+    <>
+      {reports.map((report, index) => {
+        const station = stations[report.stationId];
+        if (!station) return null;
+        return (
+          <ReportMarker key={`${report.stationId}-${index}`} report={report} station={station} />
+        );
+      })}
+    </>
+  );
+}


### PR DESCRIPTION
## Describe the issue:

`frontend-next` had no concept of reports — the map showed stations and lines but not the inspector reports that the legacy frontend renders. We need to consume the new hono-backend `/v0/reports` endpoint and surface those reports on the map.

## Explain how you solved the issue:

- New `useReports()` TanStack Query hook in `packages/frontend-next/src/api/reports.ts`. Calls `GET /v0/reports` with no query params so the backend's default 60-min window kicks in, and polls every 30s via `refetchInterval`.
- Exported the existing `fetchJson` helper from `transit.ts` so the new hook can reuse it.
- New `ReportsLayer` joins reports with `useStations()` and skips reports whose `stationId` isn't in the stations map (defensive against reseed).
- New `ReportMarker` renders a `react-map-gl` `<Marker>` with opacity fading linearly from 1.0 → 0.2 over 60 min (hidden past that) and an `animate-ping` ring while the report is younger than 15 min. Marker uses Tailwind utility classes only.
- `Map.tsx` mounts `<ReportsLayer />` after `<StationsLayer />`; markers are `pointer-events-none` so station clicks still pass through.

## Additional notes or considerations:

- No `ViewedReportsContext` / "seen" tracking — pulse is purely time-based (< 15 min). Easy to swap to viewed-tracking later if needed.
- No marker click handler / popup yet.
- No historic (24h) reports — that's a separate query in the legacy frontend.