### PR TITLE
perf: lazy-load map so shell and station modal don't wait for maplibre

### DIFF
--- a/packages/frontend-next/src/routes/_map.tsx
+++ b/packages/frontend-next/src/routes/_map.tsx
@@ -1,13 +1,28 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { lazy, Suspense } from 'react';
 
-import { MapView } from '@/components/map/Map';
 import { ReportButton } from '@/components/map/ReportButton';
 import { StationSearch } from '@/components/map/StationSearch';
+
+// Start downloading the map component and the maplibre-gl library in parallel
+// as soon as a map route loads, so the map downloads alongside the shell
+// instead of waterfalling behind it. react-map-gl lazy-imports maplibre-gl on
+// mount; priming it here removes that extra round-trip. Both promises feed the
+// lazy resolver below so the warm-up is not tree-shaken. The /report route does
+// not mount this layout, so it stays free of the map bundle.
+const mapModule = import('@/components/map/Map');
+const maplibreModule = import('maplibre-gl');
+
+const MapView = lazy(() =>
+  Promise.all([mapModule, maplibreModule]).then(([m]) => ({ default: m.MapView })),
+);
 
 export const Route = createFileRoute('/_map')({
   component: () => (
     <>
-      <MapView />
+      <Suspense fallback={null}>
+        <MapView />
+      </Suspense>
       <StationSearch />
       <ReportButton />
       <Outlet />


### PR DESCRIPTION
## Summary

The `_map` layout statically imported `MapView`, which pulls in `maplibre-gl` (~270 KB gzipped). Because the layout module couldn't execute until that chunk downloaded and parsed, everything it renders — the search box, report button, and the `StationDetail` modal in the `<Outlet/>` — was blocked behind the map bundle, even though none of them need the map to display.

This change lazy-loads `MapView` behind `Suspense` so the shell and modal paint from their small chunks immediately, while maplibre streams in behind them. To avoid turning the map's load into a render-time waterfall, the map component and `maplibre-gl` are imported eagerly at layout-module load (in parallel with the shell) and fed through `Promise.all` into the lazy resolver — which also keeps the warm-up from being tree-shaken. The `/report` route doesn't mount this layout, so it stays free of the map bundle.

## Research findings

Benchmarked the production build (`vite build` + `vite preview`) on `localhost:1871`.

**Bundle picture** — `maplibre-gl` dominates at 270 KB gzipped (~70% of initial JS on map routes); the `index` entry is 119 KB. `/report` was already correctly split and never loads maplibre.

**Coupling found** — `react-map-gl@8` (via `@vis.gl/react-maplibre`) loads maplibre through its own dynamic `import("maplibre-gl")` on mount. Combined with the static `MapView` import in the layout, the whole layout subtree waited on the map bundle.

**Decoupling (verified in build output):** the `_map` layout chunk went from bundling maplibre to **0 static references**; maplibre now lives only in an async chunk.

**`/stations/:id`** — the StationDetail modal's chunks resolve by ~57 ms, while maplibre is deferred ~350 ms behind it. Before, maplibre was in the initial parallel batch and the modal couldn't render until it parsed.

**`/` route — maplibre download start time** (3 runs each, prod build):

| | median |
|---|---|
| Before (static import) | ~1009 ms (waterfalled after render) |
| After (lazy + parallel warm-up) | ~54 ms (parallel with shell) |

The 270 KB bundle now starts downloading ~950 ms earlier, alongside the shell.

**Caveat on magnitude:** on localhost the bundle downloads in ~5–20 ms, so end-to-end wall-clock barely moves — map render there is dominated by React mount + maplibre init, not download. The win **scales with network latency**: on slow mobile (270 KB ≈ 1–3 s) this moves the download off the critical path entirely. A throttled Lighthouse run would put a hard number on the mobile gain.

**No regressions:** `/report` stays maplibre-free; `/stations` modal paints early; `/` map renders correctly.

### Follow-up (not in this PR)
- Serve assets with **brotli** + `immutable` cache headers — measured ~16% transfer saving overall (270 → 220 KB on maplibre). frontend-next isn't in `compose.yaml` yet; worth wiring up behind nginx/CDN rather than the legacy `serve -s dist`.

## Test plan
- [x] `/` loads, map renders, search + report button interactive immediately
- [x] `/stations/:id` modal appears without waiting for the map
- [x] `/report` works and loads no maplibre chunk (check Network tab)
- [x] Optional: throttled Lighthouse pass on `/` to quantify the mobile improvement