### PR TITLE
feat: open a report detail card when clicking a report on the map

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 
 import { requireEnv } from '@/lib/utils';
 
@@ -20,6 +21,29 @@ export const useReports = () =>
     refetchIntervalInBackground: false,
     staleTime: 30_000,
   });
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+export const useStationReportCount = (stationId: string) => {
+  // Compute the window once per mount (lazy initializer), rounding `to` down to
+  // the top of the hour so the query key stays stable instead of refetching on
+  // every render.
+  const [{ from, to }] = useState(() => {
+    const toMs = Math.floor(Date.now() / HOUR_MS) * HOUR_MS;
+    return { from: new Date(toMs - WEEK_MS).toISOString(), to: new Date(toMs).toISOString() };
+  });
+
+  return useQuery({
+    queryKey: ['reports', stationId, from, to],
+    queryFn: () => {
+      const params = new URLSearchParams({ from, to });
+      return fetchJson<Report[]>(`/v0/reports/${stationId}?${params.toString()}`);
+    },
+    select: (reports) => reports.length,
+    staleTime: HOUR_MS,
+  });
+};
 
 const API_URL = requireEnv('VITE_API_URL');
 

--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -19,6 +19,8 @@ export const useReports = () =>
     queryFn: () => fetchJson<Report[]>('/v0/reports'),
     refetchInterval: 30_000,
     refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
     staleTime: 30_000,
   });
 
@@ -26,11 +28,12 @@ const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 const HOUR_MS = 60 * 60 * 1000;
 
 export const useStationReportCount = (stationId: string) => {
-  // Compute the window once per mount (lazy initializer), rounding `to` down to
-  // the top of the hour so the query key stays stable instead of refetching on
-  // every render.
+  // Compute the window once per mount (lazy initializer), rounding `to` up to
+  // the next hour. Rounding keeps the query key stable across renders; rounding
+  // *up* (rather than down) keeps the current partial hour inside the window, so
+  // a report submitted moments ago is still counted.
   const [{ from, to }] = useState(() => {
-    const toMs = Math.floor(Date.now() / HOUR_MS) * HOUR_MS;
+    const toMs = Math.ceil(Date.now() / HOUR_MS) * HOUR_MS;
     return { from: new Date(toMs - WEEK_MS).toISOString(), to: new Date(toMs).toISOString() };
   });
 

--- a/packages/frontend-next/src/components/map/DetailCard.tsx
+++ b/packages/frontend-next/src/components/map/DetailCard.tsx
@@ -1,0 +1,36 @@
+import { X } from 'lucide-react';
+import * as React from 'react';
+
+import { Backdrop } from '@/components/ui/backdrop';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+
+type DetailCardProps = {
+  title: string;
+  closeLabel: string;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+export function DetailCard({ title, closeLabel, onClose, children }: DetailCardProps) {
+  return (
+    <>
+      <Backdrop
+        aria-label={closeLabel}
+        onClose={onClose}
+        className="animate-in fade-in duration-150"
+      />
+      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-20 flex justify-center p-3">
+        <Card className="animate-in slide-in-from-bottom-4 fade-in pointer-events-auto w-full max-w-md gap-1 py-4 duration-200 ease-out">
+          <CardContent className="flex items-start justify-between">
+            <h2 className="font-heading text-lg font-semibold">{title}</h2>
+            <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label={closeLabel}>
+              <X />
+            </Button>
+          </CardContent>
+          {children}
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/packages/frontend-next/src/components/map/ReportDetail.i18n.ts
+++ b/packages/frontend-next/src/components/map/ReportDetail.i18n.ts
@@ -1,0 +1,27 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'reportDetail';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  close: 'Close',
+  now: 'Just now',
+  minutesAgo: '{{count}} min ago',
+  hoursAgo_one: '1 hour ago',
+  hoursAgo_other: '{{count}} hours ago',
+  times: 'times',
+  thisWeek: 'this week',
+  inviteText: 'Data may be inaccurate.',
+  syncText: 'Reports synced with @FreiFahren_BE',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  close: 'Schließen',
+  now: 'Gerade eben',
+  minutesAgo: 'vor {{count}} min',
+  hoursAgo_one: 'vor 1 Stunde',
+  hoursAgo_other: 'vor {{count}} Stunden',
+  times: 'mal',
+  thisWeek: 'diese Woche',
+  inviteText: 'Daten vielleicht ungenau.',
+  syncText: 'Meldungen mit @FreiFahren_BE synchronisiert',
+});

--- a/packages/frontend-next/src/components/map/ReportDetail.i18n.ts
+++ b/packages/frontend-next/src/components/map/ReportDetail.i18n.ts
@@ -6,22 +6,24 @@ i18n.addResourceBundle('en', NAMESPACE, {
   close: 'Close',
   now: 'Just now',
   minutesAgo: '{{count}} min ago',
+  moreThan45Min: 'More than 45 min ago',
   hoursAgo_one: '1 hour ago',
   hoursAgo_other: '{{count}} hours ago',
   times: 'times',
   thisWeek: 'this week',
   inviteText: 'Data may be inaccurate.',
-  syncText: 'Reports synced with @FreiFahren_BE',
+  syncText: 'Reports synced with {{group}}',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
   close: 'Schließen',
   now: 'Gerade eben',
   minutesAgo: 'vor {{count}} min',
+  moreThan45Min: 'Vor mehr als 45 min',
   hoursAgo_one: 'vor 1 Stunde',
   hoursAgo_other: 'vor {{count}} Stunden',
   times: 'mal',
   thisWeek: 'diese Woche',
   inviteText: 'Daten vielleicht ungenau.',
-  syncText: 'Meldungen mit @FreiFahren_BE synchronisiert',
+  syncText: 'Meldungen mit {{group}} synchronisiert',
 });

--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -1,0 +1,67 @@
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
+
+import { useReports, useStationReportCount } from '@/api/reports';
+import { type Station, useLines, useStations } from '@/api/transit';
+import { LineBadge } from '@/components/transit/LineBadge';
+import { CardContent } from '@/components/ui/card';
+
+import { DetailCard } from './DetailCard';
+import { NAMESPACE } from './ReportDetail.i18n';
+
+type ReportDetailProps = {
+  station: Station;
+  onClose: () => void;
+};
+
+function formatElapsed(timestamp: string, t: TFunction): string {
+  const minutes = Math.floor((Date.now() - new Date(timestamp).getTime()) / 60_000);
+  if (minutes <= 1) return t('now');
+  if (minutes < 60) return t('minutesAgo', { count: minutes });
+  return t('hoursAgo', { count: Math.floor(minutes / 60) });
+}
+
+export function ReportDetail({ station, onClose }: ReportDetailProps) {
+  const { t } = useTranslation(NAMESPACE);
+  const { data: reports } = useReports();
+  const { data: lines } = useLines();
+  const { data: stations } = useStations();
+  const { data: numberOfReports } = useStationReportCount(station.id);
+
+  const report = (reports ?? [])
+    .filter((r) => r.stationId === station.id)
+    .sort((a, b) => b.timestamp.localeCompare(a.timestamp))[0];
+
+  const lineName = report?.lineId
+    ? lines?.find((line) => line.id === report.lineId)?.name
+    : undefined;
+  const directionName = report?.directionId ? stations?.[report.directionId]?.name : undefined;
+
+  return (
+    <DetailCard title={station.name} closeLabel={t('close')} onClose={onClose}>
+      {(lineName || directionName) && (
+        <CardContent className="flex items-center gap-2">
+          {lineName && <LineBadge name={lineName} />}
+          {directionName && <span className="text-sm font-medium">{directionName}</span>}
+        </CardContent>
+      )}
+      <CardContent className="space-y-1">
+        {report && (
+          <p className="text-muted-foreground text-sm">{formatElapsed(report.timestamp, t)}</p>
+        )}
+        {numberOfReports !== undefined && numberOfReports > 0 && (
+          <p className="text-sm">
+            <span className="font-semibold">
+              {numberOfReports} {t('times')}
+            </span>{' '}
+            {t('thisWeek')}
+          </p>
+        )}
+      </CardContent>
+      <CardContent className="text-muted-foreground space-y-0.5 text-xs">
+        <p>{t('inviteText')}</p>
+        <p>{t('syncText')}</p>
+      </CardContent>
+    </DetailCard>
+  );
+}

--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -5,6 +5,7 @@ import { useReports, useStationReportCount } from '@/api/reports';
 import { type Station, useLines, useStations } from '@/api/transit';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { CardContent } from '@/components/ui/card';
+import { optionalEnv } from '@/lib/utils';
 
 import { DetailCard } from './DetailCard';
 import { NAMESPACE } from './ReportDetail.i18n';
@@ -14,10 +15,14 @@ type ReportDetailProps = {
   onClose: () => void;
 };
 
+// Telegram group the reports are synced with.
+const REPORTS_GROUP_HANDLE = optionalEnv('VITE_REPORTS_GROUP_HANDLE') ?? '@FreiFahren_BE';
+
 function formatElapsed(timestamp: string, t: TFunction): string {
   const minutes = Math.floor((Date.now() - new Date(timestamp).getTime()) / 60_000);
   if (minutes <= 1) return t('now');
-  if (minutes < 60) return t('minutesAgo', { count: minutes });
+  if (minutes <= 45) return t('minutesAgo', { count: minutes });
+  if (minutes < 60) return t('moreThan45Min');
   return t('hoursAgo', { count: Math.floor(minutes / 60) });
 }
 
@@ -49,18 +54,21 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
         {report && (
           <p className="text-muted-foreground text-sm">{formatElapsed(report.timestamp, t)}</p>
         )}
-        {numberOfReports !== undefined && numberOfReports > 0 && (
-          <p className="text-sm">
-            <span className="font-semibold">
-              {numberOfReports} {t('times')}
-            </span>{' '}
-            {t('thisWeek')}
-          </p>
-        )}
+        {/* Reserve the line height so the count loading in does not shift layout. */}
+        <p className="min-h-5 text-sm">
+          {numberOfReports !== undefined && numberOfReports > 0 && (
+            <>
+              <span className="font-semibold">
+                {numberOfReports} {t('times')}
+              </span>{' '}
+              {t('thisWeek')}
+            </>
+          )}
+        </p>
       </CardContent>
       <CardContent className="text-muted-foreground space-y-0.5 text-xs">
         <p>{t('inviteText')}</p>
-        <p>{t('syncText')}</p>
+        <p>{t('syncText', { group: REPORTS_GROUP_HANDLE })}</p>
       </CardContent>
     </DetailCard>
   );

--- a/packages/frontend-next/src/components/map/ReportMarker.tsx
+++ b/packages/frontend-next/src/components/map/ReportMarker.tsx
@@ -1,8 +1,10 @@
+import { useNavigate } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
-import { Marker } from 'react-map-gl/maplibre';
+import { Marker, type MarkerEvent } from 'react-map-gl/maplibre';
 
 import type { Report } from '@/api/reports';
 import type { Station } from '@/api/transit';
+import { Route as ReportDetailRoute } from '@/routes/_map/reports/$stationId';
 
 const FADE_DURATION_MS = 60 * 60 * 1000;
 const MIN_OPACITY = 0.2;
@@ -21,6 +23,7 @@ function computeOpacity(timestamp: string, nowMs: number): number {
 }
 
 export function ReportMarker({ report, station }: ReportMarkerProps) {
+  const navigate = useNavigate();
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
@@ -34,15 +37,22 @@ export function ReportMarker({ report, station }: ReportMarkerProps) {
   const age = now - new Date(report.timestamp).getTime();
   const shouldPulse = age < PULSE_AGE_MS;
 
+  const handleClick = (event: MarkerEvent<MouseEvent>) => {
+    // Stop the map's onClick from also firing (which would open the station detail).
+    event.originalEvent.stopPropagation();
+    void navigate({ to: ReportDetailRoute.to, params: { stationId: report.stationId } });
+  };
+
   return (
     <Marker
       latitude={station.coordinates.latitude}
       longitude={station.coordinates.longitude}
       opacity={opacity.toString()}
+      onClick={handleClick}
     >
-      <span className="pointer-events-none relative block h-5 w-5">
+      <span className="relative block h-5 w-5 cursor-pointer">
         {shouldPulse && (
-          <span className="bg-destructive absolute inset-0 animate-ping rounded-full opacity-75" />
+          <span className="bg-destructive pointer-events-none absolute inset-0 animate-ping rounded-full opacity-75" />
         )}
         <span className="bg-destructive relative block h-5 w-5 rounded-full border-2 border-white shadow-sm" />
       </span>

--- a/packages/frontend-next/src/components/map/StationDetail.tsx
+++ b/packages/frontend-next/src/components/map/StationDetail.tsx
@@ -1,14 +1,13 @@
 import { Link } from '@tanstack/react-router';
-import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { resolveStationLineNames, type Station, useLines } from '@/api/transit';
 import { LineBadge } from '@/components/transit/LineBadge';
-import { Backdrop } from '@/components/ui/backdrop';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
+import { CardContent } from '@/components/ui/card';
 import { Route as ReportRoute } from '@/routes/report';
 
+import { DetailCard } from './DetailCard';
 import { NAMESPACE } from './StationDetail.i18n';
 
 type StationDetailProps = {
@@ -22,36 +21,21 @@ export function StationDetail({ station, onClose }: StationDetailProps) {
   const lineNames = resolveStationLineNames(station.lines, lines);
 
   return (
-    <>
-      <Backdrop
-        aria-label={t('close')}
-        onClose={onClose}
-        className="animate-in fade-in duration-150"
-      />
-      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-20 flex justify-center p-3">
-        <Card className="animate-in slide-in-from-bottom-4 fade-in pointer-events-auto w-full max-w-md gap-1 py-4 duration-200 ease-out">
-          <CardContent className="flex items-start justify-between">
-            <h2 className="font-heading text-lg font-semibold">{station.name}</h2>
-            <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label={t('close')}>
-              <X />
-            </Button>
-          </CardContent>
-          <CardContent className="flex flex-wrap gap-1.5">
-            {lineNames.map((name) => (
-              <LineBadge key={name} name={name} />
-            ))}
-          </CardContent>
-          <CardContent className="mt-2">
-            <Button
-              asChild
-              variant="default"
-              className="bg-destructive hover:bg-destructive/90 h-9 w-full text-sm font-medium text-white"
-            >
-              <Link to={ReportRoute.to}>{t('reportSighting')}</Link>
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-    </>
+    <DetailCard title={station.name} closeLabel={t('close')} onClose={onClose}>
+      <CardContent className="flex flex-wrap gap-1.5">
+        {lineNames.map((name) => (
+          <LineBadge key={name} name={name} />
+        ))}
+      </CardContent>
+      <CardContent className="mt-2">
+        <Button
+          asChild
+          variant="default"
+          className="bg-destructive hover:bg-destructive/90 h-9 w-full text-sm font-medium text-white"
+        >
+          <Link to={ReportRoute.to}>{t('reportSighting')}</Link>
+        </Button>
+      </CardContent>
+    </DetailCard>
   );
 }

--- a/packages/frontend-next/src/lib/utils.ts
+++ b/packages/frontend-next/src/lib/utils.ts
@@ -5,6 +5,11 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export function optionalEnv(key: string): string | undefined {
+  const raw = import.meta.env[key];
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
 export function requireEnv(key: string): string;
 export function requireEnv(key: string, as: 'number'): number;
 export function requireEnv(key: string, as?: 'number'): string | number {

--- a/packages/frontend-next/src/routeTree.gen.ts
+++ b/packages/frontend-next/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as ReportRouteImport } from './routes/report'
 import { Route as MapRouteImport } from './routes/_map'
 import { Route as MapIndexRouteImport } from './routes/_map/index'
 import { Route as MapStationsStationIdRouteImport } from './routes/_map/stations/$stationId'
+import { Route as MapReportsStationIdRouteImport } from './routes/_map/reports/$stationId'
 
 const ReportRoute = ReportRouteImport.update({
   id: '/report',
@@ -33,15 +34,22 @@ const MapStationsStationIdRoute = MapStationsStationIdRouteImport.update({
   path: '/stations/$stationId',
   getParentRoute: () => MapRoute,
 } as any)
+const MapReportsStationIdRoute = MapReportsStationIdRouteImport.update({
+  id: '/reports/$stationId',
+  path: '/reports/$stationId',
+  getParentRoute: () => MapRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof MapIndexRoute
   '/report': typeof ReportRoute
+  '/reports/$stationId': typeof MapReportsStationIdRoute
   '/stations/$stationId': typeof MapStationsStationIdRoute
 }
 export interface FileRoutesByTo {
   '/report': typeof ReportRoute
   '/': typeof MapIndexRoute
+  '/reports/$stationId': typeof MapReportsStationIdRoute
   '/stations/$stationId': typeof MapStationsStationIdRoute
 }
 export interface FileRoutesById {
@@ -49,14 +57,21 @@ export interface FileRoutesById {
   '/_map': typeof MapRouteWithChildren
   '/report': typeof ReportRoute
   '/_map/': typeof MapIndexRoute
+  '/_map/reports/$stationId': typeof MapReportsStationIdRoute
   '/_map/stations/$stationId': typeof MapStationsStationIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/report' | '/stations/$stationId'
+  fullPaths: '/' | '/report' | '/reports/$stationId' | '/stations/$stationId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/report' | '/' | '/stations/$stationId'
-  id: '__root__' | '/_map' | '/report' | '/_map/' | '/_map/stations/$stationId'
+  to: '/report' | '/' | '/reports/$stationId' | '/stations/$stationId'
+  id:
+    | '__root__'
+    | '/_map'
+    | '/report'
+    | '/_map/'
+    | '/_map/reports/$stationId'
+    | '/_map/stations/$stationId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -94,16 +109,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MapStationsStationIdRouteImport
       parentRoute: typeof MapRoute
     }
+    '/_map/reports/$stationId': {
+      id: '/_map/reports/$stationId'
+      path: '/reports/$stationId'
+      fullPath: '/reports/$stationId'
+      preLoaderRoute: typeof MapReportsStationIdRouteImport
+      parentRoute: typeof MapRoute
+    }
   }
 }
 
 interface MapRouteChildren {
   MapIndexRoute: typeof MapIndexRoute
+  MapReportsStationIdRoute: typeof MapReportsStationIdRoute
   MapStationsStationIdRoute: typeof MapStationsStationIdRoute
 }
 
 const MapRouteChildren: MapRouteChildren = {
   MapIndexRoute: MapIndexRoute,
+  MapReportsStationIdRoute: MapReportsStationIdRoute,
   MapStationsStationIdRoute: MapStationsStationIdRoute,
 }
 

--- a/packages/frontend-next/src/routes/_map/reports/$stationId.tsx
+++ b/packages/frontend-next/src/routes/_map/reports/$stationId.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
+
+import { queryClient } from '@/api/queryClient';
+import { fetchStations } from '@/api/transit';
+import { ReportDetail } from '@/components/map/ReportDetail';
+
+export const Route = createFileRoute('/_map/reports/$stationId')({
+  loader: async ({ params }) => {
+    const stations = await queryClient.ensureQueryData({
+      queryKey: ['transit', 'stations'],
+      queryFn: fetchStations,
+    });
+    const station = stations[params.stationId];
+    if (!station) throw redirect({ to: '/', replace: true });
+    return { station };
+  },
+  component: ReportRoute,
+});
+
+function ReportRoute() {
+  const { station } = Route.useLoaderData();
+  const navigate = useNavigate();
+  return <ReportDetail station={station} onClose={() => navigate({ to: '/' })} />;
+}


### PR DESCRIPTION
## Describe the issue:

Report markers on the map were not interactive — clicking one did nothing. We wanted clicking a report to open a card, similar to the existing `StationDetail`, showing the report's line/direction, how long ago it was, and how many times the station has been reported this week. Linear: FRE-602.

## Explain how you solved the issue:

- **Shared abstraction** — extracted `DetailCard` (backdrop + bottom-sheet card + title row + close button) and refactored `StationDetail` to use it, so the new report card shares the same shell and backdrop.
- **Report detail** — added `ReportDetail` plus a URL-driven route `/_map/reports/$stationId` (mirroring the station route). It shows the most recent report's `LineBadge` + direction, a relative timestamp ("Just now", "N min ago", "More than 45 min ago", "N hours ago"), the "N times this week" count, and the disclaimers.
- **Clickable markers** — `ReportMarker` now navigates to the report route on click (and stops propagation so the station detail doesn't also open).
- **Weekly count** — the Hono backend has no statistics endpoint, so the count comes from `GET /v0/reports/:stationId` over a trailing 7-day window, computed client-side in `useStationReportCount`.

## Additional notes or considerations:

- The weekly window rounds `to` **up** to the next hour so a just-submitted report (in the current partial hour) is still counted, while keeping the React Query key stable.
- The reports feed now refetches on window focus / reconnect so markers don't go stale after the tab has been idle.
- The synced-group handle is now configurable via the optional `VITE_REPORTS_GROUP_HANDLE` env var, defaulting to `@FreiFahren_BE` when unset.
- Count line reserves its height to avoid layout shift while it loads.