### PR TITLE
feat: display user's location on the map

### DIFF
--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -8,6 +8,7 @@ import { requireEnv } from '@/lib/utils';
 import { ReportsLayer } from './ReportsLayer';
 import { SegmentsLayer } from './SegmentsLayer';
 import { STATIONS_LAYER_ID, StationsLayer } from './StationsLayer';
+import { UserLocationControl } from './UserLocationControl';
 import { useStationSelection } from '../../hooks/useStationSelection';
 
 const MAP_STYLE_URL = requireEnv('VITE_MAP_STYLE_URL');
@@ -33,6 +34,7 @@ export function MapView() {
         <SegmentsLayer />
         <StationsLayer selectedStation={selectedStation} />
         <ReportsLayer />
+        <UserLocationControl />
       </MapGL>
     </div>
   );

--- a/packages/frontend-next/src/components/map/UserLocationControl.tsx
+++ b/packages/frontend-next/src/components/map/UserLocationControl.tsx
@@ -1,0 +1,58 @@
+import type { GeolocateControl as GeolocateControlInstance } from 'maplibre-gl';
+import { useEffect, useRef } from 'react';
+import { GeolocateControl, useMap } from 'react-map-gl/maplibre';
+
+import { useGeolocation } from '@/contexts/Geolocation.context';
+
+/**
+ * Renders maplibre's native GeolocateControl (blue dot, accuracy circle, continuous
+ * tracking, permission/error handling) and mirrors its events into GeolocationProvider
+ * so the rest of the app can read the user's position. Tracking is requested
+ * automatically once the map has loaded.
+ */
+export function UserLocationControl() {
+  const { current: map } = useMap();
+  const controlRef = useRef<GeolocateControlInstance>(null);
+  const { notifyLoading, notifyPosition, notifyError } = useGeolocation();
+
+  useEffect(() => {
+    if (!map) return;
+
+    // Defer the trigger so StrictMode's dev mount/unmount/mount cycle (which
+    // re-adds the control in its inactive state) settles on a single net
+    // activation — trigger() toggles, so calling it twice would switch
+    // tracking back off.
+    let timer = 0;
+    const activate = () => {
+      timer = window.setTimeout(() => {
+        notifyLoading();
+        controlRef.current?.trigger();
+      }, 0);
+    };
+
+    if (map.loaded()) activate();
+    else map.once('load', activate);
+
+    return () => {
+      window.clearTimeout(timer);
+      map.off('load', activate);
+    };
+  }, [map, notifyLoading]);
+
+  return (
+    <GeolocateControl
+      ref={controlRef}
+      // Location is requested automatically, so the control's button is hidden.
+      // This only hides the button container; the user-location dot and accuracy
+      // circle are added to the map separately and stay visible.
+      style={{ display: 'none' }}
+      positionOptions={{ enableHighAccuracy: true }}
+      trackUserLocation
+      showUserLocation
+      showAccuracyCircle
+      onGeolocate={(e) => notifyPosition(e.coords)}
+      onError={(e) => notifyError(e.code)}
+      onTrackUserLocationStart={() => notifyLoading()}
+    />
+  );
+}

--- a/packages/frontend-next/src/contexts/Geolocation.context.ts
+++ b/packages/frontend-next/src/contexts/Geolocation.context.ts
@@ -1,0 +1,24 @@
+import { createContext, useContext } from 'react';
+
+export type GeolocationStatus = 'idle' | 'loading' | 'tracking' | 'denied' | 'unavailable';
+
+export type UserPosition = { lng: number; lat: number };
+
+export type GeolocationContextValue = {
+  status: GeolocationStatus;
+  position: UserPosition | null;
+  accuracy: number | null; // metres, from GeolocationCoordinates.accuracy
+
+  // Internal setters, driven by the map's GeolocateControl events.
+  notifyLoading: () => void;
+  notifyPosition: (coords: GeolocationCoordinates) => void;
+  notifyError: (code: number) => void; // GeolocationPositionError.code
+};
+
+export const GeolocationContext = createContext<GeolocationContextValue | null>(null);
+
+export function useGeolocation(): GeolocationContextValue {
+  const ctx = useContext(GeolocationContext);
+  if (!ctx) throw new Error('useGeolocation must be used within GeolocationProvider');
+  return ctx;
+}

--- a/packages/frontend-next/src/contexts/GeolocationProvider.tsx
+++ b/packages/frontend-next/src/contexts/GeolocationProvider.tsx
@@ -1,0 +1,38 @@
+import { type ReactNode, useCallback, useState } from 'react';
+
+import {
+  GeolocationContext,
+  type GeolocationContextValue,
+  type GeolocationStatus,
+  type UserPosition,
+} from './Geolocation.context';
+
+export function GeolocationProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<GeolocationStatus>('idle');
+  const [position, setPosition] = useState<UserPosition | null>(null);
+  const [accuracy, setAccuracy] = useState<number | null>(null);
+
+  const notifyLoading = useCallback(() => setStatus('loading'), []);
+
+  const notifyPosition = useCallback((coords: GeolocationCoordinates) => {
+    setPosition({ lng: coords.longitude, lat: coords.latitude });
+    setAccuracy(coords.accuracy);
+    setStatus('tracking');
+  }, []);
+
+  const notifyError = useCallback((code: number) => {
+    // GeolocationPositionError: 1 = PERMISSION_DENIED, 2 = POSITION_UNAVAILABLE, 3 = TIMEOUT.
+    setStatus(code === 1 ? 'denied' : 'unavailable');
+  }, []);
+
+  const value: GeolocationContextValue = {
+    status,
+    position,
+    accuracy,
+    notifyLoading,
+    notifyPosition,
+    notifyError,
+  };
+
+  return <GeolocationContext value={value}>{children}</GeolocationContext>;
+}

--- a/packages/frontend-next/src/routes/__root.tsx
+++ b/packages/frontend-next/src/routes/__root.tsx
@@ -1,5 +1,11 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router';
 
+import { GeolocationProvider } from '@/contexts/GeolocationProvider';
+
 export const Route = createRootRoute({
-  component: () => <Outlet />,
+  component: () => (
+    <GeolocationProvider>
+      <Outlet />
+    </GeolocationProvider>
+  ),
 });


### PR DESCRIPTION
## Summary

Integrates the user's live browser geolocation into the `frontend-next` map (FRE-611). On map load the app requests location and shows the user's position with the native maplibre dot + accuracy circle, tracking it continuously (users are usually on a train). Position is held in an app-level context so it's reusable by downstream work (FRE-612 "closest stations in ReportForm", FRE-615).

## Changes

- **`src/contexts/Geolocation.context.ts`** — `GeolocationStatus` (`idle`/`loading`/`tracking`/`denied`/`unavailable`), `UserPosition`, the context, and the `useGeolocation()` hook (mirrors the existing `useReportSelection` pattern).
- **`src/contexts/GeolocationProvider.tsx`** — single source of truth for `{ status, position, accuracy }`; maps `GeolocationPositionError` codes (`1 → denied`, `2/3 → unavailable`).
- **`src/components/map/UserLocationControl.tsx`** — wraps maplibre's native `GeolocateControl` (`trackUserLocation`, `showAccuracyCircle`, `enableHighAccuracy`), mirrors its events into the context, and auto-triggers the permission request once the map fires `load`. The control button is hidden (`display: none`) since location is requested automatically; the dot/accuracy circle stay visible.
- **`src/components/map/Map.tsx`** — renders `<UserLocationControl />` inside the map.
- **`src/routes/__root.tsx`** — wraps the route tree in `<GeolocationProvider>` so both the `_map` and sibling `/report` routes can read the position.

## Acceptance criteria

- ✅ Requests & consumes browser geolocation with clear permission/error state (status enum exposed app-wide).
- ✅ Shows the user's position (blue dot + accuracy circle, recenters and tracks).
- ✅ Denied / unavailable / loading states never block core map usage (native control behavior; map stays interactive).
- ✅ No city-specific assumptions hard-coded — uses device location only; map center/zoom still come from `VITE_*` env vars.

## Notes

- The auto-trigger is StrictMode-safe: `trigger()` toggles, so it's deferred and cancelled in cleanup to land exactly one net activation across React's dev double-mount.

## Verification

- `npm run build` (incl. `tsc -b`) and `npm run lint` pass.
- Manual: grant → dot appears, map flies/tracks (verify movement via Chrome DevTools → Sensors); deny / unavailable → map stays fully usable.