### PR TITLE
Fix logger message format to handle zero response times

### DIFF
--- a/packages/hono-backend/src/common/logger.ts
+++ b/packages/hono-backend/src/common/logger.ts
@@ -9,7 +9,12 @@ export const logger = pino({
                 options: {
                     colorize: true,
                     ignore: 'pid,hostname,req,res,responseTime,reqId',
-                    messageFormat: '{if responseTime}{req.method} {req.url} {res.status} ({responseTime}ms){end}{msg}',
+                    // Render the request summary whenever request data is present. We gate on `req`
+                    // (always set for request logs) instead of `responseTime`, because very fast
+                    // requests can report `responseTime: 0`, which `{if responseTime}` treats as
+                    // falsy and would otherwise produce blank `INFO:` lines.
+                    messageFormat:
+                        '{if req}{req.method} {req.url} {res.status} ({responseTime}ms){end}{if msg} {msg}{end}',
                     translateTime: 'SYS:standard',
                     destination: 1,
                 },

--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -66,6 +66,9 @@ export const createApp = (dbConnection: DbConnection = db) => {
         pinoLogger({
             pino: logger,
             http: {
+                // The request summary (method, path, status, duration) is rendered by the
+                // `messageFormat` in logger.ts, so we intentionally emit an empty `msg` here to
+                // avoid duplicating it.
                 onResMessage: () => '',
             },
         })


### PR DESCRIPTION
## Describe the issue:

The logger's message format was using `{if responseTime}` to conditionally render the request summary (method, URL, status, duration). However, very fast requests can report `responseTime: 0`, which is treated as falsy by the conditional, resulting in blank `INFO:` log lines with no request information.

## Explain how you solved the issue:

Changed the conditional from `{if responseTime}` to `{if req}` since the `req` object is always present for request logs and provides a more reliable gate for rendering the request summary. This ensures that even requests with zero response time are properly logged.

Additionally:
- Added clarifying comments in both `logger.ts` and `index.ts` explaining the logging behavior
- Updated the message format to separately handle the optional message part with `{if msg}` to avoid extra whitespace when no message is present
- Clarified in `index.ts` that the `onResMessage` callback intentionally returns an empty string since the request summary is already rendered by the `messageFormat`

## Additional notes or considerations:

This is a logging behavior fix with no functional impact on the application. The change ensures consistent log output for all requests regardless of response time.

https://claude.ai/code/session_01Nmt77ePpqEakYpus7ub774