### PR TITLE
feat: risk layer for frontend-next

### DIFF
--- a/packages/frontend-next/src/api/risk.ts
+++ b/packages/frontend-next/src/api/risk.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchJson } from './transit';
+
+export type SegmentRisk = { color: string; risk: number };
+export type RiskData = { segments_risk: Record<string, SegmentRisk> };
+
+export const useRisk = () =>
+  useQuery({
+    queryKey: ['risk'],
+    queryFn: () => fetchJson<RiskData>('/v0/risk'),
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
+    staleTime: 30_000,
+  });

--- a/packages/frontend-next/src/api/transit.ts
+++ b/packages/frontend-next/src/api/transit.ts
@@ -46,6 +46,7 @@ export type Line = {
 };
 
 export type SegmentProperties = {
+  id: number;
   line: string;
   from: StationId;
   to: StationId;

--- a/packages/frontend-next/src/components/map/LayerToggleButton.i18n.ts
+++ b/packages/frontend-next/src/components/map/LayerToggleButton.i18n.ts
@@ -1,0 +1,15 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'layerToggle';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  risk: 'Risk',
+  showRiskLayer: 'Show risk layer',
+  hideRiskLayer: 'Hide risk layer',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  risk: 'Risiko',
+  showRiskLayer: 'Risiko-Ebene anzeigen',
+  hideRiskLayer: 'Risiko-Ebene ausblenden',
+});

--- a/packages/frontend-next/src/components/map/LayerToggleButton.tsx
+++ b/packages/frontend-next/src/components/map/LayerToggleButton.tsx
@@ -1,0 +1,32 @@
+import { Layers } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { useRiskLayer } from '@/hooks/useRiskLayer';
+import { cn } from '@/lib/utils';
+
+import { NAMESPACE } from './LayerToggleButton.i18n';
+
+export function LayerToggleButton() {
+  const { t } = useTranslation(NAMESPACE);
+  const { visible, toggle } = useRiskLayer();
+
+  return (
+    <div className="pointer-events-none fixed top-0 right-0 z-20 p-3">
+      <Button
+        type="button"
+        variant="secondary"
+        onClick={toggle}
+        aria-pressed={visible}
+        aria-label={visible ? t('hideRiskLayer') : t('showRiskLayer')}
+        className={cn(
+          'ring-foreground/10 pointer-events-auto h-auto flex-col gap-0.5 rounded-lg p-2 shadow-[0_6px_16px_rgba(0,0,0,0.28)] ring-1',
+          visible ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
+        )}
+      >
+        <Layers className="size-4" />
+        {visible && <span className="text-[10px] leading-none font-medium">{t('risk')}</span>}
+      </Button>
+    </div>
+  );
+}

--- a/packages/frontend-next/src/components/map/LayerToggleButton.tsx
+++ b/packages/frontend-next/src/components/map/LayerToggleButton.tsx
@@ -20,12 +20,14 @@ export function LayerToggleButton() {
         aria-pressed={visible}
         aria-label={visible ? t('hideRiskLayer') : t('showRiskLayer')}
         className={cn(
-          'ring-foreground/10 pointer-events-auto h-auto flex-col gap-0.5 rounded-lg p-2 shadow-[0_6px_16px_rgba(0,0,0,0.28)] ring-1',
+          'bg-card ring-foreground/10 hover:bg-card/80 pointer-events-auto h-auto flex-col gap-0.5 rounded-lg p-2 shadow-[0_6px_16px_rgba(0,0,0,0.28)] ring-1',
+          // Risk is the default and switching is rare, so keep the states quiet: full-strength
+          // when on, dimmed when off. The label stays put in both states, so it never reflows.
           visible ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
         )}
       >
         <Layers className="size-4" />
-        {visible && <span className="text-[10px] leading-none font-medium">{t('risk')}</span>}
+        <span className="text-[10px] leading-none font-medium">{t('risk')}</span>
       </Button>
     </div>
   );

--- a/packages/frontend-next/src/components/map/LineLayer.tsx
+++ b/packages/frontend-next/src/components/map/LineLayer.tsx
@@ -2,7 +2,9 @@ import { Layer, Source } from 'react-map-gl/maplibre';
 
 import { useSegments } from '@/api/transit';
 
-export function SegmentsLayer() {
+import { STATIONS_BASE_LAYER_ID } from './StationsLayer';
+
+export function LineLayer() {
   const { data: segments } = useSegments();
 
   if (!segments) return null;
@@ -12,6 +14,7 @@ export function SegmentsLayer() {
       <Layer
         id="segments-line"
         type="line"
+        beforeId={STATIONS_BASE_LAYER_ID}
         paint={{
           'line-color': ['get', 'color'],
           'line-width': 3,

--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -5,10 +5,12 @@ import { Map as MapGL } from 'react-map-gl/maplibre';
 
 import { requireEnv } from '@/lib/utils';
 
+import { LineLayer } from './LineLayer';
 import { ReportsLayer } from './ReportsLayer';
-import { SegmentsLayer } from './SegmentsLayer';
+import { RiskLayer } from './RiskLayer';
 import { STATIONS_LAYER_ID, StationsLayer } from './StationsLayer';
 import { UserLocationControl } from './UserLocationControl';
+import { useRiskLayer } from '../../hooks/useRiskLayer';
 import { useStationSelection } from '../../hooks/useStationSelection';
 
 const MAP_STYLE_URL = requireEnv('VITE_MAP_STYLE_URL');
@@ -21,6 +23,7 @@ const INITIAL_VIEW = {
 
 export function MapView() {
   const { selectedStation, handleMapClick } = useStationSelection();
+  const { visible: riskVisible } = useRiskLayer();
 
   return (
     <div className="fixed inset-0">
@@ -31,8 +34,8 @@ export function MapView() {
         interactiveLayerIds={[STATIONS_LAYER_ID]}
         onClick={handleMapClick}
       >
-        <SegmentsLayer />
         <StationsLayer selectedStation={selectedStation} />
+        {riskVisible ? <RiskLayer /> : <LineLayer />}
         <ReportsLayer />
         <UserLocationControl />
       </MapGL>

--- a/packages/frontend-next/src/components/map/RiskLayer.tsx
+++ b/packages/frontend-next/src/components/map/RiskLayer.tsx
@@ -1,0 +1,47 @@
+import type { FeatureCollection, LineString } from 'geojson';
+import { Layer, Source } from 'react-map-gl/maplibre';
+
+import { useRisk } from '@/api/risk';
+import { type SegmentProperties, useSegments } from '@/api/transit';
+
+import { STATIONS_BASE_LAYER_ID } from './StationsLayer';
+
+// Neutral green for segments without elevated risk. The backend
+// only returns risky (non-green) segments, so everything else falls back to this.
+const NEUTRAL_GREEN = '#13C184';
+
+type RiskSegmentProperties = SegmentProperties & { line_color: string };
+
+export function RiskLayer() {
+  const { data: segments } = useSegments();
+  const { data: risk } = useRisk();
+
+  if (!segments) return null;
+
+  const segmentsRisk = risk?.segments_risk;
+  const colored: FeatureCollection<LineString, RiskSegmentProperties> = {
+    type: 'FeatureCollection',
+    features: segments.features.map((feature) => ({
+      ...feature,
+      properties: {
+        ...feature.properties,
+        line_color: segmentsRisk?.[String(feature.properties.id)]?.color ?? NEUTRAL_GREEN,
+      },
+    })),
+  };
+
+  return (
+    <Source id="risk-segments" type="geojson" data={colored}>
+      <Layer
+        id="risk-segments-line"
+        type="line"
+        beforeId={STATIONS_BASE_LAYER_ID}
+        layout={{ 'line-join': 'round', 'line-cap': 'round' }}
+        paint={{
+          'line-color': ['get', 'line_color'],
+          'line-width': 3,
+        }}
+      />
+    </Source>
+  );
+}

--- a/packages/frontend-next/src/components/map/StationSearch.tsx
+++ b/packages/frontend-next/src/components/map/StationSearch.tsx
@@ -58,7 +58,7 @@ export function StationSearch() {
       {isActive && (
         <Backdrop aria-label={t('clear')} onClose={dismiss} className="z-10 bg-transparent" />
       )}
-      <div className="pointer-events-none fixed inset-x-0 top-0 z-20 flex justify-center p-3">
+      <div className="pointer-events-none fixed inset-x-0 top-0 z-20 flex justify-center py-3 pr-16 pl-3">
         <div className="pointer-events-auto w-full max-w-md">
           <div className="bg-card text-card-foreground ring-foreground/10 flex h-9 items-center gap-1 rounded-lg pr-1 pl-3 ring-1">
             <Search className="text-muted-foreground size-3 shrink-0" />

--- a/packages/frontend-next/src/components/map/StationsLayer.tsx
+++ b/packages/frontend-next/src/components/map/StationsLayer.tsx
@@ -2,6 +2,9 @@ import { Layer, Source } from 'react-map-gl/maplibre';
 
 import { type Station, stationsToGeoJSON, useStations } from '@/api/transit';
 
+// Bottom-most (visible) station layer. Line layers insert `beforeId` this so they always render
+// beneath the station dots, regardless of mount order when toggling between line/risk layers.
+export const STATIONS_BASE_LAYER_ID = 'stations-circle';
 export const STATIONS_LAYER_ID = 'stations-hit';
 
 type StationsLayerProps = {
@@ -16,7 +19,7 @@ export function StationsLayer({ selectedStation }: StationsLayerProps) {
   return (
     <Source id="stations" type="geojson" data={stationsToGeoJSON(stations)}>
       <Layer
-        id="stations-circle"
+        id={STATIONS_BASE_LAYER_ID}
         type="circle"
         paint={{
           'circle-radius': ['case', ['==', ['get', 'id'], selectedStation?.id ?? ''], 5, 2],

--- a/packages/frontend-next/src/hooks/useRiskLayer.ts
+++ b/packages/frontend-next/src/hooks/useRiskLayer.ts
@@ -1,0 +1,46 @@
+import { useSyncExternalStore } from 'react';
+
+// Which transit layer the map shows: risk-colored segments ('RISK') or plain line colors
+// ('LINES'). Shared between the toggle button (mounted in the map route) and the layer (nested
+// inside the lazily-loaded map), so it lives in a tiny module store rather than React context —
+// no provider, no prop-drilling across the lazy boundary. Defaults to 'RISK' and persists the
+// user's choice under the `defaultLayer` key.
+type Layer = 'RISK' | 'LINES';
+
+const STORAGE_KEY = 'defaultLayer';
+const DEFAULT_LAYER: Layer = 'RISK';
+
+function readInitial(): Layer {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'LINES' ? 'LINES' : 'RISK';
+  } catch {
+    return DEFAULT_LAYER;
+  }
+}
+
+let layer = readInitial();
+const listeners = new Set<() => void>();
+
+function setLayer(next: Layer) {
+  if (next === layer) return;
+  layer = next;
+  try {
+    localStorage.setItem(STORAGE_KEY, next);
+  } catch {
+    // Ignore storage failures (e.g. private mode); state still works for the session.
+  }
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useRiskLayer(): { visible: boolean; toggle: () => void } {
+  const current = useSyncExternalStore(subscribe, () => layer);
+  return {
+    visible: current === 'RISK',
+    toggle: () => setLayer(layer === 'RISK' ? 'LINES' : 'RISK'),
+  };
+}

--- a/packages/frontend-next/src/routes/_map.tsx
+++ b/packages/frontend-next/src/routes/_map.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { lazy, Suspense } from 'react';
 
+import { LayerToggleButton } from '@/components/map/LayerToggleButton';
 import { ReportButton } from '@/components/map/ReportButton';
 import { ReportsOverviewButton } from '@/components/map/ReportsOverviewButton';
 import { StationSearch } from '@/components/map/StationSearch';
@@ -25,6 +26,7 @@ export const Route = createFileRoute('/_map')({
         <MapView />
       </Suspense>
       <StationSearch />
+      <LayerToggleButton />
       <ReportsOverviewButton />
       <ReportButton />
       <Outlet />


### PR DESCRIPTION
## Summary

Adds a **risk layer** to `frontend-next`, ported from the legacy frontend but rebuilt with the new app's patterns (TanStack Query hooks + `react-map-gl` layer components + shadcn UI). The risk layer colors transit segments by inspector-report risk (`GET /v0/risk`) and is the **default** map view. A quiet top-right button toggles between the risk view and the plain line-color view.

## What's included

- **`useRisk()` hook** (`api/risk.ts`) — fetches `/v0/risk`, polled every 30 s like the reports layer.
- **`RiskLayer`** (`components/map/RiskLayer.tsx`) — colors each segment by its risk color, falling back to neutral green for non-risky segments (the backend only returns risky ones).
- **`SegmentsLayer` → `LineLayer`** — renamed for clarity, since both layers render the same segments; `LineLayer` colors by official line color, `RiskLayer` by risk.
- **`LayerToggleButton`** — top-right toggle. Risk on/off, label always visible, deliberately low-key (full-strength when on, dimmed when off) since switching is the exception.
- **`useRiskLayer`** — tiny `useSyncExternalStore` store shared across the lazy map boundary; persists the choice under the `defaultLayer` key (`RISK` / `LINES`), defaulting to `RISK`.

## Layer ordering

Both line layers insert with `beforeId={STATIONS_BASE_LAYER_ID}` so the colored segments always render **beneath** the station dots — on initial load *and* on every toggle (not just by mount order). `StationsLayer` mounts first so the base layer exists when the line layer references it.

## UX notes

- The toggle reserves space so it never overlaps the centered station search.
- Active/off states are intentionally subtle to keep focus on the map.
- **Known follow-up:** the touch target is below the 44 px guideline — deferred to a separate sizing PR.

## Verification

- Risk layer is on by default; segments show green with yellow/red on risky ones.
- Toggling switches to official line colors and back; choice persists across reloads.
- Risk colors refresh (~30 s) without a manual reload.
- `tsc`, `eslint`, and `prettier` all pass on the changed files.
