### PR TITLE
fix: small frontend-next UI tweaks for mobile

### DIFF
--- a/packages/frontend-next/index.html
+++ b/packages/frontend-next/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <!-- Paints the iOS status-bar / dynamic-island area with the card color (matches the
+         report form and the map search bar). Keep in sync with --card in src/index.css. -->
+    <meta name="theme-color" content="#25272b" />
     <!-- Lock page scale: the map owns pinch-zoom, so the page itself must never zoom.
          This also stops iOS Safari auto-zooming when the (position:fixed) search input is focused. -->
     <meta

--- a/packages/frontend-next/index.html
+++ b/packages/frontend-next/index.html
@@ -3,7 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Lock page scale: the map owns pinch-zoom, so the page itself must never zoom.
+         This also stops iOS Safari auto-zooming when the (position:fixed) search input is focused. -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
     <title>FreiFahren</title>
   </head>
   <body>

--- a/packages/frontend-next/src/components/map/LayerToggleButton.tsx
+++ b/packages/frontend-next/src/components/map/LayerToggleButton.tsx
@@ -20,14 +20,14 @@ export function LayerToggleButton() {
         aria-pressed={visible}
         aria-label={visible ? t('hideRiskLayer') : t('showRiskLayer')}
         className={cn(
-          'bg-card ring-foreground/10 hover:bg-card/80 pointer-events-auto h-auto flex-col gap-0.5 rounded-lg p-2 shadow-[0_6px_16px_rgba(0,0,0,0.28)] ring-1',
+          'bg-card ring-foreground/10 hover:bg-card/80 pointer-events-auto h-auto flex-col gap-0.5 rounded-lg p-3 shadow-[0_6px_16px_rgba(0,0,0,0.28)] ring-1',
           // Risk is the default and switching is rare, so keep the states quiet: full-strength
           // when on, dimmed when off. The label stays put in both states, so it never reflows.
           visible ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
         )}
       >
-        <Layers className="size-4" />
-        <span className="text-[10px] leading-none font-medium">{t('risk')}</span>
+        <Layers className="size-5" />
+        <span className="text-[11px] leading-none font-medium">{t('risk')}</span>
       </Button>
     </div>
   );

--- a/packages/frontend-next/src/components/map/LayerToggleButton.tsx
+++ b/packages/frontend-next/src/components/map/LayerToggleButton.tsx
@@ -20,7 +20,7 @@ export function LayerToggleButton() {
         aria-pressed={visible}
         aria-label={visible ? t('hideRiskLayer') : t('showRiskLayer')}
         className={cn(
-          'bg-card ring-foreground/10 hover:bg-card/80 pointer-events-auto h-auto flex-col gap-0.5 rounded-lg p-3 shadow-[0_6px_16px_rgba(0,0,0,0.28)] ring-1',
+          'bg-card ring-foreground/10 hover:bg-card/80 pointer-events-auto h-11 flex-col gap-0.5 rounded-lg px-3 shadow-[0_6px_16px_rgba(0,0,0,0.28)] ring-1',
           // Risk is the default and switching is rare, so keep the states quiet: full-strength
           // when on, dimmed when off. The label stays put in both states, so it never reflows.
           visible ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',

--- a/packages/frontend-next/src/components/map/ReportButton.tsx
+++ b/packages/frontend-next/src/components/map/ReportButton.tsx
@@ -15,7 +15,7 @@ export function ReportButton() {
       <Button
         asChild
         size="lg"
-        className="bg-accent-bright text-primary-foreground hover:bg-accent-press pointer-events-auto h-12 gap-2 rounded-lg px-5 text-sm shadow-[0_6px_16px_rgba(214,59,59,0.28)] [&_svg:not([class*='size-'])]:size-5"
+        className="bg-accent-bright text-primary-foreground hover:bg-accent-press pointer-events-auto h-14 gap-2.5 rounded-lg px-6 text-base shadow-[0_6px_16px_rgba(214,59,59,0.28)] [&_svg:not([class*='size-'])]:size-6"
       >
         <Link to={ReportRoute.to}>
           {t('report')}

--- a/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
+++ b/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
@@ -33,7 +33,7 @@ export function ReportsOverviewButton() {
       <Button
         asChild
         variant="secondary"
-        className="bg-card text-card-foreground ring-foreground/10 hover:bg-card/80 pointer-events-auto h-auto w-full max-w-xs flex-col items-stretch gap-1 rounded-lg px-3 py-2 shadow-[0_6px_16px_rgba(0,0,0,0.28)] ring-1"
+        className="bg-card text-card-foreground ring-foreground/10 hover:bg-card/80 pointer-events-auto h-auto w-full max-w-xs flex-col items-stretch gap-1.5 rounded-lg px-3.5 py-3 shadow-[0_6px_16px_rgba(0,0,0,0.28)] ring-1"
       >
         <Link to={ReportsStationsRoute.to}>
           <div className="flex items-center justify-between gap-3">

--- a/packages/frontend-next/src/components/map/StationDetail.tsx
+++ b/packages/frontend-next/src/components/map/StationDetail.tsx
@@ -31,7 +31,7 @@ export function StationDetail({ station, onClose }: StationDetailProps) {
         <Button
           asChild
           variant="default"
-          className="bg-destructive hover:bg-destructive/90 h-9 w-full text-sm font-medium text-white"
+          className="bg-destructive hover:bg-destructive/90 h-11 w-full text-sm font-medium text-white"
         >
           <Link to={ReportRoute.to}>{t('reportSighting')}</Link>
         </Button>

--- a/packages/frontend-next/src/components/map/StationSearch.tsx
+++ b/packages/frontend-next/src/components/map/StationSearch.tsx
@@ -71,7 +71,9 @@ export function StationSearch() {
               onBlur={() => setIsFocused(false)}
               placeholder={t('placeholder')}
               aria-label={t('placeholder')}
-              className="h-full flex-1 border-0 bg-transparent px-0 text-sm shadow-none focus-visible:ring-0 dark:bg-transparent"
+              // Stay at 16px so iOS Safari never auto-zooms the page on focus (a sm:text-sm
+              // revert would re-trigger the zoom on iPads, which are >=sm but still iOS).
+              className="h-full flex-1 border-0 bg-transparent px-0 text-base shadow-none focus-visible:ring-0 dark:bg-transparent"
             />
             {hasQuery && (
               <Button

--- a/packages/frontend-next/src/components/map/StationSearch.tsx
+++ b/packages/frontend-next/src/components/map/StationSearch.tsx
@@ -60,8 +60,8 @@ export function StationSearch() {
       )}
       <div className="pointer-events-none fixed inset-x-0 top-0 z-20 flex justify-center py-3 pr-16 pl-3">
         <div className="pointer-events-auto w-full max-w-md">
-          <div className="bg-card text-card-foreground ring-foreground/10 flex h-9 items-center gap-1 rounded-lg pr-1 pl-3 ring-1">
-            <Search className="text-muted-foreground size-3 shrink-0" />
+          <div className="bg-card text-card-foreground ring-foreground/10 flex h-11 items-center gap-1.5 rounded-lg pr-1 pl-3 ring-1">
+            <Search className="text-muted-foreground size-4 shrink-0" />
             <Input
               ref={inputRef}
               type="text"
@@ -71,7 +71,7 @@ export function StationSearch() {
               onBlur={() => setIsFocused(false)}
               placeholder={t('placeholder')}
               aria-label={t('placeholder')}
-              className="h-full flex-1 border-0 bg-transparent px-0 text-xs shadow-none focus-visible:ring-0 md:text-xs dark:bg-transparent"
+              className="h-full flex-1 border-0 bg-transparent px-0 text-sm shadow-none focus-visible:ring-0 dark:bg-transparent"
             />
             {hasQuery && (
               <Button
@@ -88,7 +88,7 @@ export function StationSearch() {
           {showResults && (
             <Card className="animate-in fade-in slide-in-from-top-2 mt-2 max-h-[60vh] gap-0 overflow-auto p-1 duration-150">
               {results.length === 0 ? (
-                <div className="text-muted-foreground px-3 py-4 text-xs">{t('noResults')}</div>
+                <div className="text-muted-foreground px-3 py-4 text-sm">{t('noResults')}</div>
               ) : (
                 results.map((station) => (
                   <StationListItem

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -21,7 +21,7 @@ function ClearSelectionButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="text-muted-foreground hover:text-foreground text-xs outline-none focus-visible:underline"
+      className="text-muted-foreground hover:text-foreground py-1 text-sm outline-none focus-visible:underline"
     >
       {t('clearSelection')}
     </button>
@@ -117,7 +117,7 @@ function StationPicker() {
                 aria-pressed={isSelected}
                 onClick={() => selectStation(isSelected ? null : station.id)}
                 className={cn(
-                  'hover:bg-muted focus-visible:bg-muted flex w-full items-center rounded-md px-2 py-2 text-left text-xs outline-none',
+                  'hover:bg-muted focus-visible:bg-muted flex w-full items-center rounded-md px-3 py-2.5 text-left text-sm outline-none',
                   isSelected && 'ring-2 ring-white ring-inset',
                 )}
               >
@@ -153,11 +153,11 @@ function DirectionPicker() {
               aria-pressed={isSelected}
               onClick={() => selectDirection(isSelected ? null : station.id)}
               className={cn(
-                'border-border bg-surface-solid hover:bg-muted flex items-center gap-2 rounded-md border px-2 py-1.5 text-left text-sm outline-none',
+                'border-border bg-surface-solid hover:bg-muted flex items-center gap-2 rounded-md border px-3 py-2.5 text-left text-sm outline-none',
                 isSelected && 'ring-2 ring-white ring-inset',
               )}
             >
-              <ChevronRight className="text-muted-foreground size-4 shrink-0" />
+              <ChevronRight className="text-muted-foreground size-5 shrink-0" />
               <span className="truncate">{station.name}</span>
             </button>
           );
@@ -188,7 +188,7 @@ function SubmitFooter() {
         disabled={disabled}
         onClick={handleSubmit}
         className={cn(
-          'h-12 w-full rounded-lg text-sm font-medium',
+          'h-12 w-full rounded-lg text-base font-medium',
           canSubmit
             ? 'bg-accent-bright text-primary-foreground hover:bg-accent-press shadow-[0_6px_16px_rgba(214,59,59,0.28)]'
             : 'bg-surface-solid text-muted-foreground border-border border',

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -15,13 +15,7 @@ import { ReportSelectionProvider } from './ReportSelectionProvider';
 
 const FILTERS: LineFilter[] = ['all', 'subway', 'light_rail', 'tram'];
 
-function ClearSelectionButton({
-  onClick,
-  className,
-}: {
-  onClick: () => void;
-  className?: string;
-}) {
+function ClearSelectionButton({ onClick, className }: { onClick: () => void; className?: string }) {
   const { t } = useTranslation(NAMESPACE);
   return (
     <button

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -15,13 +15,22 @@ import { ReportSelectionProvider } from './ReportSelectionProvider';
 
 const FILTERS: LineFilter[] = ['all', 'subway', 'light_rail', 'tram'];
 
-function ClearSelectionButton({ onClick }: { onClick: () => void }) {
+function ClearSelectionButton({
+  onClick,
+  className,
+}: {
+  onClick: () => void;
+  className?: string;
+}) {
   const { t } = useTranslation(NAMESPACE);
   return (
     <button
       type="button"
       onClick={onClick}
-      className="text-muted-foreground hover:text-foreground py-1 text-sm outline-none focus-visible:underline"
+      className={cn(
+        'text-muted-foreground hover:text-foreground py-1 text-sm outline-none focus-visible:underline',
+        className,
+      )}
     >
       {t('clearSelection')}
     </button>
@@ -60,11 +69,13 @@ function LinePicker() {
         </ToggleGroup>
       </div>
 
-      {lineName && (
-        <div className="mb-1 flex justify-end">
-          <ClearSelectionButton onClick={() => selectLine(null)} />
-        </div>
-      )}
+      {/* Always render the row so reserving the clear button's height avoids layout shift. */}
+      <div className="mb-1 flex justify-end">
+        <ClearSelectionButton
+          onClick={() => selectLine(null)}
+          className={cn(!lineName && 'invisible')}
+        />
+      </div>
 
       <div className="flex flex-wrap gap-2">
         {visibleLines.map((line) => {
@@ -139,30 +150,38 @@ function DirectionPicker() {
 
   return (
     <section className="mt-6 px-4">
-      <div className="mb-3 flex items-center gap-1 tracking-wide uppercase">
-        <h2 className="text-sm font-semibold">{t('direction')}</h2>
-        <p className="text-muted-foreground text-[0.625rem] tracking-wide">{t('optional')}</p>
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-1 tracking-wide uppercase">
+          <h2 className="text-sm font-semibold">{t('direction')}</h2>
+          <p className="text-muted-foreground text-[0.625rem] tracking-wide">{t('optional')}</p>
+        </div>
+        {/* Rendered unconditionally and hidden when nothing is selected to reserve its height. */}
+        <ClearSelectionButton
+          onClick={() => selectDirection(null)}
+          className={cn(!directionStationId && 'invisible')}
+        />
       </div>
-      <div className="grid grid-cols-2 gap-2">
+      <ul>
         {directionOptions.map((station) => {
           const isSelected = directionStationId === station.id;
           return (
-            <button
-              key={station.id}
-              type="button"
-              aria-pressed={isSelected}
-              onClick={() => selectDirection(isSelected ? null : station.id)}
-              className={cn(
-                'border-border bg-surface-solid hover:bg-muted flex items-center gap-2 rounded-md border px-3 py-2.5 text-left text-sm outline-none',
-                isSelected && 'ring-2 ring-white ring-inset',
-              )}
-            >
-              <ChevronRight className="text-muted-foreground size-5 shrink-0" />
-              <span className="truncate">{station.name}</span>
-            </button>
+            <li key={station.id} className="border-border/60 border-b last:border-b-0">
+              <button
+                type="button"
+                aria-pressed={isSelected}
+                onClick={() => selectDirection(isSelected ? null : station.id)}
+                className={cn(
+                  'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm outline-none',
+                  isSelected && 'ring-2 ring-white ring-inset',
+                )}
+              >
+                <ChevronRight className="text-muted-foreground size-5 shrink-0" />
+                <span className="truncate">{station.name}</span>
+              </button>
+            </li>
           );
         })}
-      </div>
+      </ul>
     </section>
   );
 }

--- a/packages/frontend-next/src/components/reports/ReportsTabBar.tsx
+++ b/packages/frontend-next/src/components/reports/ReportsTabBar.tsx
@@ -30,7 +30,7 @@ export function ReportsTabBar() {
             key={tab.route.id}
             value={tab.route.id}
             asChild
-            className="text-muted-foreground data-[state=active]:text-foreground data-[state=active]:border-foreground -mb-px rounded-none border-b-2 border-transparent py-2 text-xs font-semibold tracking-wide uppercase"
+            className="text-muted-foreground data-[state=active]:text-foreground data-[state=active]:border-foreground -mb-px rounded-none border-b-2 border-transparent py-3 text-xs font-semibold tracking-wide uppercase"
           >
             <Link to={tab.route.to}>{t(tab.labelKey)}</Link>
           </TabsTrigger>

--- a/packages/frontend-next/src/components/transit/LineBadge.tsx
+++ b/packages/frontend-next/src/components/transit/LineBadge.tsx
@@ -20,7 +20,7 @@ export function LineBadge({ name, className }: LineBadgeProps) {
 
   return (
     <Badge
-      className={cn('h-6 w-[42px] rounded-sm px-2 text-xs font-semibold text-white', className)}
+      className={cn('h-7 w-12 rounded-sm px-2 text-xs font-semibold text-white', className)}
       style={color ? { backgroundColor: color } : undefined}
     >
       {name}

--- a/packages/frontend-next/src/components/transit/StationListItem.tsx
+++ b/packages/frontend-next/src/components/transit/StationListItem.tsx
@@ -30,11 +30,11 @@ export function StationListItem({ station, onClick, selected }: StationListItemP
       aria-pressed={selected}
       onClick={onClick}
       className={cn(
-        'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-3 rounded-md px-2 py-2 text-left outline-none',
+        'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left outline-none',
         selected && 'ring-2 ring-white ring-inset',
       )}
     >
-      <span className="shrink-0 text-xs">{station.name}</span>
+      <span className="shrink-0 text-sm">{station.name}</span>
       <div className="ml-auto flex min-w-0 gap-1 overflow-hidden">
         {sortedNames.map((name) => (
           <LineBadge key={name} name={name} className="shrink-0" />

--- a/packages/frontend-next/src/components/ui/button.tsx
+++ b/packages/frontend-next/src/components/ui/button.tsx
@@ -22,14 +22,14 @@ const buttonVariants = cva(
       },
       size: {
         default:
-          "h-7 gap-1 px-2 text-xs/relaxed has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        xs: "h-5 gap-1 rounded-sm px-2 text-[0.625rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-2.5",
-        sm: "h-6 gap-1 px-2 text-xs/relaxed has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        lg: "h-8 gap-1 px-2.5 text-xs/relaxed has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-4",
-        icon: "size-7 [&_svg:not([class*='size-'])]:size-3.5",
-        'icon-xs': "size-5 rounded-sm [&_svg:not([class*='size-'])]:size-2.5",
-        'icon-sm': "size-6 [&_svg:not([class*='size-'])]:size-3",
-        'icon-lg': "size-8 [&_svg:not([class*='size-'])]:size-4",
+          "h-9 gap-1.5 px-3 text-sm has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-4",
+        xs: "h-7 gap-1 rounded-sm px-2.5 text-xs has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 gap-1 px-2.5 text-sm has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-10 gap-1.5 px-4 text-sm has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3 [&_svg:not([class*='size-'])]:size-5",
+        icon: "size-9 [&_svg:not([class*='size-'])]:size-4",
+        'icon-xs': "size-7 rounded-sm [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm': "size-8 [&_svg:not([class*='size-'])]:size-3.5",
+        'icon-lg': "size-10 [&_svg:not([class*='size-'])]:size-5",
       },
     },
     defaultVariants: {

--- a/packages/frontend-next/src/components/ui/input.tsx
+++ b/packages/frontend-next/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'border-input bg-input/20 file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-7 w-full min-w-0 rounded-md border px-2 py-0.5 text-sm transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-xs/relaxed file:font-medium focus-visible:ring-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-2 md:text-xs/relaxed',
+        'border-input bg-input/20 file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-9 w-full min-w-0 rounded-md border px-3 py-1 text-sm transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-2',
         className,
       )}
       {...props}

--- a/packages/frontend-next/src/components/ui/toggle.tsx
+++ b/packages/frontend-next/src/components/ui/toggle.tsx
@@ -5,7 +5,7 @@ import { Toggle as TogglePrimitive } from 'radix-ui';
 import { cn } from '@/lib/utils';
 
 const toggleVariants = cva(
-  "group/toggle inline-flex items-center justify-center gap-1 rounded-md text-xs font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -14,9 +14,9 @@ const toggleVariants = cva(
       },
       size: {
         default:
-          'h-7 min-w-7 px-2 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5',
-        sm: "h-6 min-w-6 rounded-[min(var(--radius-md),8px)] px-2 text-[0.625rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        lg: 'h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+          'h-9 min-w-9 px-3 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        sm: "h-8 min-w-8 rounded-[min(var(--radius-md),8px)] px-2.5 text-xs has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: 'h-10 min-w-10 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
A handful of small, mobile-focused UI tweaks in `frontend-next`.

## Changes

**Risk toggle button height** (`LayerToggleButton.tsx`)
- Changed from `h-auto p-3` to `h-11 px-3` so it matches the search bar's fixed `h-11` (44px) height — the two now line up as a pair at the top of the map.

**iOS auto-zoom on search focus** (`StationSearch.tsx`, `index.html`)
- The search input now stays at 16px (`text-base`) instead of 14px. iOS Safari auto-zooms the page whenever a focused input is below 16px.
- The viewport meta now sets `maximum-scale=1.0, user-scalable=no`. On a `position: fixed` search bar iOS would zoom on focus even at 16px and never reset, leaving the page stuck zoomed in after selecting a result. Locking page scale is safe here because MapLibre owns pinch-zoom on its own canvas — only the page is locked, not the map.

**Direction picker styling + clear button** (`ReportForm.tsx`)
- The direction picker now uses the same flat list-row style as the station picker (bottom-bordered `<li>` rows, `hover:bg-muted`, inset ring on select) instead of bordered cards in a grid.
- Added a clear-selection button to the direction picker header, mirroring the station picker.

**Reserve clear-button space** (`ReportForm.tsx`)
- The clear-selection button in the line and direction pickers is now always rendered and toggled with `invisible`, so its height is reserved. Previously it mounted/unmounted on selection, causing a small layout shift.