### PR TITLE
feat: pre-submission verification for reports

### DIFF
--- a/packages/frontend-next/src/components/report/ReportForm.i18n.ts
+++ b/packages/frontend-next/src/components/report/ReportForm.i18n.ts
@@ -20,6 +20,8 @@ i18n.addResourceBundle('en', NAMESPACE, {
   direction: 'Direction',
   submit: 'Submit report',
   disclaimer: 'Shared anonymously with all Freifahren users.',
+  errorTooSoon: 'You reported very recently. Please wait a moment.',
+  errorTooFar: "You're not close enough to the station.",
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
@@ -40,4 +42,6 @@ i18n.addResourceBundle('de', NAMESPACE, {
   direction: 'Richtung',
   submit: 'Melden',
   disclaimer: 'Anonym an alle Freifahren-Nutzer geteilt.',
+  errorTooSoon: 'Du hast gerade erst gemeldet. Bitte warte einen Moment.',
+  errorTooFar: 'Du bist nicht nah genug an der Station.',
 });

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from '@tanstack/react-router';
-import { ChevronRight, MapPin, Search } from 'lucide-react';
+import { ChevronRight, MapPin, Search, TriangleAlert } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 
 import { useSubmitReport } from '@/api/reports';
 import { type Station } from '@/api/transit';
@@ -11,13 +12,17 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { SectionHeading } from '@/components/ui/section-heading';
 import { Separator } from '@/components/ui/separator';
+import { Toaster } from '@/components/ui/sonner';
+import { ToastPill } from '@/components/ui/toast-pill';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useGeolocation } from '@/contexts/Geolocation.context';
+import { distanceMeters } from '@/lib/geo';
 import { cn } from '@/lib/utils';
 
 import { NAMESPACE } from './ReportForm.i18n';
 import { type LineFilter, useReportSelection } from './ReportSelection.context';
 import { ReportSelectionProvider } from './ReportSelectionProvider';
+import { type ReportRejection, useReportVerification } from './useReportVerification';
 
 const FILTERS: LineFilter[] = ['all', 'subway', 'light_rail', 'tram'];
 
@@ -32,17 +37,10 @@ function normalize(value: string): string {
 
 const NEARBY_COUNT = 3;
 
-/** Haversine great-circle distance in metres. */
-function distanceMeters(lat1: number, lng1: number, lat2: number, lng2: number): number {
-  const R = 6371000;
-  const toRad = (d: number) => (d * Math.PI) / 180;
-  const dLat = toRad(lat2 - lat1);
-  const dLng = toRad(lng2 - lng1);
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
-  return 2 * R * Math.asin(Math.sqrt(a));
-}
+const REJECTION_MESSAGE: Record<ReportRejection, string> = {
+  too_soon: 'errorTooSoon',
+  too_far: 'errorTooFar',
+};
 
 function ClearSelectionButton({ onClick, className }: { onClick: () => void; className?: string }) {
   const { t } = useTranslation(NAMESPACE);
@@ -271,13 +269,30 @@ function SubmitFooter() {
   const { t } = useTranslation(NAMESPACE);
   const { stationId, lineName, directionStationId } = useReportSelection();
   const submitReport = useSubmitReport();
+  const { verify, recordSubmission } = useReportVerification();
 
   const canSubmit = stationId !== null;
   const disabled = !canSubmit || submitReport.isPending;
 
   const handleSubmit = () => {
     if (!stationId) return;
-    submitReport.mutate({ stationId, lineName, directionStationId });
+    const rejection = verify(stationId);
+    if (rejection) {
+      toast.custom(
+        () => (
+          <ToastPill className="text-destructive flex w-fit items-center gap-2 text-sm font-medium">
+            <TriangleAlert className="size-4" />
+            {t(REJECTION_MESSAGE[rejection])}
+          </ToastPill>
+        ),
+        { id: 'report-verification', unstyled: true, icon: null },
+      );
+      return;
+    }
+    submitReport.mutate(
+      { stationId, lineName, directionStationId },
+      { onSuccess: recordSubmission },
+    );
   };
 
   return (
@@ -315,6 +330,8 @@ export function ReportForm() {
           <DirectionPicker />
           <SubmitFooter />
         </div>
+        {/* /report is outside the _map layout that hosts the app's Toaster, so mount one here. */}
+        <Toaster />
       </div>
     </ReportSelectionProvider>
   );

--- a/packages/frontend-next/src/components/report/useReportVerification.ts
+++ b/packages/frontend-next/src/components/report/useReportVerification.ts
@@ -1,0 +1,65 @@
+import { useStations } from '@/api/transit';
+import { useGeolocation } from '@/contexts/Geolocation.context';
+import { distanceMeters } from '@/lib/geo';
+
+export type ReportRejection = 'too_soon' | 'too_far';
+
+const MAX_REPORT_DISTANCE_M = 1500;
+const MIN_REPORT_INTERVAL_MS = 15 * 60 * 1000;
+const STORAGE_KEY = 'lastReportAt';
+
+function readLastReportAt(): number | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const value = raw ? Number(raw) : NaN;
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeLastReportAt(timestamp: number): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(timestamp));
+  } catch {
+    // Private mode / storage unavailable: skip.
+  }
+}
+
+/**
+ * Pre-submission guardrails for the report form, kept out of the form itself.
+ * `verify` returns the first failing rule, or null when the report may be sent.
+ * Disabled entirely in dev so local testing is never blocked.
+ */
+export function useReportVerification() {
+  const { position } = useGeolocation();
+  const { data: stations } = useStations();
+
+  const verify = (stationId: string): ReportRejection | null => {
+    if (import.meta.env.DEV) return null;
+
+    if (position) {
+      const station = stations?.[stationId];
+      if (station) {
+        const distance = distanceMeters(
+          position.lat,
+          position.lng,
+          station.coordinates.latitude,
+          station.coordinates.longitude,
+        );
+        if (distance > MAX_REPORT_DISTANCE_M) return 'too_far';
+      }
+    }
+
+    const lastReportAt = readLastReportAt();
+    if (lastReportAt !== null && Date.now() - lastReportAt < MIN_REPORT_INTERVAL_MS) {
+      return 'too_soon';
+    }
+
+    return null;
+  };
+
+  const recordSubmission = () => writeLastReportAt(Date.now());
+
+  return { verify, recordSubmission };
+}

--- a/packages/frontend-next/src/lib/geo.ts
+++ b/packages/frontend-next/src/lib/geo.ts
@@ -1,0 +1,11 @@
+/** Haversine great-circle distance in metres. */
+export function distanceMeters(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(a));
+}


### PR DESCRIPTION
## What

Adds two client-side guardrails that run **before** a report is submitted, surfaced as a small toast without leaking the underlying rules:

- **Too far** — the user is more than 1.5 km from the station being reported (uses shared geolocation + station coordinates). Skipped when location isn't available.
- **Too soon** — the user already submitted a report in the last 15 minutes, tracked client-side in `localStorage` (`lastReportAt`), since no per-user reports API exists.

## How

- `useReportVerification` hook encapsulates the checks and returns a vague `ReportRejection` code (`'too_soon' | 'too_far'`) or `null`. The form stays simple.
- Verification is **bypassed entirely in dev** (`import.meta.env.DEV`) so local testing isn't blocked.
- On rejection, `SubmitFooter` shows a destructive sonner toast (mapped, vague message) and aborts; on success it records the submission time. A `<Toaster />` is mounted in the report form because `/report` lives outside the `_map` layout that hosts the app's Toaster.
- Extracted the haversine helper into `src/lib/geo.ts`, shared with the existing "nearby stations" feature.

The `ReportRejection` union + the rejection→message map are the seam where backend-returned error codes will plug in later.

## Testing

Dev bypasses verification by design, so exercise the checks against a production build (`npm run build && npm run preview`): submit-twice for "too soon", far-from-station with location shared for "too far", and no-location to confirm the distance check is skipped. tsc, eslint, prettier, and the prod build all pass.