### PR TITLE
feat: report submission success screen

### DIFF
--- a/packages/frontend-next/src/components/map/StatsPopUp.tsx
+++ b/packages/frontend-next/src/components/map/StatsPopUp.tsx
@@ -5,18 +5,13 @@ import { toast } from 'sonner';
 
 import { DAY_MS, useReports } from '@/api/reports';
 import { ToastPill } from '@/components/ui/toast-pill';
+import { pickReporterCount } from '@/lib/reporters';
 import { Route as ReportsSummaryRoute } from '@/routes/reports/index';
 
 import { NAMESPACE } from './StatsPopUp.i18n';
 
 const DURATION_MS = 7_000;
 const REPORTERS_AT = 3_500;
-
-// Fabricated social-proof count — the app has no real user metric.
-const MIN_REPORTERS = 50_000;
-const MAX_REPORTERS = 60_000;
-const pickReporterCount = () =>
-  Math.floor(Math.random() * (MAX_REPORTERS - MIN_REPORTERS + 1)) + MIN_REPORTERS;
 
 export function StatsPopUp() {
   const { data: reports, isLoading } = useReports(DAY_MS);

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
-import { useSubmitReport } from '@/api/reports';
+import { type SubmitReportResponse, useSubmitReport } from '@/api/reports';
 import { type Station } from '@/api/transit';
 import { PageHeader } from '@/components/templates/PageHeader';
 import { LineBadge } from '@/components/transit/LineBadge';
@@ -22,6 +22,7 @@ import { cn } from '@/lib/utils';
 import { NAMESPACE } from './ReportForm.i18n';
 import { type LineFilter, useReportSelection } from './ReportSelection.context';
 import { ReportSelectionProvider } from './ReportSelectionProvider';
+import { ReportSuccess } from './ReportSuccess';
 import { type ReportRejection, useReportVerification } from './useReportVerification';
 
 const FILTERS: LineFilter[] = ['all', 'subway', 'light_rail', 'tram'];
@@ -265,7 +266,7 @@ function DirectionPicker() {
   );
 }
 
-function SubmitFooter() {
+function SubmitFooter({ onSubmitted }: { onSubmitted: (result: SubmitReportResponse) => void }) {
   const { t } = useTranslation(NAMESPACE);
   const { stationId, lineName, directionStationId } = useReportSelection();
   const submitReport = useSubmitReport();
@@ -291,7 +292,12 @@ function SubmitFooter() {
     }
     submitReport.mutate(
       { stationId, lineName, directionStationId },
-      { onSuccess: recordSubmission },
+      {
+        onSuccess: (result) => {
+          recordSubmission();
+          onSubmitted(result);
+        },
+      },
     );
   };
 
@@ -319,16 +325,23 @@ function SubmitFooter() {
 export function ReportForm() {
   const { t } = useTranslation(NAMESPACE);
   const navigate = useNavigate();
+  const [result, setResult] = useState<SubmitReportResponse | null>(null);
 
   return (
     <ReportSelectionProvider>
       <div className="bg-card animate-in fade-in fixed inset-0 z-30 duration-150">
         <div className="mx-auto flex h-full w-full max-w-md flex-col">
-          <PageHeader title={t('title')} onBack={() => navigate({ to: '/' })} />
-          <LinePicker />
-          <StationPicker />
-          <DirectionPicker />
-          <SubmitFooter />
+          {result ? (
+            <ReportSuccess result={result} onClose={() => navigate({ to: '/' })} />
+          ) : (
+            <>
+              <PageHeader title={t('title')} onBack={() => navigate({ to: '/' })} />
+              <LinePicker />
+              <StationPicker />
+              <DirectionPicker />
+              <SubmitFooter onSubmitted={setResult} />
+            </>
+          )}
         </div>
         {/* /report is outside the _map layout that hosts the app's Toaster, so mount one here. */}
         <Toaster />

--- a/packages/frontend-next/src/components/report/ReportSuccess.i18n.ts
+++ b/packages/frontend-next/src/components/report/ReportSuccess.i18n.ts
@@ -1,0 +1,17 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'reportSuccess';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  title: 'Thank you for your report!',
+  description: 'people appreciate your help',
+  syncText: 'Your report was synced with @FreiFahren_BE',
+  continue: 'Continue',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  title: 'Danke für deine Meldung!',
+  description: 'Menschen schätzen deine Hilfe',
+  syncText: 'Deine Meldung wurde mit @FreiFahren_BE synchronisiert.',
+  continue: 'Weiter',
+});

--- a/packages/frontend-next/src/components/report/ReportSuccess.tsx
+++ b/packages/frontend-next/src/components/report/ReportSuccess.tsx
@@ -1,0 +1,65 @@
+import { Check, Users } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { SubmitReportResponse } from '@/api/reports';
+import { useLines, useStations } from '@/api/transit';
+import { LineBadge } from '@/components/transit/LineBadge';
+import { Button } from '@/components/ui/button';
+import { useCountAnimation } from '@/hooks/useCountAnimation';
+import { pickReporterCount } from '@/lib/reporters';
+
+import { NAMESPACE } from './ReportSuccess.i18n';
+
+export function ReportSuccess({
+  result,
+  onClose,
+}: {
+  result: SubmitReportResponse;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation(NAMESPACE);
+  const { data: stations } = useStations();
+  const { data: lines } = useLines();
+  const [reporters] = useState(pickReporterCount);
+  const count = useCountAnimation(reporters, 1500);
+
+  const stationName = stations?.[result.stationId]?.name;
+  const lineName = result.lineId ? lines?.find((l) => l.id === result.lineId)?.name : null;
+
+  return (
+    <div className="flex h-full flex-col items-center px-6 pt-16 pb-6 text-center">
+      <div className="bg-accent-bright text-primary-foreground animate-in zoom-in-50 fade-in flex size-16 items-center justify-center rounded-full shadow-[0_6px_16px_rgba(214,59,59,0.28)] duration-300">
+        <Check className="size-8" />
+      </div>
+      <h1 className="font-heading mt-5 text-2xl font-semibold">{t('title')}</h1>
+
+      {stationName && (
+        <div className="mt-4 flex items-center gap-2">
+          {lineName && <LineBadge name={lineName} />}
+          <span className="text-sm font-medium">{stationName}</span>
+        </div>
+      )}
+
+      <div className="flex flex-1 flex-col items-center justify-center gap-1">
+        <div className="text-foreground flex items-center gap-2">
+          <Users className="text-muted-foreground size-6" />
+          <span className="font-heading text-4xl font-bold tabular-nums">
+            {count.toLocaleString()}
+          </span>
+        </div>
+        <p className="text-muted-foreground text-sm">{t('description')}</p>
+      </div>
+
+      <p className="text-muted-foreground text-[0.6875rem]">{t('syncText')}</p>
+      <Button
+        type="button"
+        size="lg"
+        onClick={onClose}
+        className="bg-accent-bright text-primary-foreground hover:bg-accent-press mt-4 h-12 w-full rounded-lg text-base font-medium shadow-[0_6px_16px_rgba(214,59,59,0.28)]"
+      >
+        {t('continue')}
+      </Button>
+    </div>
+  );
+}

--- a/packages/frontend-next/src/hooks/useCountAnimation.ts
+++ b/packages/frontend-next/src/hooks/useCountAnimation.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+/** Animates a number from 0 to `end` over `duration` ms via requestAnimationFrame. */
+export function useCountAnimation(end: number, duration = 1000): number {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let startTimestamp: number | null = null;
+    let frame = 0;
+
+    const step = (timestamp: number) => {
+      if (startTimestamp === null) startTimestamp = timestamp;
+      const progress = Math.min((timestamp - startTimestamp) / duration, 1);
+      setCount(Math.floor(progress * end));
+      if (progress < 1) {
+        frame = window.requestAnimationFrame(step);
+      } else {
+        setCount(end);
+      }
+    };
+
+    frame = window.requestAnimationFrame(step);
+    return () => window.cancelAnimationFrame(frame);
+  }, [end, duration]);
+
+  return count;
+}

--- a/packages/frontend-next/src/lib/reporters.ts
+++ b/packages/frontend-next/src/lib/reporters.ts
@@ -1,0 +1,6 @@
+// Fabricated social-proof count — the app has no real user metric.
+export const MIN_REPORTERS = 50_000;
+export const MAX_REPORTERS = 60_000;
+
+export const pickReporterCount = () =>
+  Math.floor(Math.random() * (MAX_REPORTERS - MIN_REPORTERS + 1)) + MIN_REPORTERS;


### PR DESCRIPTION
## What

Ports the post-submission success flow from the old frontend and adapts it to the new design. After a report is submitted successfully, the form swaps in-place for a confirmation screen.

- **Success screen** (`ReportSuccess`): on-brand check, "Thank you for your report!", a compact confirmation of what was reported (line badge + station), the synced-with-@FreiFahren_BE note, and a Continue button that returns to the map.
- **Count-up animation** kept — ported the old `useCountAnimation` (requestAnimationFrame) into `src/hooks/useCountAnimation.ts`, counting up over 1.5s.
- **Reuses the StatsPopUp user count** — extracted `pickReporterCount` into `src/lib/reporters.ts`; `StatsPopUp` now imports it and the success screen uses the same source (no duplication).
- **Share button removed** for now.

## How

`SubmitFooter` gains an `onSubmitted` callback fired in the mutation's `onSuccess` (alongside the existing `recordSubmission`); `ReportForm` holds the `SubmitReportResponse` and renders `ReportSuccess` instead of the form when set. Continue navigates to `/`.

New `reportSuccess` i18n namespace (EN + DE).

## Testing

tsc, eslint, prettier, and the production build all pass. Manual: submit a report (note verification is bypassed in dev) and confirm the success screen appears with the count-up and Continue returning to the map.