### PR TITLE
fix: use singular /station/$stationId route to match telegram bot links

### DIFF
--- a/packages/frontend-next/src/components/map/StationSearch.tsx
+++ b/packages/frontend-next/src/components/map/StationSearch.tsx
@@ -9,7 +9,7 @@ import { Backdrop } from '@/components/ui/backdrop';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { Route as StationDetailRoute } from '@/routes/_map/stations/$stationId';
+import { Route as StationDetailRoute } from '@/routes/_map/station/$stationId';
 
 import { NAMESPACE } from './StationSearch.i18n';
 

--- a/packages/frontend-next/src/components/reports/ReportRow.tsx
+++ b/packages/frontend-next/src/components/reports/ReportRow.tsx
@@ -6,7 +6,7 @@ import { formatElapsed, type Report } from '@/api/reports';
 import { useLines, useStations } from '@/api/transit';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Route as ReportDetailRoute } from '@/routes/_map/reports/$stationId';
-import { Route as StationRoute } from '@/routes/_map/stations/$stationId';
+import { Route as StationRoute } from '@/routes/_map/station/$stationId';
 
 import { NAMESPACE } from './Reports.i18n';
 

--- a/packages/frontend-next/src/hooks/useStationSelection.ts
+++ b/packages/frontend-next/src/hooks/useStationSelection.ts
@@ -3,7 +3,7 @@ import type { MapLayerMouseEvent } from 'react-map-gl/maplibre';
 
 import { HOUR_MS, useReports } from '@/api/reports';
 import { type Station, useStations } from '@/api/transit';
-import { Route as StationDetailRoute } from '@/routes/_map/stations/$stationId';
+import { Route as StationDetailRoute } from '@/routes/_map/station/$stationId';
 
 type UseStationSelectionResult = {
   selectedStation: Station | undefined;

--- a/packages/frontend-next/src/routeTree.gen.ts
+++ b/packages/frontend-next/src/routeTree.gen.ts
@@ -19,7 +19,7 @@ import { Route as MapIndexRouteImport } from './routes/_map/index'
 import { Route as ReportsStationsRouteImport } from './routes/reports/stations'
 import { Route as ReportsLinesRouteImport } from './routes/reports/lines'
 import { Route as MapSettingsIndexRouteImport } from './routes/_map/settings/index'
-import { Route as MapStationsStationIdRouteImport } from './routes/_map/stations/$stationId'
+import { Route as MapStationStationIdRouteImport } from './routes/_map/station/$stationId'
 import { Route as MapSettingsContactRouteImport } from './routes/_map/settings/contact'
 import { Route as MapReportsStationIdRouteImport } from './routes/_map/reports/$stationId'
 
@@ -72,9 +72,9 @@ const MapSettingsIndexRoute = MapSettingsIndexRouteImport.update({
   path: '/settings/',
   getParentRoute: () => MapRoute,
 } as any)
-const MapStationsStationIdRoute = MapStationsStationIdRouteImport.update({
-  id: '/stations/$stationId',
-  path: '/stations/$stationId',
+const MapStationStationIdRoute = MapStationStationIdRouteImport.update({
+  id: '/station/$stationId',
+  path: '/station/$stationId',
   getParentRoute: () => MapRoute,
 } as any)
 const MapSettingsContactRoute = MapSettingsContactRouteImport.update({
@@ -99,7 +99,7 @@ export interface FileRoutesByFullPath {
   '/reports/': typeof ReportsIndexRoute
   '/reports/$stationId': typeof MapReportsStationIdRoute
   '/settings/contact': typeof MapSettingsContactRoute
-  '/stations/$stationId': typeof MapStationsStationIdRoute
+  '/station/$stationId': typeof MapStationStationIdRoute
   '/settings/': typeof MapSettingsIndexRoute
 }
 export interface FileRoutesByTo {
@@ -112,7 +112,7 @@ export interface FileRoutesByTo {
   '/reports': typeof ReportsIndexRoute
   '/reports/$stationId': typeof MapReportsStationIdRoute
   '/settings/contact': typeof MapSettingsContactRoute
-  '/stations/$stationId': typeof MapStationsStationIdRoute
+  '/station/$stationId': typeof MapStationStationIdRoute
   '/settings': typeof MapSettingsIndexRoute
 }
 export interface FileRoutesById {
@@ -128,7 +128,7 @@ export interface FileRoutesById {
   '/reports/': typeof ReportsIndexRoute
   '/_map/reports/$stationId': typeof MapReportsStationIdRoute
   '/_map/settings/contact': typeof MapSettingsContactRoute
-  '/_map/stations/$stationId': typeof MapStationsStationIdRoute
+  '/_map/station/$stationId': typeof MapStationStationIdRoute
   '/_map/settings/': typeof MapSettingsIndexRoute
 }
 export interface FileRouteTypes {
@@ -144,7 +144,7 @@ export interface FileRouteTypes {
     | '/reports/'
     | '/reports/$stationId'
     | '/settings/contact'
-    | '/stations/$stationId'
+    | '/station/$stationId'
     | '/settings/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -157,7 +157,7 @@ export interface FileRouteTypes {
     | '/reports'
     | '/reports/$stationId'
     | '/settings/contact'
-    | '/stations/$stationId'
+    | '/station/$stationId'
     | '/settings'
   id:
     | '__root__'
@@ -172,7 +172,7 @@ export interface FileRouteTypes {
     | '/reports/'
     | '/_map/reports/$stationId'
     | '/_map/settings/contact'
-    | '/_map/stations/$stationId'
+    | '/_map/station/$stationId'
     | '/_map/settings/'
   fileRoutesById: FileRoutesById
 }
@@ -256,11 +256,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MapSettingsIndexRouteImport
       parentRoute: typeof MapRoute
     }
-    '/_map/stations/$stationId': {
-      id: '/_map/stations/$stationId'
-      path: '/stations/$stationId'
-      fullPath: '/stations/$stationId'
-      preLoaderRoute: typeof MapStationsStationIdRouteImport
+    '/_map/station/$stationId': {
+      id: '/_map/station/$stationId'
+      path: '/station/$stationId'
+      fullPath: '/station/$stationId'
+      preLoaderRoute: typeof MapStationStationIdRouteImport
       parentRoute: typeof MapRoute
     }
     '/_map/settings/contact': {
@@ -284,7 +284,7 @@ interface MapRouteChildren {
   MapIndexRoute: typeof MapIndexRoute
   MapReportsStationIdRoute: typeof MapReportsStationIdRoute
   MapSettingsContactRoute: typeof MapSettingsContactRoute
-  MapStationsStationIdRoute: typeof MapStationsStationIdRoute
+  MapStationStationIdRoute: typeof MapStationStationIdRoute
   MapSettingsIndexRoute: typeof MapSettingsIndexRoute
 }
 
@@ -292,7 +292,7 @@ const MapRouteChildren: MapRouteChildren = {
   MapIndexRoute: MapIndexRoute,
   MapReportsStationIdRoute: MapReportsStationIdRoute,
   MapSettingsContactRoute: MapSettingsContactRoute,
-  MapStationsStationIdRoute: MapStationsStationIdRoute,
+  MapStationStationIdRoute: MapStationStationIdRoute,
   MapSettingsIndexRoute: MapSettingsIndexRoute,
 }
 

--- a/packages/frontend-next/src/routes/_map/station/$stationId.tsx
+++ b/packages/frontend-next/src/routes/_map/station/$stationId.tsx
@@ -4,7 +4,7 @@ import { fetchStations } from '@/api/transit';
 import { queryClient } from '@/api/queryClient';
 import { StationDetail } from '@/components/map/StationDetail';
 
-export const Route = createFileRoute('/_map/stations/$stationId')({
+export const Route = createFileRoute('/_map/station/$stationId')({
   staticData: { legalDisclaimer: true },
   loader: async ({ params }) => {
     const stations = await queryClient.ensureQueryData({


### PR DESCRIPTION
The telegram bot links to /station/<id> (singular), but frontend-next
served the station detail at /stations/<id> (plural), breaking those
links. Rename the route to /station/$stationId and update all
file-based route references.