### PR TITLE
feat: redirect station deep links to report view when a recent sighting exists

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -86,32 +86,39 @@ const OLDER_SLICE_POLLING = {
 } as const;
 
 /**
+ * React Query options for a single report slice (`['reports', fromAgo, toAgo]`). `fromAgo`/`toAgo`
+ * are millis-ago (`0` is now). The cache key is stable while the actual `from`/`to` window is
+ * recomputed inside `queryFn` on every refetch, so the window rolls forward over time without
+ * churning the key. A slice ending at "now" (`toAgo === 0`) is the live last-hour window and polls;
+ * anything ending in the past is the older 1 h–24 h remainder, fetched once and kept fresh for an
+ * hour. Shared by `useReports` and route loaders so a loader prefetch reuses the map's cache entry.
+ */
+export const reportsSliceQueryOptions = (fromAgo: number, toAgo: number) => {
+  const isLiveSlice = toAgo === 0;
+  return {
+    queryKey: ['reports', fromAgo, toAgo] as const,
+    queryFn: () => {
+      const now = Date.now();
+      const params = new URLSearchParams({
+        from: new Date(now - fromAgo).toISOString(),
+        to: new Date(now - toAgo).toISOString(),
+      });
+      return fetchJson<Report[]>(`/v0/reports?${params.toString()}`);
+    },
+    ...(isLiveSlice ? LIVE_SLICE_POLLING : OLDER_SLICE_POLLING),
+  };
+};
+
+/**
  * Fetch reports from the last `timeframeMs` (e.g. `HOUR_MS` for the map, `DAY_MS` for the
- * overview page). Each slice's cache key is stable (`['reports', fromAgo, toAgo]`) while its
- * actual `from`/`to` window is recomputed inside `queryFn` on every (30 s) refetch, so the
- * window rolls forward over time the same way the server's default endpoint did — without
- * churning the key. Longer timeframes are stitched from the cached last-hour slice plus the
+ * overview page). Longer timeframes are stitched from the cached last-hour slice plus the
  * older remainder (see `reportSlices`), so the recent hour is shared with the map.
  */
 export const useReports = (timeframeMs: number) =>
   useQueries({
-    queries: reportSlices(timeframeMs).map(([fromAgo, toAgo]) => {
-      // A slice ending at "now" (`toAgo === 0`) is the live last-hour window; anything ending
-      // in the past is the older 1 h–24 h remainder.
-      const isLiveSlice = toAgo === 0;
-      return {
-        queryKey: ['reports', fromAgo, toAgo],
-        queryFn: () => {
-          const now = Date.now();
-          const params = new URLSearchParams({
-            from: new Date(now - fromAgo).toISOString(),
-            to: new Date(now - toAgo).toISOString(),
-          });
-          return fetchJson<Report[]>(`/v0/reports?${params.toString()}`);
-        },
-        ...(isLiveSlice ? LIVE_SLICE_POLLING : OLDER_SLICE_POLLING),
-      };
-    }),
+    queries: reportSlices(timeframeMs).map(([fromAgo, toAgo]) =>
+      reportsSliceQueryOptions(fromAgo, toAgo),
+    ),
     combine: (results) => ({
       data: mergeReportSlices(results),
       isLoading: results.some((result) => result.isLoading),

--- a/packages/frontend-next/src/routes/_map/station/$stationId.tsx
+++ b/packages/frontend-next/src/routes/_map/station/$stationId.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 
+import { HOUR_MS, reportsSliceQueryOptions } from '@/api/reports';
 import { fetchStations } from '@/api/transit';
 import { queryClient } from '@/api/queryClient';
 import { StationDetail } from '@/components/map/StationDetail';
+import { Route as ReportDetailRoute } from '@/routes/_map/reports/$stationId';
 
 export const Route = createFileRoute('/_map/station/$stationId')({
   staticData: { legalDisclaimer: true },
@@ -13,6 +15,15 @@ export const Route = createFileRoute('/_map/station/$stationId')({
     });
     const station = stations[params.stationId];
     if (!station) throw redirect({ to: '/', replace: true });
+
+    // A station deep link (e.g. from the Telegram bot) should land on the live report view when
+    // there's a sighting from the last hour, matching the recent/older split in the reports list.
+    // Reuses the map's cached last-hour slice, so this rarely costs an extra request.
+    const recentReports = await queryClient.ensureQueryData(reportsSliceQueryOptions(HOUR_MS, 0));
+    if (recentReports.some((report) => report.stationId === params.stationId)) {
+      throw redirect({ to: ReportDetailRoute.to, params, replace: true });
+    }
+
     return { station };
   },
   component: StationRoute,


### PR DESCRIPTION
## What

Opening `/station/<id>` (e.g. from a Telegram bot link) now redirects to `/reports/<id>` when there's a report for that station from the **last hour**. If there's no recent sighting, it shows the station detail modal as before.

This mirrors the recent/older split already used in the reports list (`ReportRow`), where a report from the last hour links to the live report view and older ones fall back to the station detail.

## Why

Previously a station deep link always opened the plain station detail modal, even when a fresh sighting existed — so the most relevant view (the live report) was a click away. Now follow-on traffic from bot links lands directly on the report.

## How

- Extracted `reportsSliceQueryOptions(fromAgo, toAgo)` in `api/reports.ts` as the single source of truth for a report slice's React Query options. `useReports` now maps over it, and the station route loader reuses it via `ensureQueryData`.
- Because the loader requests the same `['reports', HOUR_MS, 0]` slice the map already polls, the redirect check reuses that cache entry and rarely costs an extra request.
- The redirect uses `replace: true`, consistent with the existing station-not-found redirect.

## Testing

- `tsc -b` — clean
- `eslint` on changed files — clean

https://claude.ai/code/session_01QLBfxTyETFreT9Hycj85HD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLBfxTyETFreT9Hycj85HD)_