### PR TITLE
Increase minimum report marker opacity to 0.4

### DIFF
--- a/packages/frontend-next/src/components/map/ReportMarker.tsx
+++ b/packages/frontend-next/src/components/map/ReportMarker.tsx
@@ -7,7 +7,7 @@ import type { Station } from '@/api/transit';
 import { Route as ReportDetailRoute } from '@/routes/_map/reports/$stationId';
 
 const FADE_DURATION_MS = 60 * 60 * 1000;
-const MIN_OPACITY = 0.2;
+const MIN_OPACITY = 0.4;
 const PULSE_AGE_MS = 60 * 15 * 1000;
 const RECOMPUTE_INTERVAL_MS = 30 * 1000;
 


### PR DESCRIPTION
## Summary

Raises the minimum opacity floor for fading report markers in `frontend-next` from `0.2` to `0.4`, so older reports remain more visible on the map as they age toward the fade-out threshold.

## Changes

- `packages/frontend-next/src/components/map/ReportMarker.tsx`: `MIN_OPACITY` changed from `0.2` to `0.4`.

The fade behaviour is otherwise unchanged: a marker's opacity still decreases linearly with age and disappears entirely once it exceeds `FADE_DURATION_MS` (1 hour). The change only affects how faint a still-visible marker can get during that window.

https://claude.ai/code/session_016qAgvqihemM7RnJEexsasn

---
_Generated by [Claude Code](https://claude.ai/code/session_016qAgvqihemM7RnJEexsasn)_