### PR TITLE
fix: refetch reports and risk after submitting a report

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -217,6 +217,7 @@ function resolveLineId(input: SubmitReportInput, lines: Line[] | undefined): str
 
 export function useSubmitReport() {
   const { data: lines } = useLines();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (input: SubmitReportInput): Promise<SubmitReportResponse> => {
       const lineId = resolveLineId(input, lines);
@@ -232,6 +233,14 @@ export function useSubmitReport() {
       });
       if (!response.ok) throw new Error(`Report submission failed: ${response.status}`);
       return response.json();
+    },
+    // The backend commits the report and clears its reports/risk caches before
+    // returning 200, so by the time we get here the new data is already live —
+    // no wait/race-condition guard is needed. Refetch both so the map and risk
+    // overlay reflect the report immediately instead of waiting for the poll.
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['reports'] });
+      void queryClient.invalidateQueries({ queryKey: ['risk'] });
     },
   });
 }


### PR DESCRIPTION
## What

Invalidate the `['reports']` and `['risk']` queries in `useSubmitReport`'s `onSuccess`, so a freshly submitted report appears on the map and in the risk overlay immediately rather than after the next 30s poll.

## Why no wait / race guard

The Hono `POST /v0/reports` handler awaits the DB insert synchronously and clears both the reports cache and the risk cache **before** returning 200 (`reports-routes.ts`). The live reports slice also sends explicit `from`/`to` params, which the backend serves live from the DB. So by the time the mutation resolves, the new data is already available — a `setTimeout` would only add latency.

## Notes

- `invalidateQueries` uses prefix matching, so `['reports']` refetches every reports slice (live 1h, older slices, per-station counts) and `['risk']` refetches the overlay.
- Additive only: the existing call-site `onSuccess` in `ReportForm` still runs.