### PR TITLE
fix: prevent infinite zoom-out on the map

### DIFF
--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -21,6 +21,9 @@ const INITIAL_VIEW = {
   zoom: requireEnv('VITE_MAP_INITIAL_ZOOM', 'number'),
 };
 
+// Keep the city in view: stop users from zooming out past the metro-area level.
+const MIN_ZOOM = 15;
+
 export function MapView() {
   const { selectedStation, handleMapClick } = useStationSelection();
   const { visible: riskVisible } = useRiskLayer();
@@ -29,6 +32,7 @@ export function MapView() {
     <div className="fixed inset-0">
       <MapGL
         initialViewState={INITIAL_VIEW}
+        minZoom={MIN_ZOOM}
         mapStyle={MAP_STYLE_URL}
         attributionControl={{ compact: true }}
         interactiveLayerIds={[STATIONS_LAYER_ID]}

--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -22,7 +22,7 @@ const INITIAL_VIEW = {
 };
 
 // Keep the city in view: stop users from zooming out past the metro-area level.
-const MIN_ZOOM = 15;
+const MIN_ZOOM = 10;
 
 export function MapView() {
   const { selectedStation, handleMapClick } = useStationSelection();


### PR DESCRIPTION
## What

The `frontend-next` map (`MapView`) didn't set a `minZoom`, so users could zoom out indefinitely well past the city. This adds `minZoom={10}`, keeping the metro area in view.

## Why this value

The legacy `packages/frontend` map already caps zoom-out at `minZoom={10}`, so this matches existing behavior.

## Scope

Single prop on the `<MapGL>` component. The ticket is specifically about zooming *out*, so I left `maxZoom`/`maxBounds` alone — the legacy frontend also sets those, but they're not part of this issue and can follow up if desired.

Closes FRE-639