### PR TITLE
fix: skip direction selection for circular lines in ReportForm 

### DIFF
--- a/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
+++ b/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
@@ -96,13 +96,18 @@ export function ReportSelectionProvider({ children }: { children: ReactNode }) {
   else if (lineName) visibleStations = stationsAlongLine();
   else visibleStations = stationsByType();
 
+  // Circular lines (e.g. the Ringbahn) loop back on themselves, so picking a terminus as a
+  // "direction" is meaningless — leave directionOptions empty so the picker is skipped entirely.
+  const selectedLineIsCircular =
+    lineName !== null && (lines ?? []).some((l) => l.name === lineName && l.isCircular);
+
   // Direction picker exposes every endpoint reachable from the selected station along the
   // chosen line. If the station sits on a single variant we get the two termini of that variant;
   // if it sits on multiple variants (e.g. a branching trunk) we surface every endpoint across
   // those variants, deduplicated. The variant a chosen endpoint belongs to can be resolved at
   // submit time from (lineName, stationId, directionStationId).
   const directionOptions: Station[] = [];
-  if (lineName && selectedStation) {
+  if (lineName && selectedStation && !selectedLineIsCircular) {
     const seen = new Set<string>();
     for (const variant of lines ?? []) {
       if (variant.name !== lineName) continue;


### PR DESCRIPTION
## What

In `frontend-next`'s report form, the direction picker no longer appears when the selected line is **circular** (e.g. the Ringbahn), where choosing a terminus as a "direction" is meaningless.

## How

The fix is a single guard in `ReportSelectionProvider`: when the selected line is circular, `directionOptions` stays empty. Everything downstream already handles the empty case, so no other code needed to change:

- `DirectionPicker` already returns `null` when `directionOptions.length === 0` → the field is hidden.
- `directionStationId` is already reset to `null` on every line change, and can't be set when there are no options → submission sends `directionStationId: null`, which the payload already supports.
- Submit validation is `stationId !== null` and never depended on direction → circular reports aren't blocked.


## Verification
`tsc --noEmit` and ESLint pass. (No test suite exists for this area of frontend-next.)

Closes FRE-636