### PR TITLE
fix: close station search on map pan/zoom

### DIFF
--- a/packages/frontend-next/src/components/map/StationSearch.tsx
+++ b/packages/frontend-next/src/components/map/StationSearch.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from '@tanstack/react-router';
 import { Search, X } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { type PointerEvent as ReactPointerEvent, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { type Station, useStations } from '@/api/transit';
@@ -47,6 +47,13 @@ export function StationSearch() {
     inputRef.current?.blur();
   };
 
+  // The backdrop sits over the map while the search is open, so a tap on it already dismisses
+  // (via onClose). Also dismiss when the user starts panning (pointer move with a button/finger
+  // down) or zooming (wheel) the map underneath, so map gestures close the search too.
+  const dismissOnPan = (event: ReactPointerEvent) => {
+    if (event.buttons !== 0) dismiss();
+  };
+
   const selectStation = (station: Station) => {
     setQuery('');
     inputRef.current?.blur();
@@ -56,7 +63,13 @@ export function StationSearch() {
   return (
     <>
       {isActive && (
-        <Backdrop aria-label={t('clear')} onClose={dismiss} className="z-10 bg-transparent" />
+        <Backdrop
+          aria-label={t('clear')}
+          onClose={dismiss}
+          onPointerMove={dismissOnPan}
+          onWheel={dismiss}
+          className="z-10 bg-transparent"
+        />
       )}
       <div className="pointer-events-none fixed inset-x-0 top-0 z-30 px-3 py-3">
         <div className="pointer-events-auto mx-auto w-full sm:max-w-md">


### PR DESCRIPTION
## What

When the station search is open, panning or zooming the map now closes it — matching the existing click-to-close behavior.

## How

While the search is open, a transparent `Backdrop` (`fixed inset-0 z-10`) sits over the map and intercepts pointer input; a tap on it already dismisses the search via `onClose`. This adds two more dismissal triggers on that same backdrop:

- `onPointerMove` with a button/finger held down → a pan/pinch gesture.
- `onWheel` → a scroll/trackpad zoom.

Since the backdrop already covers the map, these gestures land on it (not the map), so this is a contained, additive change in `StationSearch.tsx` — no new context, and no changes to `Map` or the shared `Backdrop` component (extra handlers are spread onto its underlying `<button>`).

## Notes
- Scrolling/dragging within the search results list does **not** dismiss — the results `Card` sits above the backdrop (`z-30`) and captures those events.
- Worth a quick manual check on a touch device since map-gesture handling is finicky; `tsc` and ESLint pass.

Closes FRE-631