### PR TITLE
feat: show distance to report's station when opening a report

### DIFF
--- a/packages/frontend-next/src/api/transit.ts
+++ b/packages/frontend-next/src/api/transit.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import type { Feature, FeatureCollection, LineString, Point } from 'geojson';
 
+import { distanceMeters } from '@/lib/geo';
 import { requireEnv } from '@/lib/utils';
 
 const API_URL = requireEnv('VITE_API_URL');
@@ -122,3 +123,43 @@ export const useSegments = () =>
     queryKey: ['transit', 'segments'],
     queryFn: () => fetchJson<Segments>('/v0/transit/segments'),
   });
+
+function closestStationId(
+  stations: Stations,
+  position: { lat: number; lng: number },
+): string | null {
+  let bestId: string | null = null;
+  let bestDistance = Infinity;
+  for (const station of Object.values(stations)) {
+    const d = distanceMeters(
+      position.lat,
+      position.lng,
+      station.coordinates.latitude,
+      station.coordinates.longitude,
+    );
+    if (d < bestDistance) {
+      bestDistance = d;
+      bestId = station.id;
+    }
+  }
+  return bestId;
+}
+
+export const useStationDistance = (
+  toStationId: string,
+  position: { lat: number; lng: number } | null,
+) => {
+  const { data: stations } = useStations();
+  const fromStationId = position && stations ? closestStationId(stations, position) : null;
+
+  return useQuery({
+    queryKey: ['transit', 'distance', fromStationId, toStationId],
+    queryFn: () => {
+      const params = new URLSearchParams({ from: fromStationId!, to: toStationId });
+      return fetchJson<{ distance: number }>(`/v0/transit/distance?${params.toString()}`).then(
+        (data) => data.distance,
+      );
+    },
+    enabled: fromStationId !== null && toStationId.length > 0,
+  });
+};

--- a/packages/frontend-next/src/components/map/ReportDetail.i18n.ts
+++ b/packages/frontend-next/src/components/map/ReportDetail.i18n.ts
@@ -11,6 +11,8 @@ i18n.addResourceBundle('en', NAMESPACE, {
   hoursAgo_other: '{{count}} hours ago',
   times: 'times',
   thisWeek: 'this week',
+  oneStationAway: 'one station away',
+  stationsAway: '{{count}} stations away',
   inviteText: 'Data may be inaccurate.',
   syncText: 'Reports synced with {{group}}',
 });
@@ -24,6 +26,8 @@ i18n.addResourceBundle('de', NAMESPACE, {
   hoursAgo_other: 'vor {{count}} Stunden',
   times: 'mal',
   thisWeek: 'diese Woche',
+  oneStationAway: 'eine Station entfernt',
+  stationsAway: '{{count}} Stationen entfernt',
   inviteText: 'Daten vielleicht ungenau.',
   syncText: 'Meldungen mit {{group}} synchronisiert',
 });

--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -1,9 +1,11 @@
+import { MapPin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { formatElapsed, HOUR_MS, useReports, useStationReportCount } from '@/api/reports';
-import { type Station, useLines, useStations } from '@/api/transit';
+import { type Station, useLines, useStations, useStationDistance } from '@/api/transit';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { CardContent } from '@/components/ui/card';
+import { useGeolocation } from '@/contexts/Geolocation.context';
 import { optionalEnv } from '@/lib/utils';
 
 import { DetailCard } from './DetailCard';
@@ -23,6 +25,10 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
   const { data: lines } = useLines();
   const { data: stations } = useStations();
   const { data: numberOfReports } = useStationReportCount(station.id);
+  const { position } = useGeolocation();
+  // Stations between the user's nearest station and this report; absent until location is shared
+  // and the lookup resolves (and stays absent if the backend can't route between them).
+  const { data: stationDistance } = useStationDistance(station.id, position);
 
   const report = (reports ?? [])
     .filter((r) => r.stationId === station.id)
@@ -44,6 +50,14 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
       <CardContent className="space-y-1">
         {report && (
           <p className="text-muted-foreground text-sm">{formatElapsed(report.timestamp, t)}</p>
+        )}
+        {stationDistance !== undefined && (
+          <p className="text-muted-foreground flex items-center gap-1 text-sm">
+            <MapPin className="size-3.5 shrink-0" />
+            {stationDistance <= 1
+              ? t('oneStationAway')
+              : t('stationsAway', { count: stationDistance })}
+          </p>
         )}
         {/* Reserve the line height so the count loading in does not shift layout. */}
         <p className="min-h-5 text-sm">


### PR DESCRIPTION
## What

Ports the legacy frontend's "distance to your station" behavior into `frontend-next`. When a report is opened and the user has shared their location, `ReportDetail` now shows how many transit stations away the report is.

## How

- New `useStationDistance(toStationId, position)` hook in `api/transit.ts`:
  - Finds the station nearest the user's GPS position (Haversine via the existing `distanceMeters`).
  - Calls the existing backend `GET /v0/transit/distance?from=&to=`, which returns the number of stations between them — same data source the old frontend used.
  - Keyed on the resolved `from`/`to` station ids (not raw coordinates), so minor GPS jitter that keeps the same nearest station doesn't refetch.
- `ReportDetail` renders the result as a muted line with a `MapPin` icon, matching the "Nearby" pattern already used in the report form.
- Wording mirrors the legacy frontend: **"one station away"** for ≤ 1, **"N stations away"** otherwise (EN + DE).


## Notes
- Unlike the legacy version I did not port the loading **skeleton**; the line just appears once resolved (resolves fast and sits below the existing elapsed-time line). Easy to add a reserved-height placeholder if preferred.
- Distance is measured from the user's *nearest station*, not raw GPS — matching the legacy behavior, since the backend distance is a station-graph hop count.
- `tsc` and ESLint pass. No automated test suite covers this area of frontend-next; worth a quick manual check with location enabled.

Closes FRE-641