### PR TITLE
feat: stop reports pulsing once the user has viewed them

### DIFF
--- a/packages/frontend-next/src/components/map/ReportMarker.tsx
+++ b/packages/frontend-next/src/components/map/ReportMarker.tsx
@@ -4,6 +4,7 @@ import { Marker, type MarkerEvent } from 'react-map-gl/maplibre';
 
 import type { Report } from '@/api/reports';
 import type { Station } from '@/api/transit';
+import { markReportViewed, useReportViewed } from '@/lib/viewed-reports';
 import { Route as ReportDetailRoute } from '@/routes/_map/reports/$stationId';
 
 const FADE_DURATION_MS = 60 * 60 * 1000;
@@ -25,6 +26,7 @@ function computeOpacity(timestamp: string, nowMs: number): number {
 export function ReportMarker({ report, station }: ReportMarkerProps) {
   const navigate = useNavigate();
   const [now, setNow] = useState(() => Date.now());
+  const viewed = useReportViewed(report.stationId, report.timestamp);
 
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), RECOMPUTE_INTERVAL_MS);
@@ -35,11 +37,13 @@ export function ReportMarker({ report, station }: ReportMarkerProps) {
   if (opacity <= 0) return null;
 
   const age = now - new Date(report.timestamp).getTime();
-  const shouldPulse = age < PULSE_AGE_MS;
+  // Pulse only while the report is fresh and the user has not viewed it yet.
+  const shouldPulse = age < PULSE_AGE_MS && !viewed;
 
   const handleClick = (event: MarkerEvent<MouseEvent>) => {
     // Stop the map's onClick from also firing (which would open the station detail).
     event.originalEvent.stopPropagation();
+    markReportViewed(report.stationId, report.timestamp);
     void navigate({ to: ReportDetailRoute.to, params: { stationId: report.stationId } });
   };
 

--- a/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
+++ b/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
@@ -5,6 +5,7 @@ import { HOUR_MS, useReports } from '@/api/reports';
 import { useLines, useStations } from '@/api/transit';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Button } from '@/components/ui/button';
+import { markReportViewed, useReportViewed } from '@/lib/viewed-reports';
 import { Route as ReportsSummaryRoute } from '@/routes/reports/index';
 
 import { NAMESPACE } from './ReportsOverviewButton.i18n';
@@ -20,6 +21,8 @@ export function ReportsOverviewButton() {
   const allReports = reports ?? [];
   const recentCount = allReports.length;
   const latest = allReports.slice().sort((a, b) => b.timestamp.localeCompare(a.timestamp))[0];
+  // Called before the early return to keep hook order stable; empty keys match nothing.
+  const latestViewed = useReportViewed(latest?.stationId ?? '', latest?.timestamp ?? '');
 
   if (!latest) return null;
 
@@ -35,7 +38,12 @@ export function ReportsOverviewButton() {
         variant="secondary"
         className="bg-card text-card-foreground hover:bg-card/80 pointer-events-auto h-auto w-full max-w-[min(20rem,calc(100vw-10.5rem))] flex-col items-stretch gap-1.5 rounded-lg px-3.5 py-3 shadow-[0_6px_16px_rgba(0,0,0,0.28)]"
       >
-        <Link to={ReportsSummaryRoute.to}>
+        <Link
+          to={ReportsSummaryRoute.to}
+          // Opening the overview counts as viewing the latest report shown here, so it stops
+          // pulsing both on this button and on its map marker.
+          onClick={() => markReportViewed(latest.stationId, latest.timestamp)}
+        >
           <div className="flex items-center justify-between gap-3">
             <span className="text-muted-foreground text-xs">{t('lastHour')}</span>
             <span className="text-sm font-semibold">{recentCount}</span>
@@ -43,10 +51,12 @@ export function ReportsOverviewButton() {
           <div className="flex items-center gap-2">
             {lineName && <LineBadge name={lineName} />}
             <span className="flex-1 truncate text-sm font-medium">{stationName}</span>
-            <span className="relative ml-auto block size-2 shrink-0">
-              <span className="bg-destructive absolute inset-0 animate-ping rounded-full opacity-75" />
-              <span className="bg-destructive relative block size-2 rounded-full" />
-            </span>
+            {!latestViewed && (
+              <span className="relative ml-auto block size-2 shrink-0">
+                <span className="bg-destructive absolute inset-0 animate-ping rounded-full opacity-75" />
+                <span className="bg-destructive relative block size-2 rounded-full" />
+              </span>
+            )}
           </div>
         </Link>
       </Button>

--- a/packages/frontend-next/src/lib/viewed-reports.ts
+++ b/packages/frontend-next/src/lib/viewed-reports.ts
@@ -1,0 +1,51 @@
+import { useSyncExternalStore } from 'react';
+
+// Reports the user has already looked at (by opening the report detail or the reports overview)
+// stop pulsing on the map and on the overview button. Tracked by the app-wide
+// `${stationId}-${timestamp}` report key and persisted in sessionStorage so the state survives
+// route changes and reloads within the tab, and can be read from anywhere in the app. Lives in a
+// tiny module store + useSyncExternalStore (like useRiskLayer) so the map markers and the overview
+// button re-render the moment a report is marked viewed, without a provider.
+const STORAGE_KEY = 'viewedReports';
+
+function reportKey(stationId: string, timestamp: string): string {
+  return `${stationId}-${timestamp}`;
+}
+
+function readInitial(): Set<string> {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((key): key is string => typeof key === 'string'));
+  } catch {
+    // Malformed JSON or storage unavailable (private mode): start empty for this session.
+    return new Set();
+  }
+}
+
+const viewed = readInitial();
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function markReportViewed(stationId: string, timestamp: string): void {
+  const key = reportKey(stationId, timestamp);
+  if (viewed.has(key)) return;
+  viewed.add(key);
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify([...viewed]));
+  } catch {
+    // Storage unavailable: keep the in-memory state so it still works for this session.
+  }
+  for (const listener of listeners) listener();
+}
+
+/** Reactive: re-renders the caller when this specific report is marked viewed. */
+export function useReportViewed(stationId: string, timestamp: string): boolean {
+  return useSyncExternalStore(subscribe, () => viewed.has(reportKey(stationId, timestamp)));
+}


### PR DESCRIPTION
## What

Reports stop pulsing once the user has looked at them, persisted in **sessionStorage** so the state survives route changes/reloads within the tab and is readable across the app.

- Clicking a report marker marks it viewed → the marker stops pulsing.
- Opening the reports overview marks the **latest** report (the one shown on the overview button) viewed → it stops pulsing on the button **and** on its map marker. When viewed, the button's red indicator (ping halo + dot) is removed entirely.

## How

- New `src/lib/viewed-reports.ts` — a tiny module store backed by sessionStorage, keyed by the app-wide `${stationId}-${timestamp}` report key, exposed via a reactive `useReportViewed(...)` (`useSyncExternalStore`, mirroring `useRiskLayer`) and a `markReportViewed(...)` setter. Markers and the button re-render the moment a report is marked viewed — no provider, no prop-drilling across the lazy map boundary.
- `ReportMarker` — pulse gated on `age < PULSE_AGE_MS && !viewed`; marks viewed in its click handler.
- `ReportsOverviewButton` — marks the latest report viewed in the `Link`'s `onClick` (it already computes `latest`, so no extra query/effect); hides the whole indicator when that report is viewed.

## Notes
- Marking on the button's `onClick` (rather than a route effect) keeps it co-located with the report the button displays and matches the spec precisely — "the latest report (the one displayed on the button)" at click time.
- Report markers were already keyed by station+timestamp app-wide, so the storage key reuses that convention.
- `tsc` and ESLint pass. No automated test suite covers this area of frontend-next.

Closes FRE-617