### PR TITLE
feat: prefill station in report form from StationDetail

### DIFF
--- a/packages/frontend-next/src/components/map/StationDetail.tsx
+++ b/packages/frontend-next/src/components/map/StationDetail.tsx
@@ -33,7 +33,9 @@ export function StationDetail({ station, onClose }: StationDetailProps) {
           variant="default"
           className="bg-destructive hover:bg-destructive/90 h-11 w-full text-sm font-medium text-white"
         >
-          <Link to={ReportRoute.to}>{t('reportSighting')}</Link>
+          <Link to={ReportRoute.to} search={{ stationId: station.id }}>
+            {t('reportSighting')}
+          </Link>
         </Button>
       </CardContent>
     </DetailCard>

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from '@tanstack/react-router';
+import { getRouteApi, useNavigate } from '@tanstack/react-router';
 import { ChevronRight, MapPin, Search, TriangleAlert } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,6 +25,8 @@ import { type LineFilter, useReportSelection } from './ReportSelection.context';
 import { ReportSelectionProvider } from './ReportSelectionProvider';
 import { ReportSuccess } from './ReportSuccess';
 import { type ReportRejection, useReportVerification } from './useReportVerification';
+
+const routeApi = getRouteApi('/report');
 
 const FILTERS: LineFilter[] = ['all', 'subway', 'light_rail', 'tram'];
 
@@ -326,6 +328,7 @@ function SubmitFooter({ onSubmitted }: { onSubmitted: (result: SubmitReportRespo
 export function ReportForm() {
   const { t } = useTranslation(NAMESPACE);
   const navigate = useNavigate();
+  const { stationId: initialStationId } = routeApi.useSearch();
   const [result, setResult] = useState<SubmitReportResponse | null>(null);
 
   const handleSuccessClose = () => {
@@ -335,7 +338,7 @@ export function ReportForm() {
   };
 
   return (
-    <ReportSelectionProvider>
+    <ReportSelectionProvider initialStationId={initialStationId}>
       <div className="bg-card animate-in fade-in fixed inset-0 z-30 duration-150">
         <div className="mx-auto flex h-full w-full max-w-md flex-col">
           {result ? (

--- a/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
+++ b/packages/frontend-next/src/components/report/ReportSelectionProvider.tsx
@@ -15,10 +15,16 @@ import {
   type ReportSelectionContextValue,
 } from './ReportSelection.context';
 
-export function ReportSelectionProvider({ children }: { children: ReactNode }) {
+export function ReportSelectionProvider({
+  children,
+  initialStationId = null,
+}: {
+  children: ReactNode;
+  initialStationId?: string | null;
+}) {
   const [lineName, setLineName] = useState<string | null>(null);
   const [lineFilter, setLineFilter] = useState<LineFilter>('all');
-  const [stationId, setStationId] = useState<string | null>(null);
+  const [stationId, setStationId] = useState<string | null>(initialStationId);
   const [directionStationId, setDirectionStationId] = useState<string | null>(null);
 
   const { data: lines } = useLines();
@@ -49,6 +55,20 @@ export function ReportSelectionProvider({ children }: { children: ReactNode }) {
   const selectDirection = (id: string | null) => {
     setDirectionStationId(id);
   };
+
+  // The prefilled station is seeded into stationId above; once the transit data is available,
+  // mirror selectStation's single-line shortcut so a station served by exactly one line preselects
+  // that line (and its type filter), letting the user skip the line step.
+  const [appliedInitialStationId, setAppliedInitialStationId] = useState<string | null>(null);
+  if (initialStationId && lines && stations && appliedInitialStationId !== initialStationId) {
+    setAppliedInitialStationId(initialStationId);
+    const names = resolveStationLineNames(stations[initialStationId]?.lines ?? [], lines);
+    if (names.length === 1) {
+      setLineName(names[0]);
+      const type = lines.find((l) => l.name === names[0])?.type;
+      if (type) setLineFilter(type);
+    }
+  }
 
   // One badge per line name (collapses per-direction variants), sorted by canonical order.
   const typeByName = new Map<string, LineType>();

--- a/packages/frontend-next/src/routes/report.tsx
+++ b/packages/frontend-next/src/routes/report.tsx
@@ -2,7 +2,12 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { ReportForm } from '@/components/report/ReportForm';
 
+type ReportSearch = { stationId?: string };
+
 export const Route = createFileRoute('/report')({
   staticData: { legalDisclaimer: false },
+  validateSearch: (search: Record<string, unknown>): ReportSearch => ({
+    stationId: typeof search.stationId === 'string' ? search.stationId : undefined,
+  }),
   component: ReportForm,
 });


### PR DESCRIPTION
## What

Opening the report form from a station's detail card now prefills that station, so the user doesn't have to search for it again.

Closes FRE-614 / #533.

## How

- `/report` route accepts an optional `stationId` search param (`validateSearch`).
- `StationDetail`'s report link passes `search={{ stationId: station.id }}`.
- `ReportForm` reads the param and seeds it into `ReportSelectionProvider` as `initialStationId`.
- Once transit data is available, the provider mirrors `selectStation`'s single-line shortcut: a station served by exactly one line preselects that line and its type filter, so the user can skip the line step. This is applied during render with a one-shot guard (the lint config forbids synchronous `setState` in effects), which also covers cold deep-links to `/report?stationId=…`.

When no `stationId` is present (visiting `/report` directly), behavior is unchanged.
