### PR TITLE
feat: rework user location permission flow

### DIFF
--- a/packages/frontend-next/src/components/map/DetailCard.tsx
+++ b/packages/frontend-next/src/components/map/DetailCard.tsx
@@ -1,9 +1,10 @@
 import { X } from 'lucide-react';
 import * as React from 'react';
 
-import { Backdrop } from '@/components/ui/backdrop';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
+import { CardContent } from '@/components/ui/card';
+
+import { PopupCard } from './PopupCard';
 
 type DetailCardProps = {
   title: string;
@@ -14,25 +15,14 @@ type DetailCardProps = {
 
 export function DetailCard({ title, closeLabel, onClose, children }: DetailCardProps) {
   return (
-    <>
-      <Backdrop
-        aria-label={closeLabel}
-        onClose={onClose}
-        // z-40 lifts the backdrop above the map controls (z-20), the search bar (z-30) and the
-        // toasts (z-25) so it dims and blocks all of them, not just the map.
-        className="animate-in fade-in z-40 duration-150"
-      />
-      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center p-3">
-        <Card className="animate-in slide-in-from-bottom-4 fade-in pointer-events-auto w-full max-w-md gap-1 py-4 duration-200 ease-out">
-          <CardContent className="flex items-start justify-between">
-            <h2 className="font-heading text-lg font-semibold">{title}</h2>
-            <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label={closeLabel}>
-              <X />
-            </Button>
-          </CardContent>
-          {children}
-        </Card>
-      </div>
-    </>
+    <PopupCard onClose={onClose} closeLabel={closeLabel}>
+      <CardContent className="flex items-start justify-between">
+        <h2 className="font-heading text-lg font-semibold">{title}</h2>
+        <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label={closeLabel}>
+          <X />
+        </Button>
+      </CardContent>
+      {children}
+    </PopupCard>
   );
 }

--- a/packages/frontend-next/src/components/map/LocationPermissionPrompt.i18n.ts
+++ b/packages/frontend-next/src/components/map/LocationPermissionPrompt.i18n.ts
@@ -1,0 +1,18 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'locationPermission';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  title: 'Show your location?',
+  description: 'FreiFahren can show where you are on the map to help you find nearby stations.',
+  allow: 'Allow',
+  notNow: 'Not now',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  title: 'Deinen Standort anzeigen?',
+  description:
+    'FreiFahren kann deinen Standort auf der Karte anzeigen, damit du Stationen in der Nähe findest.',
+  allow: 'Erlauben',
+  notNow: 'Jetzt nicht',
+});

--- a/packages/frontend-next/src/components/map/LocationPermissionPrompt.tsx
+++ b/packages/frontend-next/src/components/map/LocationPermissionPrompt.tsx
@@ -1,0 +1,42 @@
+import { MapPin } from 'lucide-react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { CardContent, CardFooter } from '@/components/ui/card';
+
+import { NAMESPACE } from './LocationPermissionPrompt.i18n';
+import { PopupCard } from './PopupCard';
+
+type LocationPermissionPromptProps = {
+  onAllow: () => void;
+  onDismiss: () => void;
+};
+
+export function LocationPermissionPrompt({ onAllow, onDismiss }: LocationPermissionPromptProps) {
+  const { t } = useTranslation(NAMESPACE);
+
+  return createPortal(
+    <PopupCard>
+      <CardContent className="flex flex-col gap-1">
+        <h2 className="font-heading flex items-center gap-2 text-lg font-semibold">
+          <MapPin className="text-accent-bright size-5" />
+          {t('title')}
+        </h2>
+        <p className="text-muted-foreground text-sm">{t('description')}</p>
+      </CardContent>
+      <CardFooter className="gap-2">
+        <Button variant="outline" className="flex-1" onClick={onDismiss}>
+          {t('notNow')}
+        </Button>
+        <Button
+          className="bg-accent-bright text-primary-foreground hover:bg-accent-press flex-1"
+          onClick={onAllow}
+        >
+          {t('allow')}
+        </Button>
+      </CardFooter>
+    </PopupCard>,
+    document.body,
+  );
+}

--- a/packages/frontend-next/src/components/map/PopupCard.tsx
+++ b/packages/frontend-next/src/components/map/PopupCard.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+import { Backdrop } from '@/components/ui/backdrop';
+import { Card } from '@/components/ui/card';
+
+type PopupCardProps = {
+  /**
+   * When provided, the card is dismissible: a backdrop is rendered that dims and blocks the map
+   * behind the card and closes it on click. Omit it for a non-modal prompt that lets users keep
+   * interacting with the map (no backdrop, no implicit dismiss).
+   */
+  onClose?: () => void;
+  closeLabel?: string;
+  children: React.ReactNode;
+};
+
+export function PopupCard({ onClose, closeLabel, children }: PopupCardProps) {
+  return (
+    <>
+      {onClose && (
+        <Backdrop
+          aria-label={closeLabel}
+          onClose={onClose}
+          // z-40 lifts the backdrop above the map controls (z-20), the search bar (z-30) and the
+          // toasts (z-25) so it dims and blocks all of them, not just the map.
+          className="animate-in fade-in z-40 duration-150"
+        />
+      )}
+      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center p-3">
+        <Card className="animate-in slide-in-from-bottom-4 fade-in pointer-events-auto w-full max-w-md gap-1 py-4 duration-200 ease-out">
+          {children}
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/packages/frontend-next/src/components/map/UserLocationControl.tsx
+++ b/packages/frontend-next/src/components/map/UserLocationControl.tsx
@@ -1,66 +1,112 @@
+import { useRouterState } from '@tanstack/react-router';
 import type { GeolocateControl as GeolocateControlInstance } from 'maplibre-gl';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { GeolocateControl, useMap } from 'react-map-gl/maplibre';
 
 import { useGeolocation } from '@/contexts/Geolocation.context';
+import { useLegalDisclaimer } from '@/lib/legal-disclaimer';
+import {
+  dismissLocationPrompt,
+  isLocationOptedIn,
+  isLocationPromptDismissed,
+  LOCATION_PROMPT_DELAY_MS,
+  markLocationOptedIn,
+  queryGeolocationPermission,
+} from '@/lib/location-prompt';
+
+import { LocationPermissionPrompt } from './LocationPermissionPrompt';
 
 /**
- * Renders maplibre's native GeolocateControl (blue dot, accuracy circle, continuous
- * tracking, permission/error handling) and mirrors its events into GeolocationProvider
- * so the rest of the app can read the user's position. Tracking is requested
- * automatically once the map has loaded.
+ * Renders maplibre's GeolocateControl (location dot, accuracy circle, tracking) and mirrors its
+ * events into GeolocationProvider. Location is not requested eagerly — it is gated and delayed;
+ * see `@/lib/location-prompt`.
  */
 export function UserLocationControl() {
   const { current: map } = useMap();
   const controlRef = useRef<GeolocateControlInstance>(null);
   const { notifyLoading, notifyPosition, notifyError } = useGeolocation();
+  const { accepted } = useLegalDisclaimer();
+  const [showPrompt, setShowPrompt] = useState(false);
+  // Soft-ask only on the bare map, never over a sub-route's panel.
+  const onMapIndex = useRouterState({ select: (s) => s.location.pathname === '/' });
 
+  const trigger = useCallback(() => {
+    const control = controlRef.current;
+    // Suppress GeolocateControl recentering/zooming the camera on the first fix; we only want the dot.
+    if (control) {
+      (control as unknown as { _updateCamera: () => void })._updateCamera = () => {};
+    }
+    notifyLoading();
+    control?.trigger();
+  }, [notifyLoading]);
+
+  // Gate on disclaimer acceptance + map load. Already-consented users track immediately; everyone
+  // else gets the soft-ask, deferred so it doesn't interrupt before they can orient themselves.
   useEffect(() => {
-    if (!map) return;
+    if (!map || !accepted) return;
 
-    // Defer the trigger so StrictMode's dev mount/unmount/mount cycle (which
-    // re-adds the control in its inactive state) settles on a single net
-    // activation — trigger() toggles, so calling it twice would switch
-    // tracking back off.
+    let cancelled = false;
     let timer = 0;
-    const activate = () => {
+
+    const evaluate = async () => {
+      const permission = await queryGeolocationPermission();
+      if (cancelled) return;
+
+      if (permission === 'denied') return;
+      if (permission === 'granted' || isLocationOptedIn()) {
+        trigger();
+        return;
+      }
+
+      if (isLocationPromptDismissed()) return;
       timer = window.setTimeout(() => {
-        const control = controlRef.current;
-        // Suppress GeolocateControl's default behavior of recentering and
-        // zooming the camera to the user on the first fix. We only want the
-        // location dot/accuracy circle, which are rendered independently of
-        // this camera update.
-        if (control) {
-          (control as unknown as { _updateCamera: () => void })._updateCamera = () => {};
-        }
-        notifyLoading();
-        control?.trigger();
-      }, 0);
+        if (!cancelled && !isLocationPromptDismissed()) setShowPrompt(true);
+      }, LOCATION_PROMPT_DELAY_MS);
     };
 
-    if (map.loaded()) activate();
-    else map.once('load', activate);
+    const start = () => void evaluate();
+    if (map.loaded()) start();
+    else map.once('load', start);
 
     return () => {
+      cancelled = true;
       window.clearTimeout(timer);
-      map.off('load', activate);
+      map.off('load', start);
     };
-  }, [map, notifyLoading]);
+  }, [map, accepted, trigger]);
+
+  const handleAllow = () => {
+    setShowPrompt(false);
+    markLocationOptedIn();
+    trigger();
+  };
+
+  const handleDismiss = () => {
+    setShowPrompt(false);
+    dismissLocationPrompt();
+  };
 
   return (
-    <GeolocateControl
-      ref={controlRef}
-      // Location is requested automatically, so the control's button is hidden.
-      // This only hides the button container; the user-location dot and accuracy
-      // circle are added to the map separately and stay visible.
-      style={{ display: 'none' }}
-      positionOptions={{ enableHighAccuracy: true }}
-      trackUserLocation
-      showUserLocation
-      showAccuracyCircle
-      onGeolocate={(e) => notifyPosition(e.coords)}
-      onError={(e) => notifyError(e.code)}
-      onTrackUserLocationStart={() => notifyLoading()}
-    />
+    <>
+      <GeolocateControl
+        ref={controlRef}
+        // Requested programmatically, so hide the control's button; the dot/accuracy circle stay.
+        style={{ display: 'none' }}
+        positionOptions={{ enableHighAccuracy: true }}
+        trackUserLocation
+        showUserLocation
+        showAccuracyCircle
+        onGeolocate={(e) => {
+          // A fix means permission was granted — remember it for browsers without the Permissions API.
+          markLocationOptedIn();
+          notifyPosition(e.coords);
+        }}
+        onError={(e) => notifyError(e.code)}
+        onTrackUserLocationStart={() => notifyLoading()}
+      />
+      {showPrompt && onMapIndex && (
+        <LocationPermissionPrompt onAllow={handleAllow} onDismiss={handleDismiss} />
+      )}
+    </>
   );
 }

--- a/packages/frontend-next/src/lib/location-prompt.ts
+++ b/packages/frontend-next/src/lib/location-prompt.ts
@@ -1,0 +1,50 @@
+// Coordinates when the map may ask for the browser's location permission. The native
+// geolocation prompt is one-shot per origin (a denial is sticky and cannot be re-triggered),
+// so we gate it behind an in-app soft-ask and remember just enough state to avoid re-nagging.
+
+// Let users orient themselves on the map before the prompt interrupts them.
+export const LOCATION_PROMPT_DELAY_MS = 15_000;
+
+export type GeolocationPermissionState = 'granted' | 'denied' | 'prompt' | 'unsupported';
+
+export async function queryGeolocationPermission(): Promise<GeolocationPermissionState> {
+  try {
+    const status = await navigator.permissions.query({ name: 'geolocation' });
+    return status.state; // 'granted' | 'denied' | 'prompt'
+  } catch {
+    return 'unsupported';
+  }
+}
+
+// "Not now" suppresses the soft-ask for the current session only ("not now" means "later"),
+// so this is intentionally in-memory and resets on reload.
+let dismissed = false;
+
+export function isLocationPromptDismissed(): boolean {
+  return dismissed;
+}
+
+export function dismissLocationPrompt(): void {
+  dismissed = true;
+}
+
+// Persisted opt-in: once the user has allowed (or we have seen a successful fix), remember it so
+// browsers without the Permissions API (iOS Safari) are not soft-asked again on a later visit.
+const OPT_IN_KEY = 'locationOptIn';
+
+export function isLocationOptedIn(): boolean {
+  try {
+    return localStorage.getItem(OPT_IN_KEY) === 'true';
+  } catch {
+    // Private mode / disabled storage: treat as not opted in so the soft-ask can still appear.
+    return false;
+  }
+}
+
+export function markLocationOptedIn(): void {
+  try {
+    localStorage.setItem(OPT_IN_KEY, 'true');
+  } catch {
+    // Ignore storage failures; the worst case is asking again on a future visit.
+  }
+}


### PR DESCRIPTION
## What

Stops the app from asking for the browser location permission too early. Previously `UserLocationControl` auto-triggered MapLibre's `GeolocateControl` on map load — firing the native prompt before/over the legal disclaimer, with no delay.

Closes FRE-635 / #573.

## How

The native geolocation prompt is one-shot per origin (a denial is sticky and can't be re-triggered), so we gate it behind a branded in-app soft-ask:

- **Only on the map** — `UserLocationControl` already mounts only under the `_map` layout, so no extra guard is needed there.
- **Only after the disclaimer is accepted** — gated on `useLegalDisclaimer().accepted`.
- **Already-consented users track immediately** — if the Permissions API reports `granted` (or we have a stored opt-in), the location dot appears right away, no delay, no prompt.
- **Everyone else gets a deferred soft-ask** — `prompt`/`unsupported` with no prior opt-in shows the branded card ~15s after the map is visible, so users can orient themselves first. "Allow" fires the real native prompt; "Not now" leaves the browser permission untouched.
- **Shown only on the bare map (`/`)** — never over a station/report/settings sub-route panel.
- **No re-nagging** — `denied` is never auto-asked; "Not now" suppresses for the session; a persisted opt-in covers browsers without the Permissions API (iOS Safari).

### Shared card chrome
Extracted `PopupCard` from `DetailCard` so the soft-ask shares the bottom-anchored layout, sizing, and slide-up animation with the contribute/detail cards. The backdrop + close button are now opt-in (`onClose`), so the non-modal soft-ask omits them. `DetailCard`'s output is unchanged.