### PR TITLE
fix: never trigger the native location prompt before the soft-ask

### DIFF
--- a/packages/frontend-next/src/components/map/UserLocationControl.tsx
+++ b/packages/frontend-next/src/components/map/UserLocationControl.tsx
@@ -7,10 +7,8 @@ import { useGeolocation } from '@/contexts/Geolocation.context';
 import { useLegalDisclaimer } from '@/lib/legal-disclaimer';
 import {
   dismissLocationPrompt,
-  isLocationOptedIn,
   isLocationPromptDismissed,
   LOCATION_PROMPT_DELAY_MS,
-  markLocationOptedIn,
   queryGeolocationPermission,
 } from '@/lib/location-prompt';
 
@@ -40,8 +38,10 @@ export function UserLocationControl() {
     control?.trigger();
   }, [notifyLoading]);
 
-  // Gate on disclaimer acceptance + map load. Already-consented users track immediately; everyone
-  // else gets the soft-ask, deferred so it doesn't interrupt before they can orient themselves.
+  // Gate on disclaimer acceptance + map load. Only 'granted' tracks immediately (the API call is
+  // silent then); for 'prompt'/'unsupported' we must not call the API ourselves — on Safari/iOS
+  // that would surface the native prompt — so we show the deferred soft-ask and only trigger on
+  // the user's explicit Allow.
   useEffect(() => {
     if (!map || !accepted) return;
 
@@ -52,11 +52,11 @@ export function UserLocationControl() {
       const permission = await queryGeolocationPermission();
       if (cancelled) return;
 
-      if (permission === 'denied') return;
-      if (permission === 'granted' || isLocationOptedIn()) {
+      if (permission === 'granted') {
         trigger();
         return;
       }
+      if (permission === 'denied') return;
 
       if (isLocationPromptDismissed()) return;
       timer = window.setTimeout(() => {
@@ -77,7 +77,6 @@ export function UserLocationControl() {
 
   const handleAllow = () => {
     setShowPrompt(false);
-    markLocationOptedIn();
     trigger();
   };
 
@@ -96,11 +95,7 @@ export function UserLocationControl() {
         trackUserLocation
         showUserLocation
         showAccuracyCircle
-        onGeolocate={(e) => {
-          // A fix means permission was granted — remember it for browsers without the Permissions API.
-          markLocationOptedIn();
-          notifyPosition(e.coords);
-        }}
+        onGeolocate={(e) => notifyPosition(e.coords)}
         onError={(e) => notifyError(e.code)}
         onTrackUserLocationStart={() => notifyLoading()}
       />

--- a/packages/frontend-next/src/lib/location-prompt.ts
+++ b/packages/frontend-next/src/lib/location-prompt.ts
@@ -1,6 +1,6 @@
-// Coordinates when the map may ask for the browser's location permission. The native
-// geolocation prompt is one-shot per origin (a denial is sticky and cannot be re-triggered),
-// so we gate it behind an in-app soft-ask and remember just enough state to avoid re-nagging.
+// Coordinates when the map may ask for the browser's location permission. We never call the
+// geolocation API on a hint — only when it is reliably 'granted' (silent) or the user explicitly
+// taps Allow — so we never surface the native prompt before our in-app soft-ask.
 
 // Let users orient themselves on the map before the prompt interrupts them.
 export const LOCATION_PROMPT_DELAY_MS = 15_000;
@@ -26,25 +26,4 @@ export function isLocationPromptDismissed(): boolean {
 
 export function dismissLocationPrompt(): void {
   dismissed = true;
-}
-
-// Persisted opt-in: once the user has allowed (or we have seen a successful fix), remember it so
-// browsers without the Permissions API (iOS Safari) are not soft-asked again on a later visit.
-const OPT_IN_KEY = 'locationOptIn';
-
-export function isLocationOptedIn(): boolean {
-  try {
-    return localStorage.getItem(OPT_IN_KEY) === 'true';
-  } catch {
-    // Private mode / disabled storage: treat as not opted in so the soft-ask can still appear.
-    return false;
-  }
-}
-
-export function markLocationOptedIn(): void {
-  try {
-    localStorage.setItem(OPT_IN_KEY, 'true');
-  } catch {
-    // Ignore storage failures; the worst case is asking again on a future visit.
-  }
 }


### PR DESCRIPTION
## The bug

On **Safari/iOS** with the site location permission set to **"Ask" (Fragen)**, the **native** geolocation prompt appeared *instantly* on the map instead of our in-app soft-ask — exactly the early, uninvited prompt FRE-635 set out to prevent.

## Root cause

The auto-trigger branch in `UserLocationControl` was:

```ts
if (permission === 'granted' || isLocationOptedIn()) { trigger(); return; }
```

`isLocationOptedIn()` was a persisted localStorage flag (`locationOptIn`) added on the assumption that **iOS Safari has no Permissions API**, so we needed our own "they allowed before" signal. That assumption is outdated. A returning tester who had allowed once still had `locationOptIn=true`, so on the next visit — even with the browser set to "Ask" — we hit the fast path and called the geolocation API directly. Calling `getCurrentPosition`/`watchPosition` on a `prompt`/"Ask" origin is exactly what surfaces the **native** prompt, bypassing our soft-ask.

The deeper mistake: **deciding to call the geolocation API from a stored hint.** The API must only be called when it won't prompt, or after the user explicitly opts in.

## New findings — how the three engines actually behave

Researched and verified across engines:

| Engine | Permissions API for geolocation | Notable quirk |
|---|---|---|
| **Safari (desktop + iOS) 16+** | **Supported** (not unsupported, as we'd assumed) | "Deny" misreports as `prompt` (WebKit bug); "Allow without Remember" stays `prompt` |
| **Chrome 43+ / Android** | Supported, accurate | Dismissing the prompt keeps state `prompt` but won't re-show |
| **Firefox 46+** | Supported | Temporary grant (no "Remember this decision") historically reported `prompt`; [fixed in recent versions](https://bugzilla.mozilla.org/show_bug.cgi?id=1924572) |

Key invariant that makes the flow safe everywhere: `permissions.query()` **never** prompts, and the native prompt only fires on a geolocation API call. So as long as we only call the API on a reliable `granted` or an explicit Allow, **no engine can surface the native prompt before our soft-ask**. Every misreport above degrades to (at worst) a *redundant soft-ask*, never a surprise prompt.

## The fix

- Auto-trigger **only** when `query()` reports `granted` (the call is silent then).
- For `prompt` / `unsupported`, never call the geolocation API ourselves — show the deferred in-app soft-ask and `trigger()` only on the user's explicit **Allow**.
- Removed the now-dead `isLocationOptedIn` / `markLocationOptedIn` / `locationOptIn` localStorage flag and the `onGeolocate` marking.

### Resulting behavior

| Setting | `query()` | Behavior |
|---|---|---|
| Allow (any engine) | `granted` | tracks immediately, silent, no prompt |
| Safari/iOS "Ask" | `prompt` | soft-ask → Allow → native prompt ✅ (was: instant native prompt ❌) |
| Safari/iOS "Deny" | `prompt` (bug) | soft-ask → Allow → API errors silently (Safari can't report `denied`) |
| Chrome/Firefox prompt | `prompt` | soft-ask → Allow → native prompt |
| Chrome/Firefox denied | `denied` | never asked |
| Old browsers | `unsupported` | soft-ask → Allow → native prompt |


Follow-up to #598 (FRE-635).