### PR TITLE
fix: stop re-asking location with the in-app prompt on every iOS visit

### DIFF
--- a/packages/frontend-next/src/components/map/UserLocationControl.tsx
+++ b/packages/frontend-next/src/components/map/UserLocationControl.tsx
@@ -7,8 +7,10 @@ import { useGeolocation } from '@/contexts/Geolocation.context';
 import { useLegalDisclaimer } from '@/lib/legal-disclaimer';
 import {
   dismissLocationPrompt,
+  hasConsentedToLocation,
   isLocationPromptDismissed,
   LOCATION_PROMPT_DELAY_MS,
+  markLocationConsented,
   queryGeolocationPermission,
 } from '@/lib/location-prompt';
 
@@ -38,10 +40,11 @@ export function UserLocationControl() {
     control?.trigger();
   }, [notifyLoading]);
 
-  // Gate on disclaimer acceptance + map load. Only 'granted' tracks immediately (the API call is
-  // silent then); for 'prompt'/'unsupported' we must not call the API ourselves — on Safari/iOS
-  // that would surface the native prompt — so we show the deferred soft-ask and only trigger on
-  // the user's explicit Allow.
+  // Gate on disclaimer acceptance + map load. 'granted' tracks silently. A returning user who
+  // already accepted our soft-ask is also triggered directly: iOS scopes the grant to the session
+  // and keeps reporting 'prompt', so we rely on stored consent rather than re-nagging — the browser
+  // re-confirms natively if its session grant has lapsed. First-time 'prompt'/'unsupported' users
+  // get the deferred soft-ask; we never call the API ourselves before that.
   useEffect(() => {
     if (!map || !accepted) return;
 
@@ -52,11 +55,11 @@ export function UserLocationControl() {
       const permission = await queryGeolocationPermission();
       if (cancelled) return;
 
-      if (permission === 'granted') {
+      if (permission === 'denied') return;
+      if (permission === 'granted' || hasConsentedToLocation()) {
         trigger();
         return;
       }
-      if (permission === 'denied') return;
 
       if (isLocationPromptDismissed()) return;
       timer = window.setTimeout(() => {
@@ -77,6 +80,7 @@ export function UserLocationControl() {
 
   const handleAllow = () => {
     setShowPrompt(false);
+    markLocationConsented();
     trigger();
   };
 

--- a/packages/frontend-next/src/lib/location-prompt.ts
+++ b/packages/frontend-next/src/lib/location-prompt.ts
@@ -27,3 +27,26 @@ export function isLocationPromptDismissed(): boolean {
 export function dismissLocationPrompt(): void {
   dismissed = true;
 }
+
+// iOS Safari scopes a geolocation grant to the session and never reports it back through
+// permissions.query() (it stays 'prompt'), so once the user has accepted our soft-ask we remember
+// it here to avoid re-showing the in-app prompt on every visit; the browser re-confirms natively
+// when its own session grant lapses. Set only on an explicit in-app Allow, which guarantees the
+// soft-ask is shown at least once before we ever skip it.
+const CONSENT_KEY = 'locationConsented';
+
+export function hasConsentedToLocation(): boolean {
+  try {
+    return localStorage.getItem(CONSENT_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function markLocationConsented(): void {
+  try {
+    localStorage.setItem(CONSENT_KEY, 'true');
+  } catch {
+    // Ignore storage failures; worst case we show the soft-ask again on the next visit.
+  }
+}


### PR DESCRIPTION
## The bug

On iOS Safari, after allowing location once via the in-app soft-ask, returning to the page showed the **in-app prompt again on every visit**, while the **native popup never reappeared** and the per-site setting stayed at "Fragen" (Ask).

## Root cause — and the part that is iOS, not us

**iOS Safari scopes a geolocation grant to the session.** Tapping "Erlauben" in the native prompt grants location for that session only; it does **not** flip the per-site setting to "Allow", and `navigator.permissions.query({name:'geolocation'})` keeps returning `'prompt'` indefinitely (documented WebKit behavior — there is no persistent "remember" on the iOS prompt).

The previous change (#601) made the in-app soft-ask the gate for *every* `'prompt'` result. Since iOS always reports `'prompt'`, users got re-asked on every visit. We cannot detect prior consent through the Permissions API on iOS, so we must remember it ourselves.

## The fix

Distinguish **first-time** from **returning consenter**:

```ts
if (permission === 'denied') return;
if (permission === 'granted' || hasConsentedToLocation()) { trigger(); return; }
// first-time prompt/unsupported → deferred in-app soft-ask
```

- `hasConsentedToLocation()` reads a new `locationConsented` localStorage flag, set **only** when the user explicitly taps **Allow** in our in-app card. This guarantees the soft-ask is shown at least once before we ever skip it — so #601's behavior (first-timers always see the in-app prompt, never an uninvited native one) is preserved.
- A **new** localStorage key is used so stale `locationOptIn` values from the earlier build don't pre-qualify anyone.

### Resulting behavior (iOS Safari "Ask")

| Scenario | Behavior |
|---|---|
| First visit | soft-ask → Allow → native prompt → location |
| Return, same session | triggers directly → silent → dot, **no in-app prompt** |
| Return, new session (grant lapsed) | triggers directly → **browser's native prompt** reappears, **no in-app nag** |

Chrome / Firefox / Android persist the grant normally, so `query()` returns `granted` and they track silently with no prompts at all on return.

## What this does NOT (and can't) fix

The per-site setting staying at "Fragen" and the native prompt reappearing each new session is **inherent iOS Safari behavior** (session-scoped geolocation). The only way to stop all prompting is the user manually setting the site's Location to "Allow" in Safari's website settings (aA menu → Website Settings → Location → Allow). No web app can change that programmatically.

Follow-up to #601 / #598 (FRE-635).