### PR TITLE
perf: keep map warm across frontend-next navigation (FRE-642)

### DIFF
--- a/packages/frontend-next/src/components/map/PersistentMapView.tsx
+++ b/packages/frontend-next/src/components/map/PersistentMapView.tsx
@@ -1,0 +1,39 @@
+import { useRouterState } from '@tanstack/react-router';
+import { lazy, Suspense, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+// Load the map + maplibre-gl in parallel only once the map first mounts, keeping the
+// heavy bundle out of the shell and off map-less routes (/report, /privacy, /impressum).
+const MapView = lazy(() =>
+  Promise.all([import('@/components/map/Map'), import('maplibre-gl')]).then(([m]) => ({
+    default: m.MapView,
+  })),
+);
+
+// Map routes share the `/_map` id prefix; the `/reports` overview does not.
+const selectOnMapRoute = (s: { matches: { routeId: string }[] }) =>
+  s.matches.some((m) => m.routeId.startsWith('/_map'));
+
+/**
+ * Hosts a single map instance at the app shell so it survives navigation. The map mounts
+ * on the first map-route visit and stays mounted for the session; off-map routes only
+ * hide it, so returning is instant — no remount, no tile/style refetch.
+ */
+export function PersistentMapView() {
+  const onMapRoute = useRouterState({ select: selectOnMapRoute });
+  const [mounted, setMounted] = useState(false);
+  if (onMapRoute && !mounted) setMounted(true);
+
+  if (!mounted) return null;
+
+  // `invisible` (not `hidden`) keeps the full-viewport map sized and its WebGL context
+  // alive, and blocks pointer events while off-map.
+  return (
+    <div className={cn(!onMapRoute && 'invisible')}>
+      <Suspense fallback={null}>
+        <MapView />
+      </Suspense>
+    </div>
+  );
+}

--- a/packages/frontend-next/src/routes/__root.tsx
+++ b/packages/frontend-next/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import { createRootRoute, Outlet } from '@tanstack/react-router';
 
 import { ContributeCard } from '@/components/contribute/ContributeCard';
 import { LegalDisclaimer } from '@/components/LegalDisclaimer';
+import { PersistentMapView } from '@/components/map/PersistentMapView';
 import { GeolocationProvider } from '@/contexts/GeolocationProvider';
 
 export const Route = createRootRoute({
@@ -10,6 +11,7 @@ export const Route = createRootRoute({
   staticData: { legalDisclaimer: false },
   component: () => (
     <GeolocationProvider>
+      <PersistentMapView />
       <Outlet />
       <LegalDisclaimer />
       <ContributeCard />

--- a/packages/frontend-next/src/routes/_map.tsx
+++ b/packages/frontend-next/src/routes/_map.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router';
-import { lazy, Suspense } from 'react';
 
 import { LayerToggleButton } from '@/components/map/LayerToggleButton';
 import { ReportButton } from '@/components/map/ReportButton';
@@ -10,27 +9,13 @@ import { StatsPopUp } from '@/components/map/StatsPopUp';
 import { RefreshNotification } from '@/components/RefreshNotification';
 import { Toaster } from '@/components/ui/sonner';
 
-// Start downloading the map component and the maplibre-gl library in parallel
-// as soon as a map route loads, so the map downloads alongside the shell
-// instead of waterfalling behind it. react-map-gl lazy-imports maplibre-gl on
-// mount; priming it here removes that extra round-trip. Both promises feed the
-// lazy resolver below so the warm-up is not tree-shaken. The /report route does
-// not mount this layout, so it stays free of the map bundle.
-const mapModule = import('@/components/map/Map');
-const maplibreModule = import('maplibre-gl');
-
-const MapView = lazy(() =>
-  Promise.all([mapModule, maplibreModule]).then(([m]) => ({ default: m.MapView })),
-);
-
 export const Route = createFileRoute('/_map')({
   // Pathless layout — never the active leaf; its children declare their own flag.
+  // The map instance lives at the app shell (PersistentMapView in __root); this layout
+  // only holds the on-map controls and modals.
   staticData: { legalDisclaimer: false },
   component: () => (
     <>
-      <Suspense fallback={null}>
-        <MapView />
-      </Suspense>
       <StationSearch />
       <StatsPopUp />
       <RefreshNotification />


### PR DESCRIPTION
## Problem

The MapLibre map is mounted inside the `/_map` pathless layout. Navigating to a sibling route — `/reports` (a full-screen `z-30` overlay), `/report`, `/privacy`, `/impressum` — unmounts the whole layout, **destroying the map instance and its tile/style cache**. Returning re-runs the lazy chunk load and refetches the style + vector tiles, adding latency and unnecessary network work.

Closes FRE-642 / #596.

## Change

Host a single map instance at the **app shell** (`PersistentMapView` in `__root.tsx`) so it survives every page transition:

- Mounts on the **first map-route visit** and stays mounted for the session.
- Off-map routes only **hide** it via `visibility: hidden` (not `display: none`), which keeps the full-viewport map sized — no `map.resize()` on re-show, WebGL context preserved — and blocks pointer events.
- Map-route detection uses the `/_map` route-id prefix (`matches.some(m => m.routeId.startsWith('/_map'))`), so `/_map/reports/$stationId` counts as map while the `/reports` overview does not. No city-specific assumptions.
- `_map.tsx` keeps only the on-map controls/modals; the lazy `MapView` + maplibre prewarm moved to `PersistentMapView`.

Returning to the map is now instant — no remount, no tile refetch — and pan/zoom is preserved as a bonus.

## Bundle impact (no initial-load regression)

`maplibre-gl` and `Map` stay code-split and load in parallel on first map mount, so the shell and map-less routes are unaffected:

| Chunk (gzip) | before | after | Δ |
|---|---|---|---|
| `index.js` (shell) | 140.71 kB | 141.00 kB | +0.29 kB |
| `_map.js` | 5.66 kB | 5.38 kB | −0.28 kB |
| `maplibre-gl.js` (lazy) | 272.93 kB | 272.93 kB | — |
| `Map.js` (lazy) | 10.57 kB | 10.57 kB | — |
