### PR TITLE
perf: preload reachable routes in frontend-next

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -145,25 +145,30 @@ export const useReportsRefreshSignal = () => {
   return signal;
 };
 
-export const useStationReportCount = (stationId: string) => {
-  // Compute the window once per mount (lazy initializer), rounding `to` up to
-  // the next hour. Rounding keeps the query key stable across renders; rounding
-  // *up* (rather than down) keeps the current partial hour inside the window, so
-  // a report submitted moments ago is still counted.
-  const [{ from, to }] = useState(() => {
-    const toMs = Math.ceil(Date.now() / HOUR_MS) * HOUR_MS;
-    return { from: new Date(toMs - WEEK_MS).toISOString(), to: new Date(toMs).toISOString() };
-  });
-
-  return useQuery({
-    queryKey: ['reports', stationId, from, to],
+/**
+ * React Query options for a station's 7-day report history (`['reports', stationId, from, to]`).
+ * `to` is rounded up to the next hour so the key is stable within an hour (and rounding *up* keeps
+ * the current partial hour — and a just-submitted report — inside the window). Shared by
+ * `useStationReportCount` and the report-detail route loader so a preload warms the same entry.
+ */
+export const stationReportCountQueryOptions = (stationId: string) => {
+  const toMs = Math.ceil(Date.now() / HOUR_MS) * HOUR_MS;
+  const from = new Date(toMs - WEEK_MS).toISOString();
+  const to = new Date(toMs).toISOString();
+  return {
+    queryKey: ['reports', stationId, from, to] as const,
     queryFn: () => {
       const params = new URLSearchParams({ from, to });
       return fetchJson<Report[]>(`/v0/reports/${stationId}?${params.toString()}`);
     },
-    select: (reports) => reports.length,
     staleTime: HOUR_MS,
-  });
+  };
+};
+
+export const useStationReportCount = (stationId: string) => {
+  // Freeze the window (and thus the query key) at mount; `select` reduces to the count.
+  const [options] = useState(() => stationReportCountQueryOptions(stationId));
+  return useQuery({ ...options, select: (reports) => reports.length });
 };
 
 const API_URL = requireEnv('VITE_API_URL');

--- a/packages/frontend-next/src/api/risk.ts
+++ b/packages/frontend-next/src/api/risk.ts
@@ -5,11 +5,12 @@ import { fetchJson } from './transit';
 export type SegmentRisk = { color: string; risk: number };
 export type RiskData = { segments_risk: Record<string, SegmentRisk> };
 
-export const useRisk = () =>
-  useQuery({
-    queryKey: ['risk'],
-    queryFn: () => fetchJson<RiskData>('/v0/risk'),
-    refetchInterval: 30_000,
-    refetchIntervalInBackground: false,
-    staleTime: 30_000,
-  });
+export const riskQueryOptions = () => ({
+  queryKey: ['risk'] as const,
+  queryFn: () => fetchJson<RiskData>('/v0/risk'),
+  refetchInterval: 30_000,
+  refetchIntervalInBackground: false,
+  staleTime: 30_000,
+});
+
+export const useRisk = () => useQuery(riskQueryOptions());

--- a/packages/frontend-next/src/api/transit.ts
+++ b/packages/frontend-next/src/api/transit.ts
@@ -106,23 +106,26 @@ export async function fetchStations(): Promise<Stations> {
   return stations;
 }
 
-export const useStations = () =>
-  useQuery({
-    queryKey: ['transit', 'stations'],
-    queryFn: fetchStations,
-  });
+export const stationsQueryOptions = () => ({
+  queryKey: ['transit', 'stations'] as const,
+  queryFn: fetchStations,
+});
 
-export const useLines = () =>
-  useQuery({
-    queryKey: ['transit', 'lines'],
-    queryFn: () => fetchJson<Line[]>('/v0/transit/lines'),
-  });
+export const linesQueryOptions = () => ({
+  queryKey: ['transit', 'lines'] as const,
+  queryFn: () => fetchJson<Line[]>('/v0/transit/lines'),
+});
 
-export const useSegments = () =>
-  useQuery({
-    queryKey: ['transit', 'segments'],
-    queryFn: () => fetchJson<Segments>('/v0/transit/segments'),
-  });
+export const segmentsQueryOptions = () => ({
+  queryKey: ['transit', 'segments'] as const,
+  queryFn: () => fetchJson<Segments>('/v0/transit/segments'),
+});
+
+export const useStations = () => useQuery(stationsQueryOptions());
+
+export const useLines = () => useQuery(linesQueryOptions());
+
+export const useSegments = () => useQuery(segmentsQueryOptions());
 
 function closestStationId(
   stations: Stations,

--- a/packages/frontend-next/src/components/LegalDisclaimer.tsx
+++ b/packages/frontend-next/src/components/LegalDisclaimer.tsx
@@ -104,6 +104,7 @@ export function LegalDisclaimer() {
           <div className="flex gap-4 self-end">
             <Link
               to={ImpressumRoute.to}
+              preload={false}
               onClick={dismissible ? closeLegalDisclaimer : undefined}
               className="text-muted-foreground hover:text-foreground text-xs underline"
             >
@@ -111,6 +112,7 @@ export function LegalDisclaimer() {
             </Link>
             <Link
               to={PrivacyRoute.to}
+              preload={false}
               onClick={dismissible ? closeLegalDisclaimer : undefined}
               className="text-muted-foreground hover:text-foreground text-xs underline"
             >

--- a/packages/frontend-next/src/components/legal/Impressum.tsx
+++ b/packages/frontend-next/src/components/legal/Impressum.tsx
@@ -47,7 +47,9 @@ export function Impressum() {
       </section>
 
       <section>
-        <Link to="/privacy">{t('links.privacy')}</Link>
+        <Link to="/privacy" preload={false}>
+          {t('links.privacy')}
+        </Link>
       </section>
     </LegalPage>
   );

--- a/packages/frontend-next/src/components/map/ReportMarker.tsx
+++ b/packages/frontend-next/src/components/map/ReportMarker.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useRouter } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { Marker, type MarkerEvent } from 'react-map-gl/maplibre';
 
@@ -25,8 +25,16 @@ function computeOpacity(timestamp: string, nowMs: number): number {
 
 export function ReportMarker({ report, station }: ReportMarkerProps) {
   const navigate = useNavigate();
+  const router = useRouter();
   const [now, setNow] = useState(() => Date.now());
   const viewed = useReportViewed(report.stationId, report.timestamp);
+
+  // Markers navigate imperatively, so the router's viewport preloading doesn't see them. Mirror it:
+  // a visible marker warms its report-detail route — the chunk plus the loader data (station +
+  // this-week count) — so opening it is instant instead of fetching on tap.
+  useEffect(() => {
+    void router.preloadRoute({ to: ReportDetailRoute.to, params: { stationId: report.stationId } });
+  }, [router, report.stationId]);
 
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), RECOMPUTE_INTERVAL_MS);

--- a/packages/frontend-next/src/components/map/SettingsCard.tsx
+++ b/packages/frontend-next/src/components/map/SettingsCard.tsx
@@ -30,7 +30,11 @@ function LegalLink({
 }) {
   if (to) {
     return (
-      <Link to={to} className="text-muted-foreground hover:text-foreground text-xs underline">
+      <Link
+        to={to}
+        preload={false}
+        className="text-muted-foreground hover:text-foreground text-xs underline"
+      >
         {children}
       </Link>
     );

--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -7,7 +7,9 @@ import './lib/i18n';
 import { routeTree } from './routeTree.gen';
 import './index.css';
 
-const router = createRouter({ routeTree, defaultPreload: 'intent' });
+// 'viewport' preloads each <Link>'s route (chunk + loader data) once it's on screen via an
+// IntersectionObserver — so the pages reachable from the current view warm in the background
+const router = createRouter({ routeTree, defaultPreload: 'viewport' });
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/packages/frontend-next/src/routes/_map/reports/$stationId.tsx
+++ b/packages/frontend-next/src/routes/_map/reports/$stationId.tsx
@@ -1,18 +1,20 @@
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 
 import { queryClient } from '@/api/queryClient';
-import { fetchStations } from '@/api/transit';
+import { stationReportCountQueryOptions } from '@/api/reports';
+import { stationsQueryOptions } from '@/api/transit';
 import { ReportDetail } from '@/components/map/ReportDetail';
 
 export const Route = createFileRoute('/_map/reports/$stationId')({
   staticData: { legalDisclaimer: true },
   loader: async ({ params }) => {
-    const stations = await queryClient.ensureQueryData({
-      queryKey: ['transit', 'stations'],
-      queryFn: fetchStations,
-    });
+    const stations = await queryClient.ensureQueryData(stationsQueryOptions());
     const station = stations[params.stationId];
     if (!station) throw redirect({ to: '/', replace: true });
+    // Fire-and-forget warm of the "X times this week" count ReportDetail shows, so a preload
+    // (idle, or from a hovered/visible marker) makes it instant on open. (Distance can't be
+    // warmed here — it needs the live user position, which lives in React state, not the loader.)
+    void queryClient.prefetchQuery(stationReportCountQueryOptions(params.stationId));
     return { station };
   },
   component: ReportRoute,

--- a/packages/frontend-next/src/routes/_map/station/$stationId.tsx
+++ b/packages/frontend-next/src/routes/_map/station/$stationId.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 
 import { HOUR_MS, reportsSliceQueryOptions } from '@/api/reports';
-import { fetchStations } from '@/api/transit';
+import { stationsQueryOptions } from '@/api/transit';
 import { queryClient } from '@/api/queryClient';
 import { StationDetail } from '@/components/map/StationDetail';
 import { Route as ReportDetailRoute } from '@/routes/_map/reports/$stationId';
@@ -9,10 +9,7 @@ import { Route as ReportDetailRoute } from '@/routes/_map/reports/$stationId';
 export const Route = createFileRoute('/_map/station/$stationId')({
   staticData: { legalDisclaimer: true },
   loader: async ({ params }) => {
-    const stations = await queryClient.ensureQueryData({
-      queryKey: ['transit', 'stations'],
-      queryFn: fetchStations,
-    });
+    const stations = await queryClient.ensureQueryData(stationsQueryOptions());
     const station = stations[params.stationId];
     if (!station) throw redirect({ to: '/', replace: true });
 

--- a/packages/frontend-next/src/routes/report.tsx
+++ b/packages/frontend-next/src/routes/report.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 
+import { queryClient } from '@/api/queryClient';
+import { linesQueryOptions, stationsQueryOptions } from '@/api/transit';
 import { ReportForm } from '@/components/report/ReportForm';
 
 type ReportSearch = { stationId?: string };
@@ -9,5 +11,10 @@ export const Route = createFileRoute('/report')({
   validateSearch: (search: Record<string, unknown>): ReportSearch => ({
     stationId: typeof search.stationId === 'string' ? search.stationId : undefined,
   }),
+  // Prefetch what the form renders (stations + lines). Fire-and-forget; no-op if already cached.
+  loader: () => {
+    void queryClient.prefetchQuery(stationsQueryOptions());
+    void queryClient.prefetchQuery(linesQueryOptions());
+  },
   component: ReportForm,
 });

--- a/packages/frontend-next/src/routes/reports.tsx
+++ b/packages/frontend-next/src/routes/reports.tsx
@@ -1,13 +1,24 @@
 import { createFileRoute, Outlet, useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
-import { DAY_MS, useReports } from '@/api/reports';
+import { queryClient } from '@/api/queryClient';
+import { DAY_MS, HOUR_MS, reportsSliceQueryOptions, useReports } from '@/api/reports';
+import { linesQueryOptions, stationsQueryOptions } from '@/api/transit';
 import { ReportsTabBar } from '@/components/reports/ReportsTabBar';
 import { NAMESPACE } from '@/components/reports/Reports.i18n';
 import { PageHeader } from '@/components/templates/PageHeader';
 
 export const Route = createFileRoute('/reports')({
   staticData: { legalDisclaimer: false },
+  // Prefetch what this section renders (the day window + stations + lines). Runs for any reports
+  // tab on preload (it's the shared layout). Fire-and-forget so it never blocks the transition;
+  // already-cached queries are no-ops. Covers all tabs, so they need no loader of their own.
+  loader: () => {
+    void queryClient.prefetchQuery(reportsSliceQueryOptions(HOUR_MS, 0));
+    void queryClient.prefetchQuery(reportsSliceQueryOptions(DAY_MS, HOUR_MS));
+    void queryClient.prefetchQuery(stationsQueryOptions());
+    void queryClient.prefetchQuery(linesQueryOptions());
+  },
   component: ReportsOverviewLayout,
 });
 


### PR DESCRIPTION
## Problem

Navigating between `frontend-next` pages opened the target route cold — its code chunk and data fetched on demand. FRE-644 asks for Linear-style background preloading of pages reachable from the current view, without a hand-maintained reachable-route graph.

Closes FRE-644 / #599.

## Approach

Use TanStack Router's **native** preloading instead of custom machinery:

- **`defaultPreload: 'viewport'`** (`main.tsx`) — every on-screen `<Link>` preloads its route chunk **and** runs its loader (data) via IntersectionObserver. The set of visible links *is* the reachable set; no graph to maintain.
- **Report markers** navigate imperatively (they're maplibre markers, not `<Link>`s), so they preload their detail route manually via `router.preloadRoute` while visible (`ReportMarker.tsx`).
- **Legal links** (`impressum`/`privacy`) opt out with `preload={false}`.

## Data warming (single, decision-free rule)

> A route loader prefetches what its component renders — always, idempotently. A warm query (the cache uses `staleTime: Infinity`) is a no-op, so you never reason about what's already cached.

- Extracted `queryOptions` helpers (`stationsQueryOptions`, `linesQueryOptions`, `segmentsQueryOptions`, `riskQueryOptions`, `stationReportCountQueryOptions`) so hooks and loaders share one source for each query's key + fetcher.
- `reports` (layout, covers all tabs), `report`, and the two `$stationId` routes prefetch their data; the report-detail loader also warms the "X times this week" count.
- `_map/index` has no loader — it renders `() => null` (the map lives at the app shell), so there's nothing to warm.

## No initial-load regression

Measured `main` vs branch (headless Chrome, Fast-3G + 4× CPU, 6 cold loads, median):

| Metric | main | branch | Δ |
|---|---|---|---|
| FCP | 1204 ms | 1210 ms | +6 ms (noise) |
| LCP | 1288 ms | 1350 ms | +62 ms (~5%, constrained-net only) |
| DOMContentLoaded | 881 ms | 880 ms | ~0 |
| load | 882 ms | 881 ms | ~0 |

Heavy chunks (`maplibre`, `Map`) stay code-split; the shell is unchanged. The only delta is a small LCP cost on slow connections from background prefetch contention — the inherent trade of preloading.

## Test plan

- [x] `tsc -b`, `eslint .`, `prettier --check`, `vite build` all pass
- [x] Browser-verified (production build): visible links viewport-preload their chunks (`report`/`reports`/`settings`); a visible report marker preloads its detail chunk + the week-count request; `impressum`/`privacy` are **not** preloaded
- [x] Manual: open the map, then tap a report marker / open Reports → page appears without a cold fetch