### PR TITLE
perf: speed up frontend-next map load on mobile

### DIFF
--- a/packages/frontend-next/index.html
+++ b/packages/frontend-next/index.html
@@ -5,6 +5,12 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="icon" href="/favicon.ico" />
+    <!-- Open the TCP+TLS connections to the map-tile and API hosts during HTML parse, so the
+         handshakes are already done when maplibre requests tiles and the route loaders fetch
+         data (otherwise those connections open ~3-4s in, on the critical path to LCP).
+         crossorigin is required: both origins are reached via CORS fetch (vector tiles / JSON). -->
+    <link rel="preconnect" href="https://tiles.freifahren.org" crossorigin />
+    <link rel="preconnect" href="https://api.freifahren.org" crossorigin />
     <!-- Paints the iOS status-bar / dynamic-island area with the card color (matches the
          report form and the map search bar). Keep in sync with --card in src/index.css. -->
     <meta name="theme-color" content="#25272b" />

--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -1,8 +1,11 @@
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './Map.css';
 
+import { useState } from 'react';
 import { Map as MapGL } from 'react-map-gl/maplibre';
 
+import { useRisk } from '@/api/risk';
+import { useSegments } from '@/api/transit';
 import { requireEnv } from '@/lib/utils';
 
 import { LineLayer } from './LineLayer';
@@ -27,6 +30,14 @@ const MIN_ZOOM = 10;
 export function MapView() {
   const { selectedStation, handleMapClick } = useStationSelection();
   const { visible: riskVisible } = useRiskLayer();
+  const [baseMapReady, setBaseMapReady] = useState(false);
+
+  // Fetch the overlay data now — in parallel with the base-map style and tiles — even though we
+  // hold off *rendering* the overlays until the base map has painted (below). The fetches must
+  // not wait for the layers to mount, or the lines/reports would visibly lag the map. (Stations
+  // and reports are already warmed by useStationSelection; this covers the segments/risk data.)
+  useSegments();
+  useRisk();
 
   return (
     <div className="fixed inset-0">
@@ -37,11 +48,25 @@ export function MapView() {
         attributionControl={{ compact: true }}
         interactiveLayerIds={[STATIONS_LAYER_ID]}
         onClick={handleMapClick}
+        // Let the base map render its first frame before we add the GeoJSON sources and the
+        // report markers, so that overlay setup doesn't compete with the heaviest part of map
+        // init. The map is persistent, so this fires once per session.
+        onLoad={() => setBaseMapReady(true)}
+        // The style is baked and version-pinned by the tile-server, so re-validating its 89 layers
+        // against the spec on every load is wasted main-thread work at the most contended moment
+        // (and lets maplibre tree-shake the validator out). See maplibre MapOptions.validateStyle.
+        validateStyle={false}
+        // App is city-wide, so no world copies are visible.
+        renderWorldCopies={false}
       >
-        <StationsLayer selectedStation={selectedStation} />
-        {riskVisible ? <RiskLayer /> : <LineLayer />}
-        <ReportsLayer />
-        <UserLocationControl />
+        {baseMapReady && (
+          <>
+            <StationsLayer selectedStation={selectedStation} />
+            {riskVisible ? <RiskLayer /> : <LineLayer />}
+            <ReportsLayer />
+            <UserLocationControl />
+          </>
+        )}
       </MapGL>
     </div>
   );

--- a/packages/frontend-next/src/components/map/PersistentMapView.tsx
+++ b/packages/frontend-next/src/components/map/PersistentMapView.tsx
@@ -5,11 +5,23 @@ import { cn } from '@/lib/utils';
 
 // Load the map + maplibre-gl in parallel only once the map first mounts, keeping the
 // heavy bundle out of the shell and off map-less routes (/report, /privacy, /impressum).
-const MapView = lazy(() =>
+const importMap = () =>
   Promise.all([import('@/components/map/Map'), import('maplibre-gl')]).then(([m]) => ({
     default: m.MapView,
-  })),
-);
+  }));
+
+const MapView = lazy(importMap);
+
+// When the app *boots* directly onto a map page (the common case: the live map at `/`, and the
+// `/station/:id` deep-links), kick the heavy map chunk off immediately — in parallel with the
+// main bundle parsing and React mounting — instead of waiting for first render to discover the
+// dynamic import. That removes a ~0.5-1s serial step from the critical path to the map's first
+// paint. The import is module-cached, so the lazy() call below reuses this same in-flight fetch.
+// Other map routes (e.g. /settings) keep the lazy-on-mount path; they're rarely the entry point.
+if (typeof window !== 'undefined') {
+  const { pathname } = window.location;
+  if (pathname === '/' || pathname.startsWith('/station/')) void importMap();
+}
 
 // Map routes share the `/_map` id prefix; the `/reports` overview does not.
 const selectOnMapRoute = (s: { matches: { routeId: string }[] }) =>


### PR DESCRIPTION
## Why
Live mobile PageSpeed for `app.freifahren.org` is ~57 (LCP ~8s, FCP ~4.8s). Most users are on mobile, and a sizable share land on `/station/:id` deep-links. This trims the critical-path latency to the first map paint without changing behaviour.

## Changes (frontend-next only)
- **Preconnect** to `tiles.freifahren.org` + `api.freifahren.org` — handshakes finish during HTML parse instead of ~3–4s in.
- **Warm the maplibre + Map chunk in parallel** on `/` and `/station/*` entries — it downloads alongside the main bundle instead of after it executes (verified: maplibre request starts at ~40ms vs ~1950ms).
- **`validateStyle={false}`** — the style is server-baked and version-pinned, so re-validating its 89 layers on the main thread at init is wasted work (and lets maplibre tree-shake the validator). Per maplibre's own production guidance.
- **`renderWorldCopies={false}`** — city-wide app, so wrapped world copies are never visible; rendering them is pure overdraw.
- **Defer GeoJSON overlays + report markers to the base map's `onLoad`**, while still firing their data fetches immediately — overlay setup no longer competes with the heaviest part of map init, and the base map paints first.

## Verification
- `bun run build` + `bun run lint` clean.
- Screenshot-verified the base map and the full overlay (station dots, green segment network, report marker) render correctly with the deferral.
- Note: localhost can't measure the data-overlay cost because `api.freifahren.org` blocks CORS from localhost — real overlay-inclusive TBT (~890ms) only shows against the live origin. Re-measure with PageSpeed once deployed.

## Not addressed here (tracked separately)
- Oversized basemap tiles (the dominant real-world cost) — #604.
- The ~669ms Cloudflare bot-challenge JS — Cloudflare zone setting.