### PR TITLE
fix: re-arm the user location prompt after the overlay-deferral change

### DIFF
--- a/packages/frontend-next/src/components/map/UserLocationControl.tsx
+++ b/packages/frontend-next/src/components/map/UserLocationControl.tsx
@@ -64,14 +64,13 @@ export function UserLocationControl() {
       }, LOCATION_PROMPT_DELAY_MS);
     };
 
-    const start = () => void evaluate();
-    if (map.loaded()) start();
-    else map.once('load', start);
+    // Mounts only after the base map's `load` (gated by MapView), so don't wait on that one-shot
+    // event — it has already fired and won't fire again. Evaluate now.
+    void evaluate();
 
     return () => {
       cancelled = true;
       window.clearTimeout(timer);
-      map.off('load', start);
     };
   }, [map, accepted, trigger]);
 


### PR DESCRIPTION
## The bug

After the recent perf work, the browser **never** asks for location — neither our in-app soft-ask nor the native prompt ever appears.

## Root cause

#606 deferred the map overlays so they mount only after the base map paints, moving `<UserLocationControl />` behind the `baseMapReady` gate. As a result it now mounts **after** the map's one-shot `load` event and **in the same commit** as the overlay layers.

`UserLocationControl`'s effect chose its start path with:

```ts
if (map.loaded()) start();
else map.once('load', start);
```

The overlay layers (`StationsLayer`, `LineLayer`) add GeoJSON sources whose loading flips `map.loaded()` back to `false`. Their effects run before this control's (siblings, earlier in the tree), so at the moment this effect runs `map.loaded()` is `false` → it falls into `map.once('load', start)`. But `load` is one-shot and **already fired** (that's why `baseMapReady` is true and this component exists), so it never fires again. `evaluate()` never runs → no permission query, no soft-ask, no native prompt.

Before #606 the control mounted *with* the map while `load` was still pending, so it correctly caught the event.

## The fix

The control is now guaranteed to mount post-load, so the load-event gating is both unnecessary and broken. Evaluate directly.

## Test plan

- [x] `tsc -b` + `eslint` clean
- [ ] Manual: open `/`, accept the disclaimer, wait ~15s (`LOCATION_PROMPT_DELAY_MS`) → soft-ask appears → Allow → native prompt fires