### PR TITLE
chore: disallow crawling of the app subdomain

### DIFF
--- a/packages/frontend-next/public/robots.txt
+++ b/packages/frontend-next/public/robots.txt
@@ -1,0 +1,4 @@
+# app.freifahren.org is the web app, not our content surface. Disallow crawling
+# so it does not cannibalize freifahren.org in search results.
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Why

PageSpeed Insights reported `robots.txt is not valid — 42 errors found`, flagging lines of `<!doctype html>`, `<html>`, etc. as "Syntax not understood."

The cause: there was **no `robots.txt`**. Our Cloudflare assets config uses `not_found_handling: "single-page-application"`, so any unmatched path — including `/robots.txt` — returns `index.html` with a `200`. The crawler parsed our HTML shell as robots.txt directives.

## What

Add a real `public/robots.txt` (Vite copies it into `dist/`; Cloudflare serves static assets before the SPA fallback).

We **disallow all crawlers** rather than allow:

- `app.freifahren.org` is the web app, not a content surface — an SPA that serves the same `index.html` for every route, so there's little uniquely crawlable content.
- We don't want the app subdomain competing with **freifahren.org** for the same search terms and splitting ranking signals (cannibalization). SEO authority should sit with the main site.

```
User-agent: *
Disallow: /
```

## Verify

After deploy, `https://app.freifahren.org/robots.txt` returns the file above (not HTML), and the PageSpeed "Crawling and indexing" error clears.