### PR TITLE
Revert "App fix: add privacyPolicyMeta.json to next frontend"

### DIFF
--- a/packages/frontend-next/public/privacyPolicyMeta.json
+++ b/packages/frontend-next/public/privacyPolicyMeta.json
@@ -1,4 +1,0 @@
-{
-  "version": 5,
-  "lastModified": "2026-05-30"
-}


### PR DESCRIPTION
Reverts FreiFahren/FreiFahren#583

The app fetches this from the freifahren.org domain (not app subdomain) which is no longer redirected to the app because of the landing page, so this was not the solution