### PR TITLE
perf: drop IBM Plex Sans 500 weight and preload the 400 woff2

### DIFF
--- a/packages/frontend-next/src/components/LegalDisclaimer.tsx
+++ b/packages/frontend-next/src/components/LegalDisclaimer.tsx
@@ -81,11 +81,11 @@ export function LegalDisclaimer() {
         <CardContent className="min-h-0 flex-1 overflow-y-auto">
           <ol className="marker:text-muted-foreground list-decimal space-y-3 pl-5">
             <li>
-              <strong className="font-medium">{t('ticket')}</strong>
+              <strong className="font-semibold">{t('ticket')}</strong>
               <p className="text-muted-foreground mt-1 text-sm">{t('ticketDescription')}</p>
             </li>
             <li>
-              <strong className="font-medium">{t('activeUsage')}</strong>
+              <strong className="font-semibold">{t('activeUsage')}</strong>
               <p className="text-muted-foreground mt-1 text-sm">{t('activeUsageDescription')}</p>
             </li>
           </ol>

--- a/packages/frontend-next/src/components/RefreshNotification.tsx
+++ b/packages/frontend-next/src/components/RefreshNotification.tsx
@@ -19,7 +19,7 @@ export function RefreshNotification() {
     // the fixed id collapses near-simultaneous slice refetches into one toast instead of stacking.
     toast.custom(
       () => (
-        <ToastPill className="text-foreground flex w-fit items-center gap-2 text-sm font-medium">
+        <ToastPill className="text-foreground flex w-fit items-center gap-2 text-sm font-semibold">
           <RefreshCw className="size-4 animate-spin" />
           {i18n.t('refreshed', { ns: NAMESPACE })}
         </ToastPill>

--- a/packages/frontend-next/src/components/contribute/ContributeCard.tsx
+++ b/packages/frontend-next/src/components/contribute/ContributeCard.tsx
@@ -127,7 +127,7 @@ function BankTab() {
           >
             <div className="min-w-0">
               <p className="text-muted-foreground text-xs">{row.label}</p>
-              <p className="truncate text-sm font-medium">{row.value}</p>
+              <p className="truncate text-sm font-semibold">{row.value}</p>
             </div>
             <Button
               variant="ghost"

--- a/packages/frontend-next/src/components/legal/LegalPage.tsx
+++ b/packages/frontend-next/src/components/legal/LegalPage.tsx
@@ -10,7 +10,7 @@ const ARTICLE_CLASS = [
   'min-h-0 flex-1 overflow-y-auto px-4 pt-1 pb-10 text-sm leading-relaxed text-muted-foreground',
   '[&_section]:mt-6 [&_section:first-child]:mt-0 [&_section]:space-y-2',
   '[&_h2]:text-foreground [&_h2]:text-base [&_h2]:font-semibold',
-  '[&_h3]:text-foreground [&_h3]:font-medium [&_h3]:pt-1',
+  '[&_h3]:text-foreground [&_h3]:font-semibold [&_h3]:pt-1',
   '[&_ul]:list-disc [&_ul]:space-y-1 [&_ul]:pl-5 [&_li]:marker:text-muted-foreground',
   '[&_a]:text-foreground [&_a]:break-words [&_a]:underline',
 ].join(' ');

--- a/packages/frontend-next/src/components/map/ContactCard.tsx
+++ b/packages/frontend-next/src/components/map/ContactCard.tsx
@@ -61,7 +61,7 @@ export function ContactCard({ onClose }: ContactCardProps) {
               alt=""
               className="bg-muted size-8 shrink-0 rounded-full object-cover"
             />
-            <span className="text-sm font-medium">{member.name}</span>
+            <span className="text-sm font-semibold">{member.name}</span>
             <div className="ml-auto flex items-center gap-1">
               {member.channels.map((channel) => {
                 const Icon = CHANNEL_ICON[channel.type];

--- a/packages/frontend-next/src/components/map/LayerToggleButton.tsx
+++ b/packages/frontend-next/src/components/map/LayerToggleButton.tsx
@@ -27,7 +27,7 @@ export function LayerToggleButton() {
         )}
       >
         <Layers className="size-5" />
-        <span className="text-[11px] leading-none font-medium">{t('risk')}</span>
+        <span className="text-[11px] leading-none font-semibold">{t('risk')}</span>
       </Button>
     </div>
   );

--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -44,7 +44,7 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
       {(lineName || directionName) && (
         <CardContent className="flex items-center gap-2">
           {lineName && <LineBadge name={lineName} />}
-          {directionName && <span className="text-sm font-medium">{directionName}</span>}
+          {directionName && <span className="text-sm font-semibold">{directionName}</span>}
         </CardContent>
       )}
       <CardContent className="space-y-1">

--- a/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
+++ b/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
@@ -50,7 +50,7 @@ export function ReportsOverviewButton() {
           </div>
           <div className="flex items-center gap-2">
             {lineName && <LineBadge name={lineName} />}
-            <span className="flex-1 truncate text-sm font-medium">{stationName}</span>
+            <span className="flex-1 truncate text-sm font-semibold">{stationName}</span>
             {!latestViewed && (
               <span className="relative ml-auto block size-2 shrink-0">
                 <span className="bg-destructive absolute inset-0 animate-ping rounded-full opacity-75" />

--- a/packages/frontend-next/src/components/map/StationDetail.tsx
+++ b/packages/frontend-next/src/components/map/StationDetail.tsx
@@ -31,7 +31,7 @@ export function StationDetail({ station, onClose }: StationDetailProps) {
         <Button
           asChild
           variant="default"
-          className="bg-destructive hover:bg-destructive/90 h-11 w-full text-sm font-medium text-white"
+          className="bg-destructive hover:bg-destructive/90 h-11 w-full text-sm font-semibold text-white"
         >
           <Link to={ReportRoute.to} search={{ stationId: station.id }}>
             {t('reportSighting')}

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -187,7 +187,7 @@ function StationPicker() {
       </div>
 
       {stationId ? (
-        <div className="bg-muted flex items-center rounded-md px-3 py-2.5 text-sm font-medium">
+        <div className="bg-muted flex items-center rounded-md px-3 py-2.5 text-sm font-semibold">
           {visibleStations[0]?.name}
         </div>
       ) : (
@@ -255,7 +255,7 @@ function DirectionPicker() {
                 onClick={() => selectDirection(isSelected ? null : station.id)}
                 className={cn(
                   'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm outline-none',
-                  isSelected && 'bg-muted font-medium',
+                  isSelected && 'bg-muted font-semibold',
                 )}
               >
                 <ChevronRight className="text-muted-foreground size-5 shrink-0" />
@@ -284,7 +284,7 @@ function SubmitFooter({ onSubmitted }: { onSubmitted: (result: SubmitReportRespo
     if (rejection) {
       toast.custom(
         () => (
-          <ToastPill className="text-destructive flex w-fit items-center gap-2 text-sm font-medium">
+          <ToastPill className="text-destructive flex w-fit items-center gap-2 text-sm font-semibold">
             <TriangleAlert className="size-4" />
             {t(REJECTION_MESSAGE[rejection])}
           </ToastPill>
@@ -312,7 +312,7 @@ function SubmitFooter({ onSubmitted }: { onSubmitted: (result: SubmitReportRespo
         disabled={disabled}
         onClick={handleSubmit}
         className={cn(
-          'h-12 w-full rounded-lg text-base font-medium',
+          'h-12 w-full rounded-lg text-base font-semibold',
           canSubmit
             ? 'bg-accent-bright text-primary-foreground hover:bg-accent-press shadow-[0_6px_16px_rgba(214,59,59,0.28)]'
             : 'bg-surface-solid text-muted-foreground border-border border',

--- a/packages/frontend-next/src/components/report/ReportSuccess.tsx
+++ b/packages/frontend-next/src/components/report/ReportSuccess.tsx
@@ -37,7 +37,7 @@ export function ReportSuccess({
       {stationName && (
         <div className="mt-4 flex items-center gap-2">
           {lineName && <LineBadge name={lineName} />}
-          <span className="text-sm font-medium">{stationName}</span>
+          <span className="text-sm font-semibold">{stationName}</span>
         </div>
       )}
 
@@ -56,7 +56,7 @@ export function ReportSuccess({
         type="button"
         size="lg"
         onClick={onClose}
-        className="bg-accent-bright text-primary-foreground hover:bg-accent-press mt-4 h-12 w-full rounded-lg text-base font-medium shadow-[0_6px_16px_rgba(214,59,59,0.28)]"
+        className="bg-accent-bright text-primary-foreground hover:bg-accent-press mt-4 h-12 w-full rounded-lg text-base font-semibold shadow-[0_6px_16px_rgba(214,59,59,0.28)]"
       >
         {t('continue')}
       </Button>

--- a/packages/frontend-next/src/components/transit/StationListItem.tsx
+++ b/packages/frontend-next/src/components/transit/StationListItem.tsx
@@ -31,7 +31,7 @@ export function StationListItem({ station, onClick, selected }: StationListItemP
       onClick={onClick}
       className={cn(
         'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left outline-none',
-        selected && 'bg-muted font-medium',
+        selected && 'bg-muted font-semibold',
       )}
     >
       <span className="shrink-0 text-sm">{station.name}</span>

--- a/packages/frontend-next/src/components/ui/badge.tsx
+++ b/packages/frontend-next/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { Slot } from 'radix-ui';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  'group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-[0.625rem] font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-2.5!',
+  'group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-[0.625rem] font-semibold whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-2.5!',
   {
     variants: {
       variant: {

--- a/packages/frontend-next/src/components/ui/button.tsx
+++ b/packages/frontend-next/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from 'radix-ui';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-sm border border-transparent bg-clip-padding text-xs/relaxed font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-sm border border-transparent bg-clip-padding text-xs/relaxed font-semibold whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/packages/frontend-next/src/components/ui/card.tsx
+++ b/packages/frontend-next/src/components/ui/card.tsx
@@ -37,7 +37,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-title"
-      className={cn('font-heading text-sm font-medium', className)}
+      className={cn('font-heading text-sm font-semibold', className)}
       {...props}
     />
   );

--- a/packages/frontend-next/src/components/ui/input.tsx
+++ b/packages/frontend-next/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'border-input bg-input/20 file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-9 w-full min-w-0 rounded-md border px-3 py-1 text-sm transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-2',
+        'border-input bg-input/20 file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-9 w-full min-w-0 rounded-md border px-3 py-1 text-sm transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-semibold focus-visible:ring-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-2',
         className,
       )}
       {...props}

--- a/packages/frontend-next/src/components/ui/tabs.tsx
+++ b/packages/frontend-next/src/components/ui/tabs.tsx
@@ -30,7 +30,7 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "focus-visible:ring-ring/30 inline-flex items-center justify-center gap-1.5 rounded-sm px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus-visible:ring-ring/30 inline-flex items-center justify-center gap-1.5 rounded-sm px-2 py-1 text-sm font-semibold whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/packages/frontend-next/src/components/ui/toggle.tsx
+++ b/packages/frontend-next/src/components/ui/toggle.tsx
@@ -5,7 +5,7 @@ import { Toggle as TogglePrimitive } from 'radix-ui';
 import { cn } from '@/lib/utils';
 
 const toggleVariants = cva(
-  "group/toggle inline-flex items-center justify-center gap-1 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-md text-sm font-semibold whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/packages/frontend-next/src/index.css
+++ b/packages/frontend-next/src/index.css
@@ -3,7 +3,6 @@
 @import 'shadcn/tailwind.css';
 
 @import '@fontsource/ibm-plex-sans/latin-400.css';
-@import '@fontsource/ibm-plex-sans/latin-500.css';
 @import '@fontsource/ibm-plex-sans/latin-600.css';
 
 @custom-variant dark (&:is(.dark *));

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -1,9 +1,45 @@
 import path from 'node:path';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react, { reactCompilerPreset } from '@vitejs/plugin-react';
 import babel from '@rolldown/plugin-babel';
 import tailwindcss from '@tailwindcss/vite';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
+
+// The 400 (regular) weight is our body font and is on the critical render path, but it's only
+// discovered after the CSS chain resolves (index.html -> index.css -> @font-face), several round
+// trips in on a slow connection. Inject a <link rel="preload"> so the browser starts fetching it
+// during HTML parse. The filename is content-hashed, so we read the emitted name from the bundle
+// rather than hard-coding it. `crossorigin` is required: font fetches are always CORS-mode, so
+// without it the preload wouldn't match the actual request and would be downloaded twice.
+function preloadPrimaryFont(): Plugin {
+  return {
+    name: 'preload-primary-font',
+    transformIndexHtml(html, ctx) {
+      const font = ctx.bundle
+        ? Object.keys(ctx.bundle).find((file) =>
+            /ibm-plex-sans-latin-400-normal-[^/]*\.woff2$/.test(file),
+          )
+        : undefined;
+      if (!font) return html;
+      return {
+        html,
+        tags: [
+          {
+            tag: 'link',
+            attrs: {
+              rel: 'preload',
+              as: 'font',
+              type: 'font/woff2',
+              href: `/${font}`,
+              crossorigin: '',
+            },
+            injectTo: 'head',
+          },
+        ],
+      };
+    },
+  };
+}
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -12,6 +48,7 @@ export default defineConfig({
     react(),
     babel({ presets: [reactCompilerPreset({ target: '19' })] }),
     tailwindcss(),
+    preloadPrimaryFont(),
   ],
   server: {
     port: 1871,


### PR DESCRIPTION
Closes #614.

Reduces font payload and removes a render-blocking font fetch — aimed at low-bandwidth / low-end-device users (riders on the subway).

## Changes

- **Drop the IBM Plex Sans 500 weight.** It shipped on every load (~24 kB woff2 + a woff fallback) but is visually close to 600. Removed the `latin-500.css` import from `src/index.css`.
- **Fold `font-medium` → `font-semibold` (600).** Emphasized UI (buttons, selected list items, labels, badges) keeps its weight at 600 instead of silently falling back to 400. CSS font matching resolves a requested 500 to the 400 face when 500 isn't defined, so an explicit remap avoids an unintended lightening across ~18 components.
- **Preload the 400 (body) woff2.** It's on the critical render path but only discovered after the `index.html → index.css → @font-face` chain — several round trips in on a slow link. A small Vite plugin (`preloadPrimaryFont`) reads the content-hashed filename from the build bundle and injects `<link rel="preload" as="font" type="font/woff2" crossorigin>`, so the fetch starts during HTML parse without hard-coding the hash. `crossorigin` is required so the preload matches the CORS-mode font fetch (otherwise it'd download twice).

## Verification

- `bun run build` — only `ibm-plex-sans-latin-400` and `-600` font assets emitted (500 gone); built `dist/index.html` contains the injected preload link pointing at the hashed 400 woff2.
- `bun run lint` — clean.
- `bun run format:check` — clean.

## Note for review

Folding to **600** makes medium-weight UI text slightly heavier. If any spot looks too bold, it can be moved to `font-normal` individually — but the default here preserves the existing emphasis hierarchy.

---

Part of the low-bandwidth findings set (#610–#615). The sonner replacement (#615) is now a separate PR.