### PR TITLE
perf: serve hashed assets with immutable Cache-Control via _headers

### DIFF
--- a/packages/frontend-next/public/_headers
+++ b/packages/frontend-next/public/_headers
@@ -1,0 +1,16 @@
+# Honored by Cloudflare Workers static assets (wrangler.jsonc -> assets.directory).
+# Vite copies this file from public/ to the dist/ root at build time.
+#
+# Everything under /assets/ is emitted by Vite with a content hash in the filename
+# (index-BVAEI_dW.js, ibm-plex-sans-latin-400-normal-CDDApCn2.woff2, ...), so a URL's
+# content can never change — a new build gets a new filename via index.html. Without
+# this rule the assets are served `max-age=0, must-revalidate`, which makes the browser
+# re-validate every JS/CSS/font file on every app open: one conditional round trip per
+# file that stalls on flaky subway connections and fails entirely offline. Cloudflare's
+# edge cache doesn't help here — it only speeds up the server side; this header is what
+# lets the *browser* skip the network entirely.
+#
+# index.html is not under /assets/ and keeps the default revalidation behavior, so
+# deploys still roll out immediately.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
Closes #610.

One static file, no app-code change: `packages/frontend-next/public/_headers`, which Vite copies to the `dist/` root and Cloudflare Workers static assets honors.

```
/assets/*
  Cache-Control: public, max-age=31536000, immutable
```

## Why Cloudflare's edge caching doesn't already cover this

The live assets show `cf-cache-status: HIT` — but that's the **server-side** cache. The response header is still `cache-control: public, max-age=0, must-revalidate`, and that header is an instruction to the **browser**: re-validate this file on every use. So every app open currently does one conditional request (`If-None-Match` → `304`) per asset — `index-*.js` (~207 kB gz), CSS, the maplibre chunk, every font file. The edge makes those round trips *fast*, but it can't make them *zero*, and on a flaky subway connection each one can stall the load. Offline, they fail outright.

`immutable` + 1-year `max-age` tells the browser it may serve these files from disk cache without ever asking the network. That's safe because everything under `/assets/` is content-hashed by Vite — a changed file gets a new filename, referenced by a fresh `index.html`.

## What keeps deploys instant

`index.html` lives at the root, not under `/assets/`, so it's not matched by the rule and keeps the default `max-age=0, must-revalidate` — every visit picks up the newest asset references immediately.

## Verification

- `bun run build` — `_headers` is copied to `dist/_headers` with the rule intact.
- `bun run lint` / `bun run format:check` — clean.
- After the next deploy, verify with:
  ```
  curl -sI https://app.freifahren.org/assets/<any-hashed-file> | grep -i cache-control
  # expect: cache-control: public, max-age=31536000, immutable
  ```

## Expected impact

Returning visitors (the common case for a daily-commute app) load the entire JS/CSS/font shell from disk cache with **zero network requests** — faster startup on slow links, and a prerequisite for the planned offline work (#612, #613).

---

Part of the low-bandwidth findings set (#610–#615).

---
_Generated by [Claude Code](https://claude.ai/code/session_018U2hMXAP7EPmivUwY2zBXU)_