### PR TITLE
perf: shrink basemap vector tiles by dropping undrawn data

### DIFF
--- a/packages/tile-server/tilemaker/config-freifahren.json
+++ b/packages/tile-server/tilemaker/config-freifahren.json
@@ -16,11 +16,6 @@
       "filter_below": 13,
       "filter_area": 0.00000001
     },
-    "housenum_label": {
-      "minzoom": 14,
-      "maxzoom": 14,
-      "combine_points": true
-    },
     "landuse": {
       "minzoom": 5,
       "maxzoom": 14,
@@ -29,21 +24,6 @@
       "combine_polygons_below": 8,
       "simplify_below": 12,
       "simplify_level": 0.00008
-    },
-    "natural_label": {
-      "minzoom": 0,
-      "maxzoom": 14,
-      "combine_points": true
-    },
-    "place_label": {
-      "minzoom": 1,
-      "maxzoom": 14,
-      "combine_points": true
-    },
-    "poi_label": {
-      "minzoom": 10,
-      "maxzoom": 14,
-      "combine_points": true
     },
     "road": {
       "minzoom": 5,
@@ -56,11 +36,6 @@
     "structure": {
       "minzoom": 13,
       "maxzoom": 14
-    },
-    "transit_label": {
-      "minzoom": 11,
-      "maxzoom": 14,
-      "combine_points": true
     },
     "water": {
       "minzoom": 0,

--- a/packages/tile-server/tilemaker/process-freifahren.lua
+++ b/packages/tile-server/tilemaker/process-freifahren.lua
@@ -1,17 +1,4 @@
-node_keys = {
-  "addr:housenumber",
-  "amenity",
-  "highway",
-  "leisure",
-  "name",
-  "natural",
-  "place",
-  "public_transport",
-  "railway",
-  "shop",
-  "station",
-  "tourism"
-}
+node_keys = {}
 
 ZRES9 = 305.7
 ZRES10 = 152.9
@@ -27,9 +14,7 @@ way_keys = {
   "highway",
   "landuse",
   "leisure",
-  "name",
   "natural",
-  "oneway",
   "railway",
   "tunnel",
   "water",
@@ -44,26 +29,6 @@ function first_non_empty(...)
     end
   end
   return ""
-end
-
-function add_names()
-  local name = Find("name")
-  if name ~= "" then
-    Attribute("name", name)
-  end
-
-  local name_ltn = first_non_empty(Find("name:latin"), Find("int_name"), Find("name:en"))
-  if name_ltn ~= "" and name_ltn ~= name then
-    Attribute("name_ltn", name_ltn)
-  end
-
-  local languages = { "de", "en", "es", "fr", "it", "ja", "ko", "nl", "ru", "zh" }
-  for _, lang in ipairs(languages) do
-    local translated = Find("name:" .. lang)
-    if translated ~= "" then
-      Attribute("name_" .. lang, translated)
-    end
-  end
 end
 
 function add_structure()
@@ -135,16 +100,17 @@ function road_z_order(class)
   return orders[class] or 0
 end
 
+-- Matches the earliest zoom at which the style actually draws each class
+-- (see styles/rewrite-style.mjs output) so tiles never carry invisible geometry.
 function road_minzoom(class, type)
   if class == "motorway" or class == "motorway_link" then return 5 end
   if class == "main" and type == "trunk" then return 7 end
   if class == "main" and type == "primary" then return 8 end
   if class == "main" then return 9 end
-  if class == "major_rail" then return 10 end
-  if class == "minor_rail" then return 11 end
-  if class == "street" then return 11 end
-  if class == "street_limited" then return 12 end
-  if class == "service" or class == "driveway" or class == "path" then return 13 end
+  if class == "major_rail" then return 12 end
+  if class == "minor_rail" then return 12 end
+  if class == "street" then return 12 end
+  if class == "service" then return 13 end
 
   return 14
 end
@@ -190,43 +156,9 @@ function should_emit_landuse(class, area)
   return true
 end
 
+-- The style renders no symbol layers (rewrite-style.mjs strips every layer with
+-- text-field/icon-image), so no label layers or name attributes are emitted.
 function node_function()
-  local place = Find("place")
-  if place ~= "" then
-    Layer("place_label", false)
-    Attribute("class", place)
-    add_names()
-    if place == "city" then MinZoom(3)
-    elseif place == "town" then MinZoom(6)
-    else MinZoom(10) end
-  end
-
-  local railway = Find("railway")
-  local station = Find("station")
-  local public_transport = Find("public_transport")
-  if railway == "station" or railway == "halt" or station ~= "" or public_transport == "station" then
-    Layer("transit_label", false)
-    Attribute("class", first_non_empty(railway, public_transport, station))
-    add_names()
-    MinZoom(11)
-  end
-
-  local amenity = Find("amenity")
-  local shop = Find("shop")
-  local tourism = Find("tourism")
-  if amenity ~= "" or shop ~= "" or tourism ~= "" then
-    Layer("poi_label", false)
-    Attribute("class", first_non_empty(amenity, shop, tourism))
-    add_names()
-    MinZoom(13)
-  end
-
-  local house_num = Find("addr:housenumber")
-  if house_num ~= "" then
-    Layer("housenum_label", false)
-    Attribute("house_num", house_num)
-    MinZoom(14)
-  end
 end
 
 function way_function()
@@ -252,7 +184,6 @@ function way_function()
   if landuse ~= "" and is_area and should_emit_landuse(landuse, Area()) then
     Layer("landuse", true)
     Attribute("class", landuse)
-    add_names()
     MinZoom(landuse_minzoom(landuse))
   end
 
@@ -261,7 +192,6 @@ function way_function()
   if is_area and (natural == "water" or water ~= "" or Find("waterway") == "riverbank") and should_emit_water(first_non_empty(water, natural, "water"), Area()) then
     Layer("water", true)
     Attribute("class", first_non_empty(water, natural, "water"))
-    add_names()
   end
 
   local waterway = Find("waterway")
@@ -269,7 +199,6 @@ function way_function()
     Layer("waterway", false)
     Attribute("class", waterway)
     add_structure()
-    add_names()
   end
 
   local building = Find("building")
@@ -318,16 +247,7 @@ function way_function()
     Layer("road", is_area)
     Attribute("class", class)
     Attribute("type", type)
-    AttributeBoolean("oneway", Find("oneway") == "yes" or Find("oneway") == "1" or Find("oneway") == "true")
     add_structure()
-    add_names()
-    local ref = Find("ref")
-    if ref ~= "" then
-      Attribute("ref", ref)
-      AttributeNumeric("reflen", string.len(ref))
-    end
-    local access = Find("access")
-    if access ~= "" then Attribute("access", access) end
     MinZoom(road_minzoom(class, type))
     ZOrder(road_z_order(class))
   end

--- a/packages/tile-server/tileserver/compose.yaml
+++ b/packages/tile-server/tileserver/compose.yaml
@@ -1,6 +1,6 @@
 services:
   tileserver:
-    image: ghcr.io/maplibre/martin:v0.13.0
+    image: ghcr.io/maplibre/martin:1.8.2
     command: ["--config", "/config/config.yaml"]
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary

Basemap vector tiles served from Martin (`tiles.freifahren.org`) were far larger than they should be — a Berlin viewport pulled ~880 KB of tiles, with the single z11 tile at **320 KB**. This regenerates the tiles to drop data the style never draws. Closes #604.

The MapLibre style renders **zero symbol layers** (it has no glyphs/sprite, and `rewrite-style.mjs` strips every layer with `text-field`/`icon-image`), and from the `road` layer it only ever reads `class`, `type`, and `structure`. Yet the tiles carried five label layers, 12 `name_*` fields per labeled feature, and road geometry at zoom levels below where the style actually draws it. All pure dead weight.

## Findings

Decoding the 320 KB z11 tile showed the `road` layer was ~80% of it — **27,598 road features**, of which ~67% were residential streets and rail the style doesn't draw until z12. The tile minzooms in `road_minzoom()` didn't match the style's layer minzooms:

| class | was in tiles from | style draws from |
| -- | -- | -- |
| `street` (residential) | z11 | z12 |
| `major_rail` | z10 | z12 |
| `minor_rail` | z11 | z12 |
| `street_limited`, `driveway`, `path` | z12–z13 | z14 |

## Changes

**`tilemaker/process-freifahren.lua`**
- Align `road_minzoom()` to the zoom the style first draws each class (street/major_rail/minor_rail z11→z12; street_limited/driveway/path → z14). `service` stays z13.
- Delete `add_names()` and the unused `oneway`/`ref`/`reflen`/`access` road attributes — the style references none of them.
- Empty `node_function()` and `node_keys` — every node emitted only to label layers.

**`tilemaker/config-freifahren.json`**
- Remove the dead `place_label`, `transit_label`, `poi_label`, `housenum_label`, `natural_label` layer definitions.

**`tileserver/compose.yaml`** (Martin version)
- Bump the local image `v0.13.0` → `1.8.2` to match the `Dockerfile`/production. `v0.13.0` predates the current config schema (top-level `styles:` block, `cache.size_mb`) and crash-loops with `Unable to parse config file … OptOneMany`, so `serve` was broken locally. **Local-dev only** — production already builds on 1.8.2, so this changes nothing about what's deployed.

## Impact — measured (gzipped, over the wire vs. regenerated)

| Tile | Production (before) | After | Change |
| -- | -- | -- | -- |
| z11/1100/671 | 320 KB | 117 KB | **−64%** |
| z12/2200/1342 | 141 KB | 112 KB | −20% |
| z13/4402/2686 | 194 KB | 58 KB | **−70%** |
| z14/8801/5374 | 104 KB | 80 KB | −23% |

z11 road feature count: **27,598 → 9,425** (all of which the style actually draws). Less to download, and less for MapLibre to decode/parse on weak phones.

## Verification

- Regenerated the `.mbtiles` from a fresh Berlin extract with the new config; decoded the tiles to confirm label layers are gone and roads carry only `class`/`type`/`structure`.
- Confirmed the live production style is byte-identical to `source/freifahren-style.json` post-rewrite (89 layers), so the minzoom mapping is correct against what's deployed.
- Served the new tiles through Martin 1.8.2 locally and pixel-diffed prod-vs-new renders at z10–z14: **0.00–0.07% differing pixels**, and the only visible diff is one building that genuinely changed in OSM since prod's extract. No visual regression.

## Deploy / cache busting

Tiles are baked into the image and served `immutable` behind Cloudflare. Invalidation is automatic via the `?v=<BUILD_SHA>` token in the style — each deploy bakes a new SHA, so the edge sees new tile URLs and fetches fresh tiles. Requires Coolify's `BUILD_SHA=${SOURCE_COMMIT}` build variable to be set (it already is for prior deploys to have busted correctly).
