### PR TITLE
fix: stats pill no longer leaks onto non-map routes (FRE-653)

### DIFF
--- a/packages/frontend-next/src/components/ui/toaster.tsx
+++ b/packages/frontend-next/src/components/ui/toaster.tsx
@@ -1,7 +1,7 @@
-import { useSyncExternalStore } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 
 import { cn } from '@/lib/utils';
-import { getToasts, subscribeToasts } from '@/lib/toast';
+import { clearToasts, getToasts, subscribeToasts } from '@/lib/toast';
 
 /**
  * Renders the toast stack (see `@/lib/toast`) top-center, below the floating search bar.
@@ -10,6 +10,11 @@ import { getToasts, subscribeToasts } from '@/lib/toast';
  */
 export function Toaster() {
   const toasts = useSyncExternalStore(subscribeToasts, getToasts);
+
+  // The toast store is a module global that outlives this route-scoped component. Drop any
+  // lingering toasts when leaving the map layout so a pill fired here (e.g. the stats popup)
+  // can't survive the route transition and stay painted on a non-map route like /report (FRE-653).
+  useEffect(() => clearToasts, []);
 
   if (toasts.length === 0) return null;
 

--- a/packages/frontend-next/src/lib/toast.ts
+++ b/packages/frontend-next/src/lib/toast.ts
@@ -84,3 +84,20 @@ export const toast = {
     startExit(id);
   },
 };
+
+/**
+ * Drops every toast immediately (no exit animation) and cancels their timers. Called when the
+ * map-scoped <Toaster> unmounts (the user leaving the map for /report, /reports, etc.). The store
+ * is a module global that outlives the route: a toast fired on the map keeps its live timer and
+ * stays in the store, and during the route transition the <Toaster>'s `position: fixed` node can
+ * be carried into the incoming route's subtree — so the stats pill stays painted on top of a
+ * non-map page (FRE-653). Emptying the store on unmount makes the <Toaster> render nothing,
+ * enforcing the invariant that toasts only ever live on the map.
+ */
+export function clearToasts() {
+  for (const timer of timers.values()) clearTimeout(timer);
+  timers.clear();
+  if (toasts.length === 0) return;
+  toasts = [];
+  emit();
+}

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -113,7 +113,11 @@ export default defineConfig({
     port: 1871,
   },
   preview: {
-    port: 1871,
+    // Deliberately a different port from `server`: `preview` ships the real service worker, and a
+    // SW is scoped per origin (host + port). Sharing 1871 with `bun run dev` (which ships no SW,
+    // devOptions.enabled: false) lets a preview SW keep controlling dev and serve a stale precache.
+    // Different port = different origin = the preview SW can never bleed into the dev server.
+    port: 1872,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #622 (FRE-653).

## The bug

After the custom toast shipped (#617), the StatsPopUp pill ("N reports today in Berlin") stays painted on non-map routes — open the app, quickly open `/report` (or `/reports`), and the pill is still there over the page.

## Root cause

The toast store (`src/lib/toast.ts`) is a module-level global, but its only renderer — `<Toaster>` — lives in the route-scoped `_map` layout. Nothing actually enforced the documented invariant that "toasts only ever live on the map":

- A pill fired on the map stays in the store with its live timer after the user leaves.
- During the route transition, the `<Toaster>`'s `position: fixed` DOM node gets carried into the **incoming** route's subtree as `_map` tears down (verified via DOM ancestry — the pill ends up nested inside `/report`'s `bg-card animate-in` wrapper), so it survives the unmount and stays painted.

`sonner` cleaned up its own queue on `<Toaster>` unmount; the in-house replacement never did.

## Fix

- `src/lib/toast.ts` — add `clearToasts()` (drops all toasts + cancels their timers).
- `src/components/ui/toaster.tsx` — call it from the `<Toaster>`'s unmount effect (`useEffect(() => clearToasts, [])`), so leaving the map empties the store and the Toaster renders nothing.

Toasts still persist across **map sub-routes** (`/settings`, `/station/...`, `/reports/$id`) because the `_map` layout — and its `<Toaster>` — stays mounted there; the store is only cleared when the layout itself unmounts.

## Also: dev/preview port split

`server.port` (dev) and `preview.port` were both `1871`. A service worker is scoped per origin (host + port), so the SW that `bun run preview` ships shared an origin with `bun run dev` (which ships no SW — `devOptions.enabled: false`) and kept serving a stale precache, masking local changes. Moved `preview.port` to `1872` so the two can never bleed into each other.

## Verification

Reproduced and verified with Playwright against both a dev server and a **production build with the service worker active** (the real environment):

| | pill on `/` (map) | pill on `/report` |
|---|---|---|
| fix off | 1 | **1 (bug)** |
| fix on | 1 | **0 (fixed)** |

Also confirmed the pill persists across map sub-routes (`/settings`) and does not resurrect when returning to the map. `bun run lint`, `tsc --noEmit`, and `prettier --check` all clean.