### PR TITLE
fix: location soft-ask can no longer overlap the contribute card (FRE-654)

### DIFF
--- a/packages/frontend-next/src/components/map/UserLocationControl.tsx
+++ b/packages/frontend-next/src/components/map/UserLocationControl.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { GeolocateControl, useMap } from 'react-map-gl/maplibre';
 
 import { useGeolocation } from '@/contexts/Geolocation.context';
+import { useContributeModalOpen } from '@/lib/contribute-modal';
 import { useLegalDisclaimer } from '@/lib/legal-disclaimer';
 import {
   dismissLocationPrompt,
@@ -27,6 +28,10 @@ export function UserLocationControl() {
   const [showPrompt, setShowPrompt] = useState(false);
   // Soft-ask only on the bare map, never over a sub-route's panel.
   const onMapIndex = useRouterState({ select: (s) => s.location.pathname === '/' });
+  // The soft-ask is the lowest-priority card: it must never overlap another card. Sub-route panels
+  // are already excluded by `onMapIndex`; the contribute card is the one card that can open over the
+  // map index (e.g. after a report submit), so yield to it and resurface once it closes.
+  const contributeOpen = useContributeModalOpen();
 
   const trigger = useCallback(() => {
     const control = controlRef.current;
@@ -98,7 +103,7 @@ export function UserLocationControl() {
         onError={(e) => notifyError(e.code)}
         onTrackUserLocationStart={() => notifyLoading()}
       />
-      {showPrompt && onMapIndex && (
+      {showPrompt && onMapIndex && !contributeOpen && (
         <LocationPermissionPrompt onAllow={handleAllow} onDismiss={handleDismiss} />
       )}
     </>


### PR DESCRIPTION
Closes #623 (FRE-654).

## The bug

The contribute card could open on top of (overlap) the location permission soft-ask.

## Root cause

The location permission prompt (`LocationPermissionPrompt`) opens on a timer when on the map index (`/`). The `ContributeCard` is rendered at the root level from a global store and can also open over the map index — e.g. after a report submit (`ReportForm` → navigate to `/` → `openContributeModal()`). Nothing stopped both from being visible at once.

## Fix

Make the soft-ask the lowest-priority card: gate its render on the contribute modal being closed.

```diff
-{showPrompt && onMapIndex && (
+{showPrompt && onMapIndex && !contributeOpen && (
```

The prompt now yields while the contribute card is open and resurfaces once it closes (rather than being permanently suppressed).

Why this covers every case on the map index:
- **Sub-route panels** (settings, station detail, report detail) — already excluded by the existing `onMapIndex` (`pathname === '/'`) check.
- **Legal disclaimer** — mutually exclusive: the prompt's effect is gated on `accepted`, and the disclaimer only shows while `!accepted`.
- **Contribute card** — the one remaining root-level card that can open over `/`; now handled here.

## Verification

`bun run lint`, `tsc --noEmit`, and `prettier --check` all clean.