### PR TITLE
fix: ensure fresh data on PWA cold start with refetchOnMount

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -70,9 +70,14 @@ function mergeReportSlices(
 // every 30 s. The older `[DAY_MS, HOUR_MS]` remainder changes slowly: no interval polling, fresh
 // for an hour. Either way the shared last-hour slice keeps recent reports current without a full
 // 24 h refetch.
+// `refetchOnMount: 'always'` revalidates on mount even within `staleTime`, so a PWA cold start
+// (cache rehydrated from IndexedDB with its original `dataUpdatedAt`) always kicks off a background
+// refetch instead of serving a stale snapshot. Ongoing polling is still governed by `staleTime` /
+// `refetchInterval`.
 const LIVE_SLICE_POLLING = {
   refetchInterval: 30_000,
   refetchIntervalInBackground: false,
+  refetchOnMount: 'always',
   refetchOnWindowFocus: true,
   refetchOnReconnect: true,
   staleTime: 30_000,
@@ -80,6 +85,7 @@ const LIVE_SLICE_POLLING = {
 
 const OLDER_SLICE_POLLING = {
   refetchInterval: false,
+  refetchOnMount: 'always',
   refetchOnWindowFocus: true,
   refetchOnReconnect: true,
   staleTime: HOUR_MS,

--- a/packages/frontend-next/src/api/risk.ts
+++ b/packages/frontend-next/src/api/risk.ts
@@ -10,6 +10,10 @@ export const riskQueryOptions = () => ({
   queryFn: () => fetchJson<RiskData>('/v0/risk'),
   refetchInterval: 30_000,
   refetchIntervalInBackground: false,
+  // Always revalidate on mount so a PWA cold start (cache rehydrated from IndexedDB with its
+  // original `dataUpdatedAt`) refetches even within `staleTime`, instead of serving a stale snapshot.
+  refetchOnMount: 'always',
+  refetchOnReconnect: true,
   staleTime: 30_000,
 });
 


### PR DESCRIPTION
## Describe the issue:

When a PWA cold starts with cached data rehydrated from IndexedDB, stale data may be served to users instead of triggering a background refresh. The cache retains the original `dataUpdatedAt` timestamp, which can be within the `staleTime` window, preventing automatic revalidation on mount.

## Explain how you solved the issue:

Added `refetchOnMount: 'always'` to query options in `reports.ts` and `risk.ts` to ensure data is always revalidated when components mount, even if the cached data is within the `staleTime` window. This guarantees that PWA cold starts trigger a background refetch instead of serving a stale snapshot.

- **reports.ts**: Added `refetchOnMount: 'always'` to both `LIVE_SLICE_POLLING` and `OLDER_SLICE_POLLING` configurations
- **risk.ts**: Added `refetchOnMount: 'always'` and `refetchOnReconnect: true` to `riskQueryOptions`

Ongoing polling behavior remains governed by `staleTime` and `refetchInterval` as before.

## Additional notes or considerations:

This change ensures better data freshness for PWA users without affecting the polling strategy for already-mounted components. The background refetch respects the existing `refetchInterval` and `staleTime` settings for subsequent updates.

https://claude.ai/code/session_01BZNzb1JeJyUpS6ipVKCkVJ