### PR TITLE
fix: invalidate on cache restore instead of refetchOnMount: 'always'

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -69,15 +69,12 @@ function mergeReportSlices(
 // The live last-hour slice (`toAgo === 0`) powers the map and recent-reports views, so it polls
 // every 30 s. The older `[DAY_MS, HOUR_MS]` remainder changes slowly: no interval polling, fresh
 // for an hour. Either way the shared last-hour slice keeps recent reports current without a full
-// 24 h refetch.
-// `refetchOnMount: 'always'` revalidates on mount even within `staleTime`, so a PWA cold start
-// (cache rehydrated from IndexedDB with its original `dataUpdatedAt`) always kicks off a background
-// refetch instead of serving a stale snapshot. Ongoing polling is still governed by `staleTime` /
-// `refetchInterval`.
+// 24 h refetch. PWA cold-start freshness is handled once by invalidating on cache restore (see
+// `main.tsx`), not via `refetchOnMount: 'always'` — the latter forces a refetch per observer, and
+// the map subscribes several to this same slice, so it would fan out into redundant requests.
 const LIVE_SLICE_POLLING = {
   refetchInterval: 30_000,
   refetchIntervalInBackground: false,
-  refetchOnMount: 'always',
   refetchOnWindowFocus: true,
   refetchOnReconnect: true,
   staleTime: 30_000,
@@ -85,7 +82,6 @@ const LIVE_SLICE_POLLING = {
 
 const OLDER_SLICE_POLLING = {
   refetchInterval: false,
-  refetchOnMount: 'always',
   refetchOnWindowFocus: true,
   refetchOnReconnect: true,
   staleTime: HOUR_MS,

--- a/packages/frontend-next/src/api/risk.ts
+++ b/packages/frontend-next/src/api/risk.ts
@@ -11,9 +11,8 @@ export const riskQueryOptions = () =>
     queryFn: () => fetchJson<RiskData>('/v0/risk'),
     refetchInterval: 30_000,
     refetchIntervalInBackground: false,
-    // Always revalidate on mount so a PWA cold start (cache rehydrated from IndexedDB with its
-    // original `dataUpdatedAt`) refetches even within `staleTime`, instead of serving a stale snapshot.
-    refetchOnMount: 'always',
+    // PWA cold-start freshness is handled once by invalidating on cache restore (see `main.tsx`);
+    // `refetchOnReconnect` still refreshes risk when the network comes back.
     refetchOnReconnect: true,
     staleTime: 30_000,
   }) as const;

--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -38,6 +38,16 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <PersistQueryClientProvider
       client={queryClient}
+      // On a PWA cold start the cache is rehydrated from IndexedDB with each query's original
+      // `dataUpdatedAt`, so a reload within `staleTime` would serve a stale snapshot with no
+      // network request. `onSuccess` fires after restore but while queries are still paused
+      // (`isRestoring`), so invalidating here only marks them stale — no fetch yet. When the
+      // queries unpause, the default staleness-gated `refetchOnMount` fires exactly one deduped
+      // refetch per key, regardless of how many observers mount. This is stale-while-revalidate
+      // without the per-observer fan-out that `refetchOnMount: 'always'` would cause.
+      onSuccess={() => {
+        void queryClient.invalidateQueries();
+      }}
       persistOptions={{
         persister,
         // persisted cache from an older build so a changed query shape can't hydrate incompatibly.


### PR DESCRIPTION
## Problem

#627 fixed PWA cold-start staleness by adding `refetchOnMount: 'always'` to the risk and reports query options. But `'always'` forces a refetch on **every observer mount**, and the map subscribes several observers to the same query keys:

- **`risk`** → `Map.tsx` + `RiskLayer.tsx` (2 observers)
- **live `reports` slice** (`['reports', HOUR_MS, 0]`) → `ReportsLayer`, `ReportsOverviewButton`, `useStationSelection` (3 observers)

These mount at staggered times (~400ms apart) as the map, layers, and buttons render — past React Query's in-flight dedup window. Each fast (~60ms) fetch settles before the next observer mounts, so every one fires its own request. A single page load fans out into ~5 redundant `/v0/risk` and `/v0/reports` calls (observed in the network panel: 2× risk, 3× live reports).

## Fix

Solve the original cold-start staleness once at the source instead of per-mount: invalidate the rehydrated cache in `PersistQueryClientProvider`'s `onSuccess`.

```tsx
onSuccess={() => { void queryClient.invalidateQueries(); }}
```

`onSuccess` runs after restore completes but while queries are still paused (`isRestoring`), so `invalidateQueries()` only marks everything stale — no fetch yet. When the queries unpause, the default staleness-gated `refetchOnMount` fires **exactly one deduped refetch per key**, regardless of how many observers mount. This is the stale-while-revalidate behavior #626 wanted, without the fan-out.

- Remove `refetchOnMount: 'always'` from `riskQueryOptions` and from `LIVE_SLICE_POLLING` / `OLDER_SLICE_POLLING`.
- Add `onSuccess` invalidation to `PersistQueryClientProvider`.
- Keep the `refetchOnReconnect` addition to risk from #627.

## Result

Cold-start hydration still shows persisted data instantly and then revalidates; offline hydration still works; ongoing polling is unchanged. Redundant requests on load drop from ~5 back to one per key (plus the separate older 24h reports slice).

Follow-up to #627 / #626.

https://claude.ai/code/session_01BZNzb1JeJyUpS6ipVKCkVJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZNzb1JeJyUpS6ipVKCkVJ)_