### PR TITLE
feat: track contribution funnel in PostHog

### DIFF
--- a/packages/frontend-next/src/components/contribute/ContributeCard.tsx
+++ b/packages/frontend-next/src/components/contribute/ContributeCard.tsx
@@ -1,14 +1,16 @@
 import { Check, Copy, HeartHandshake } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DetailCard } from '@/components/map/DetailCard';
 import { Button } from '@/components/ui/button';
 import { CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { track } from '@/lib/analytics';
 import {
   closeContributeModal,
   dismissContributeForever,
+  getContributeSource,
   useContributeModalOpen,
 } from '@/lib/contribute-modal';
 import { optionalEnv } from '@/lib/utils';
@@ -22,6 +24,12 @@ const BANK_BIC = 'GENODEF1SLR';
 const stripePaymentLink = optionalEnv('VITE_STRIPE_PAYMENT_LINK');
 const hasStripeConfig = Boolean(stripePaymentLink);
 
+const DEFAULT_TAB = 'stripe';
+
+// Maps a tab value to the analytics method name, shared by the initial view and tab switches.
+const methodForTab = (tab: string): 'stripe' | 'bank_transfer' =>
+  tab === 'bank' ? 'bank_transfer' : 'stripe';
+
 type BankFieldId = 'holder' | 'iban' | 'bic' | 'reference';
 
 export function ContributeCard() {
@@ -33,13 +41,27 @@ export function ContributeCard() {
 function ContributeCardContent() {
   const { t } = useTranslation(NAMESPACE);
 
+  useEffect(() => {
+    // The modal mounts on the default tab (or the bank details when Stripe isn't configured).
+    // Record that initial view here since onValueChange only fires on later switches.
+    track('contribute_method_viewed', {
+      method: hasStripeConfig ? methodForTab(DEFAULT_TAB) : 'bank_transfer',
+    });
+  }, []);
+
   return (
     <DetailCard title={t('title')} closeLabel={t('close')} onClose={closeContributeModal}>
       <CardContent className="flex flex-col gap-4">
         <p className="text-muted-foreground text-sm">{t('description')}</p>
 
         {hasStripeConfig ? (
-          <Tabs defaultValue="stripe" className="gap-4">
+          <Tabs
+            defaultValue={DEFAULT_TAB}
+            className="gap-4"
+            onValueChange={(value) =>
+              track('contribute_method_viewed', { method: methodForTab(value) })
+            }
+          >
             <TabsList className="bg-surface-solid border-border grid w-full grid-cols-2 gap-0.5 rounded-md border p-0.5">
               <TabsTrigger value="stripe" className={triggerClass}>
                 {t('tabStripe')}
@@ -86,7 +108,12 @@ function StripeTab() {
         size="lg"
         className="bg-accent-bright text-primary-foreground hover:bg-accent-press h-11 w-full gap-2"
       >
-        <a href={stripePaymentLink} target="_blank" rel="noopener noreferrer">
+        <a
+          href={stripePaymentLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => track('contribute_stripe_clicked', { source: getContributeSource() })}
+        >
           <HeartHandshake />
           {t('support')}
         </a>

--- a/packages/frontend-next/src/components/map/SettingsCard.tsx
+++ b/packages/frontend-next/src/components/map/SettingsCard.tsx
@@ -75,7 +75,7 @@ export function SettingsCard({ onClose }: SettingsCardProps) {
       <CardContent>
         <Button
           type="button"
-          onClick={openContributeModal}
+          onClick={() => openContributeModal('settings')}
           className="bg-accent-bright text-primary-foreground hover:bg-accent-press h-11 w-full gap-2"
         >
           <HeartHandshake />

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -340,7 +340,7 @@ export function ReportForm() {
   const handleSuccessClose = () => {
     navigate({ to: '/' });
     // Invite a contribution after a successful report, unless the user opted out.
-    if (!isContributeDismissed()) openContributeModal();
+    if (!isContributeDismissed()) openContributeModal('report_success');
   };
 
   return (

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -1,5 +1,7 @@
 import posthog from 'posthog-js';
 
+import type { ContributeSource } from '@/lib/contribute-modal';
+
 // Provider-agnostic analytics facade. The rest of the app calls `track(...)` and never imports the
 // analytics SDK directly, so swapping PostHog for another provider is a single-file change here.
 // When no VITE_POSTHOG_KEY is set the SDK is never initialized (see main.tsx) and capture() no-ops.
@@ -15,11 +17,23 @@ type AnalyticsEvents = {
     lineId: string | null;
     directionId: string | null;
   };
+  // Contribution funnel. `source` records which entry point opened the modal so we can compare the
+  // settings button against the prompt shown after a successful report. The donation itself happens
+  // off-site (Stripe redirect / manual bank transfer), so these events measure intent, not completion.
+  contribute_modal_opened: { source: ContributeSource };
+  contribute_method_viewed: { method: 'stripe' | 'bank_transfer' };
+  contribute_stripe_clicked: { source: ContributeSource };
+  contribute_dismissed: { source: ContributeSource };
 };
 
 export function track<E extends keyof AnalyticsEvents>(
   event: E,
   properties: AnalyticsEvents[E],
 ): void {
+  if (import.meta.env.DEV) {
+    // In development we usually run without a PostHog key, so capture() no-ops. Log instead so the
+    // funnel events are visible in the console while wiring up tracking.
+    console.log('[analytics]', event, properties);
+  }
   posthog.capture(event, properties);
 }

--- a/packages/frontend-next/src/lib/contribute-modal.ts
+++ b/packages/frontend-next/src/lib/contribute-modal.ts
@@ -1,10 +1,16 @@
 import { useSyncExternalStore } from 'react';
 
+import { track } from '@/lib/analytics';
+
 // "Don't show again" preference. Reuse the old frontend's key so users who already
 // dismissed the modal there are not nagged again after the rewrite ships.
 const DISMISSED_KEY = 'contributionModalDismissed';
 
+// Which entry point opened the modal, carried through to the contribution analytics events.
+export type ContributeSource = 'settings' | 'report_success';
+
 let open = false;
+let source: ContributeSource = 'settings';
 const listeners = new Set<() => void>();
 
 function notify(): void {
@@ -16,9 +22,15 @@ function subscribe(listener: () => void): () => void {
   return () => listeners.delete(listener);
 }
 
-export function openContributeModal(): void {
+export function openContributeModal(from: ContributeSource): void {
+  source = from;
   open = true;
   notify();
+  track('contribute_modal_opened', { source: from });
+}
+
+export function getContributeSource(): ContributeSource {
+  return source;
 }
 
 export function closeContributeModal(): void {
@@ -40,6 +52,7 @@ export function isContributeDismissed(): boolean {
 }
 
 export function dismissContributeForever(): void {
+  track('contribute_dismissed', { source });
   try {
     localStorage.setItem(DISMISSED_KEY, 'true');
   } catch {


### PR DESCRIPTION
## What

Instruments the contribute modal so we can measure the donation funnel in PostHog. Four intent-tracking events, wired into the existing type-safe `track()` facade:

| Event | Fires when | Properties |
|---|---|---|
| `contribute_modal_opened` | modal opens | `source: 'settings' \| 'report_success'` |
| `contribute_method_viewed` | initial view on open + tab switch | `method: 'stripe' \| 'bank_transfer'` |
| `contribute_stripe_clicked` | outbound Stripe link clicked | `source` |
| `contribute_dismissed` | "Don't show again" clicked | `source` |

The `source` is captured once at open time in the modal store, so all source-bearing events report a consistent entry point. `DEFAULT_TAB` + `methodForTab` keep the opening tab and its reported method in sync.

The key funnel: `contribute_modal_opened` → `contribute_stripe_clicked`, broken down by `source` — does the post-report prompt convert better than the settings button?

## Notes

- These events measure **intent, not completion** — Stripe is an off-site redirect and bank transfers are invisible client-side. A future `donation_completed` event (fired on a Stripe post-payment redirect) would close the loop, but that needs `VITE_STRIPE_PAYMENT_LINK` to be live first.
- Dev builds `console.log` each event, since local runs have no PostHog key and `capture()` no-ops.
- No PII; consistent with the existing `autocapture: false` / `respect_dnt` privacy setup.