### PR TITLE
feat: track risk layer usage in PostHog

### DIFF
--- a/packages/frontend-next/src/hooks/useRiskLayer.ts
+++ b/packages/frontend-next/src/hooks/useRiskLayer.ts
@@ -1,4 +1,6 @@
-import { useSyncExternalStore } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
+
+import { setSuperProperties, track } from '@/lib/analytics';
 
 // Which transit layer the map shows: risk-colored segments ('RISK') or plain line colors
 // ('LINES'). Shared between the toggle button (mounted in the map route) and the layer (nested
@@ -29,6 +31,8 @@ function setLayer(next: Layer) {
   } catch {
     // Ignore storage failures (e.g. private mode); state still works for the session.
   }
+  track('risk_layer_toggled', { to: next });
+  setSuperProperties({ map_layer: next });
   for (const listener of listeners) listener();
 }
 
@@ -39,6 +43,11 @@ function subscribe(listener: () => void): () => void {
 
 export function useRiskLayer(): { visible: boolean; toggle: () => void } {
   const current = useSyncExternalStore(subscribe, () => layer);
+  // Stamp the current layer as a super property once PostHog is initialized (it isn't yet at module
+  // load), so events fired before any toggle — pageviews, reports — still carry the default state.
+  useEffect(() => {
+    setSuperProperties({ map_layer: current });
+  }, [current]);
   return {
     visible: current === 'RISK',
     toggle: () => setLayer(layer === 'RISK' ? 'LINES' : 'RISK'),

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -6,6 +6,12 @@ import type { ContributeSource } from '@/lib/contribute-modal';
 // analytics SDK directly, so swapping PostHog for another provider is a single-file change here.
 // When no VITE_POSTHOG_KEY is set the SDK is never initialized (see main.tsx) and capture() no-ops.
 
+// Properties attached to every subsequent event (PostHog super properties), so all metrics —
+// including pageviews — can be sliced by which map layer the user is on.
+type SuperProperties = {
+  map_layer: 'RISK' | 'LINES';
+};
+
 /**
  * The events we send and their property shape. Add an entry here to introduce a new event — the
  * `track()` signature is derived from this map, so call sites get autocomplete and type-checking on
@@ -17,9 +23,7 @@ type AnalyticsEvents = {
     lineId: string | null;
     directionId: string | null;
   };
-  // Contribution funnel. `source` records which entry point opened the modal so we can compare the
-  // settings button against the prompt shown after a successful report. The donation itself happens
-  // off-site (Stripe redirect / manual bank transfer), so these events measure intent, not completion.
+  risk_layer_toggled: { to: SuperProperties['map_layer'] };
   contribute_modal_opened: { source: ContributeSource };
   contribute_method_viewed: { method: 'stripe' | 'bank_transfer' };
   contribute_stripe_clicked: { source: ContributeSource };
@@ -36,4 +40,15 @@ export function track<E extends keyof AnalyticsEvents>(
     console.log('[analytics]', event, properties);
   }
   posthog.capture(event, properties);
+}
+
+/**
+ * Register super properties — attached to every event sent afterwards. Used to stamp the current
+ * map layer onto all events so adoption and retention can be broken down by it.
+ */
+export function setSuperProperties(properties: Partial<SuperProperties>): void {
+  if (import.meta.env.DEV) {
+    console.log('[analytics] register', properties);
+  }
+  posthog.register(properties);
 }


### PR DESCRIPTION
## What

Adds frontend analytics for the risk layer so we can measure how it's used.

- **`risk_layer_toggled`** event (`{ to: 'RISK' | 'LINES' }`) fired whenever the user switches the map layer.
- **`map_layer`** super property registered on init and on every toggle, so it's stamped on *all* events (pageviews included) and any metric can be broken down by which layer the user is on.

No backend changes — this is purely client-side event tracking through the existing `analytics.ts` facade.

## Why

The risk layer is **on by default**, so "usage" can't be measured from toggle clicks alone. Stamping `map_layer` on every event lets us answer:

- **Adoption** — share of active users on `RISK` vs `LINES` (e.g. DAU broken down by `map_layer`).
- **Opt-out without opting back in** — persons whose most recent `risk_layer_toggled` was `to: 'LINES'`.

## Notes

- Capture respects the existing consent/opt-out model; nothing new is sent for users who declined.
- The `map_layer` super property is registered from a `useEffect` (PostHog isn't initialized at module load), so events fired before any toggle still carry the default layer.