### PR TITLE
feat: track location sharing funnel in PostHog

### DIFF
--- a/packages/frontend-next/src/components/map/UserLocationControl.tsx
+++ b/packages/frontend-next/src/components/map/UserLocationControl.tsx
@@ -159,7 +159,9 @@ export function UserLocationControl() {
         onError={(e) => handleError(e.code)}
         onTrackUserLocationStart={() => notifyLoading()}
       />
-      {promptVisible && <LocationPermissionPrompt onAllow={handleAllow} onDismiss={handleDismiss} />}
+      {promptVisible && (
+        <LocationPermissionPrompt onAllow={handleAllow} onDismiss={handleDismiss} />
+      )}
     </>
   );
 }

--- a/packages/frontend-next/src/components/map/UserLocationControl.tsx
+++ b/packages/frontend-next/src/components/map/UserLocationControl.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { GeolocateControl, useMap } from 'react-map-gl/maplibre';
 
 import { useGeolocation } from '@/contexts/Geolocation.context';
+import { type LocationRequestTrigger, track } from '@/lib/analytics';
 import { useContributeModalOpen } from '@/lib/contribute-modal';
 import { useLegalDisclaimer } from '@/lib/legal-disclaimer';
 import {
@@ -14,6 +15,11 @@ import {
 } from '@/lib/location-prompt';
 
 import { LocationPermissionPrompt } from './LocationPermissionPrompt';
+
+// GeolocationPositionError codes (1/2/3). 'denied' after a soft-ask Allow is the key browser-quirk
+// signal: the user consented in-app but the native prompt (or OS-level setting) blocked us.
+const failureReason = (code: number) =>
+  code === 1 ? 'denied' : code === 3 ? 'timeout' : 'unavailable';
 
 /**
  * Renders maplibre's GeolocateControl (location dot, accuracy circle, tracking) and mirrors its
@@ -32,16 +38,28 @@ export function UserLocationControl() {
   // are already excluded by `onMapIndex`; the contribute card is the one card that can open over the
   // map index (e.g. after a report submit), so yield to it and resurface once it closes.
   const contributeOpen = useContributeModalOpen();
+  // Funnel tracking state. GeolocateControl keeps tracking after the first fix (onGeolocate fires
+  // on every update, onError can repeat), so report acquired/failed once per request.
+  const requestRef = useRef<{ trigger: LocationRequestTrigger } | null>(null);
+  const outcomeReportedRef = useRef(false);
+  const permissionTrackedRef = useRef(false);
+  const promptShownTrackedRef = useRef(false);
 
-  const trigger = useCallback(() => {
-    const control = controlRef.current;
-    // Suppress GeolocateControl recentering/zooming the camera on the first fix; we only want the dot.
-    if (control) {
-      (control as unknown as { _updateCamera: () => void })._updateCamera = () => {};
-    }
-    notifyLoading();
-    control?.trigger();
-  }, [notifyLoading]);
+  const trigger = useCallback(
+    (requestTrigger: LocationRequestTrigger) => {
+      const control = controlRef.current;
+      // Suppress GeolocateControl recentering/zooming the camera on the first fix; we only want the dot.
+      if (control) {
+        (control as unknown as { _updateCamera: () => void })._updateCamera = () => {};
+      }
+      track('location_request_started', { trigger: requestTrigger });
+      requestRef.current = { trigger: requestTrigger };
+      outcomeReportedRef.current = false;
+      notifyLoading();
+      control?.trigger();
+    },
+    [notifyLoading],
+  );
 
   // Gate on disclaimer acceptance + map load. Only 'granted' tracks immediately (the API call is
   // silent then); for 'prompt'/'unsupported' we must not call the API ourselves — on Safari/iOS
@@ -57,8 +75,16 @@ export function UserLocationControl() {
       const permission = await queryGeolocationPermission();
       if (cancelled) return;
 
+      // Funnel entry: the pre-existing permission state, where browsers diverge the most (older
+      // Safari has no Permissions API → 'unsupported', "Allow once" doesn't persist, etc.).
+      // Once per session — the effect can re-run on dependency changes.
+      if (!permissionTrackedRef.current) {
+        permissionTrackedRef.current = true;
+        track('location_permission_evaluated', { state: permission });
+      }
+
       if (permission === 'granted') {
-        trigger();
+        trigger('auto');
         return;
       }
       if (permission === 'denied') return;
@@ -80,14 +106,44 @@ export function UserLocationControl() {
   }, [map, accepted, trigger]);
 
   const handleAllow = () => {
+    track('location_prompt_allowed', {});
     setShowPrompt(false);
-    trigger();
+    trigger('soft_prompt');
   };
 
   const handleDismiss = () => {
+    track('location_prompt_dismissed', {});
     setShowPrompt(false);
     dismissLocationPrompt();
   };
+
+  const handleGeolocate = (coords: GeolocationCoordinates) => {
+    notifyPosition(coords);
+    const request = requestRef.current;
+    if (request && !outcomeReportedRef.current) {
+      outcomeReportedRef.current = true;
+      track('location_acquired', { trigger: request.trigger });
+    }
+  };
+
+  const handleError = (code: number) => {
+    notifyError(code);
+    const request = requestRef.current;
+    if (request && !outcomeReportedRef.current) {
+      outcomeReportedRef.current = true;
+      track('location_failed', { trigger: request.trigger, reason: failureReason(code) });
+    }
+  };
+
+  // The card is conditionally rendered below; count it as "shown" only when it is actually visible,
+  // not when the timer merely arms it while a sub-route panel or the contribute card covers the map.
+  const promptVisible = showPrompt && onMapIndex && !contributeOpen;
+  useEffect(() => {
+    if (promptVisible && !promptShownTrackedRef.current) {
+      promptShownTrackedRef.current = true;
+      track('location_prompt_shown', {});
+    }
+  }, [promptVisible]);
 
   return (
     <>
@@ -99,13 +155,11 @@ export function UserLocationControl() {
         trackUserLocation
         showUserLocation
         showAccuracyCircle
-        onGeolocate={(e) => notifyPosition(e.coords)}
-        onError={(e) => notifyError(e.code)}
+        onGeolocate={(e) => handleGeolocate(e.coords)}
+        onError={(e) => handleError(e.code)}
         onTrackUserLocationStart={() => notifyLoading()}
       />
-      {showPrompt && onMapIndex && !contributeOpen && (
-        <LocationPermissionPrompt onAllow={handleAllow} onDismiss={handleDismiss} />
-      )}
+      {promptVisible && <LocationPermissionPrompt onAllow={handleAllow} onDismiss={handleDismiss} />}
     </>
   );
 }

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -1,13 +1,13 @@
 import posthog from 'posthog-js';
 
 import type { ContributeSource } from '@/lib/contribute-modal';
+import type { GeolocationPermissionState } from '@/lib/location-prompt';
 
 // Provider-agnostic analytics facade. The rest of the app calls `track(...)` and never imports the
 // analytics SDK directly, so swapping PostHog for another provider is a single-file change here.
 // When no VITE_POSTHOG_KEY is set the SDK is never initialized (see main.tsx) and capture() no-ops.
 
-// Properties attached to every subsequent event (PostHog super properties), so all metrics —
-// including pageviews — can be sliced by which map layer the user is on.
+export type LocationRequestTrigger = 'auto' | 'soft_prompt';
 type SuperProperties = {
   map_layer: 'RISK' | 'LINES';
 };
@@ -28,6 +28,16 @@ type AnalyticsEvents = {
   contribute_method_viewed: { method: 'stripe' | 'bank_transfer' };
   contribute_stripe_clicked: { source: ContributeSource };
   contribute_dismissed: { source: ContributeSource };
+  location_permission_evaluated: { state: GeolocationPermissionState };
+  location_prompt_shown: Record<string, never>;
+  location_prompt_allowed: Record<string, never>;
+  location_prompt_dismissed: Record<string, never>;
+  location_request_started: { trigger: LocationRequestTrigger };
+  location_acquired: { trigger: LocationRequestTrigger };
+  location_failed: {
+    trigger: LocationRequestTrigger;
+    reason: 'denied' | 'unavailable' | 'timeout';
+  };
 };
 
 export function track<E extends keyof AnalyticsEvents>(


### PR DESCRIPTION
Instruments the geolocation soft-ask flow so we can see where users drop off, broken down by browser — the location APIs (`navigator.permissions` / `navigator.geolocation`) behave very differently across browsers, and we currently have no visibility into it.

## Events

Added to the typed registry in `analytics.ts` (same pattern as the contribution funnel, #640):

| Event | Properties | When |
|---|---|---|
| `location_permission_evaluated` | `state` | funnel entry — pre-existing permission state |
| `location_prompt_shown` | — | soft-ask becomes visible |
| `location_prompt_allowed` / `_dismissed` | — | user choice on the soft-ask |
| `location_request_started` | `trigger` | `auto` (already granted) vs `soft_prompt` (tapped Allow) |
| `location_acquired` | `trigger` | first fix, once per request |
| `location_failed` | `trigger`, `reason` | `denied` / `unavailable` / `timeout` |

All instrumentation lives in `UserLocationControl.tsx`. No behaviour changes — `notifyPosition` / `notifyError` fire exactly as before.

## Notes

- `location_prompt_shown` fires on actual visibility (`showPrompt && onMapIndex && !contributeOpen`), not when the 15s timer arms it, so users on sub-routes / behind the contribute card don't inflate the funnel entry.
- `acquired` / `failed` are guarded to once per request — `GeolocateControl` keeps firing `onGeolocate` while tracking.
- No coordinates leave the device.

## Dashboard

Live in PostHog (project 200383): soft-ask funnel by browser, returning-users (granted → acquired), failures by reason, and initial permission state. Tiles populate once this ships.