### PR TITLE
feat: track /reports page usage in PostHog

### DIFF
--- a/packages/frontend-next/src/components/reports/ReportRow.tsx
+++ b/packages/frontend-next/src/components/reports/ReportRow.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { formatElapsed, type Report } from '@/api/reports';
 import { useLines, useStations } from '@/api/transit';
+import { track } from '@/lib/analytics';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Route as ReportDetailRoute } from '@/routes/_map/reports/$stationId';
 import { Route as StationRoute } from '@/routes/_map/station/$stationId';
@@ -37,6 +38,13 @@ export function ReportRow({ report, recent }: { report: Report; recent: boolean 
     </>
   );
 
+  const trackSelection = () =>
+    track('report_row_selected', {
+      recent,
+      has_line: report.lineId !== null,
+      has_direction: report.directionId !== null,
+    });
+
   // A report from the last hour opens the live report view; older ones fall back to the station.
   return (
     <li className="border-border/60 border-b last:border-b-0">
@@ -45,6 +53,7 @@ export function ReportRow({ report, recent }: { report: Report; recent: boolean 
           to={ReportDetailRoute.to}
           params={{ stationId: report.stationId }}
           className="flex flex-col gap-1 px-4 py-3"
+          onClick={trackSelection}
         >
           {content}
         </Link>
@@ -53,6 +62,7 @@ export function ReportRow({ report, recent }: { report: Report; recent: boolean 
           to={StationRoute.to}
           params={{ stationId: report.stationId }}
           className="flex flex-col gap-1 px-4 py-3"
+          onClick={trackSelection}
         >
           {content}
         </Link>

--- a/packages/frontend-next/src/components/reports/ReportsTabBar.tsx
+++ b/packages/frontend-next/src/components/reports/ReportsTabBar.tsx
@@ -33,10 +33,7 @@ export function ReportsTabBar() {
             asChild
             className="text-muted-foreground data-[state=active]:text-foreground data-[state=active]:border-foreground -mb-px rounded-none border-b-2 border-transparent py-3 text-xs font-semibold tracking-wide uppercase"
           >
-            <Link
-              to={tab.route.to}
-              onClick={() => track('reports_tab_selected', { tab: tab.tab })}
-            >
+            <Link to={tab.route.to} onClick={() => track('reports_tab_selected', { tab: tab.tab })}>
               {t(tab.labelKey)}
             </Link>
           </TabsTrigger>

--- a/packages/frontend-next/src/components/reports/ReportsTabBar.tsx
+++ b/packages/frontend-next/src/components/reports/ReportsTabBar.tsx
@@ -1,6 +1,7 @@
 import { Link, useRouterState } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
+import { track } from '@/lib/analytics';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Route as LinesRoute } from '@/routes/reports/lines';
 import { Route as StationsRoute } from '@/routes/reports/stations';
@@ -9,9 +10,9 @@ import { Route as SummaryRoute } from '@/routes/reports/index';
 import { NAMESPACE } from './Reports.i18n';
 
 const TABS = [
-  { route: SummaryRoute, labelKey: 'tabSummary' },
-  { route: LinesRoute, labelKey: 'tabLines' },
-  { route: StationsRoute, labelKey: 'tabReports' },
+  { route: SummaryRoute, labelKey: 'tabSummary', tab: 'summary' },
+  { route: LinesRoute, labelKey: 'tabLines', tab: 'lines' },
+  { route: StationsRoute, labelKey: 'tabReports', tab: 'reports' },
 ] as const;
 
 export function ReportsTabBar() {
@@ -32,7 +33,12 @@ export function ReportsTabBar() {
             asChild
             className="text-muted-foreground data-[state=active]:text-foreground data-[state=active]:border-foreground -mb-px rounded-none border-b-2 border-transparent py-3 text-xs font-semibold tracking-wide uppercase"
           >
-            <Link to={tab.route.to}>{t(tab.labelKey)}</Link>
+            <Link
+              to={tab.route.to}
+              onClick={() => track('reports_tab_selected', { tab: tab.tab })}
+            >
+              {t(tab.labelKey)}
+            </Link>
           </TabsTrigger>
         ))}
       </TabsList>

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -38,14 +38,11 @@ type AnalyticsEvents = {
     trigger: LocationRequestTrigger;
     reason: 'denied' | 'unavailable' | 'timeout';
   };
-  // Map interactions. These cover deliberate in-app selections only; external arrivals (the
-  // Telegram deep link) are attributed via utm_source on the $pageview, since a cold load and an
-  // in-app tap hit the same route and the redirect erases the origin (see station/$stationId loader).
   station_selected: { source: 'map' | 'search' };
-  // Tapping a report dot on the map. No `source` — this only ever fires on a map tap (deep links
-  // redirect straight to the report view without going through the marker). `report_age_minutes`
-  // is the raw age so we can find the real engagement-vs-freshness threshold, not assume one.
   report_marker_selected: { report_age_minutes: number };
+  reports_overview_opened: { report_count: number };
+  reports_tab_selected: { tab: 'summary' | 'lines' | 'reports' };
+  report_row_selected: { recent: boolean; has_line: boolean; has_direction: boolean };
 };
 
 export function track<E extends keyof AnalyticsEvents>(

--- a/packages/frontend-next/src/routes/reports.tsx
+++ b/packages/frontend-next/src/routes/reports.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Outlet, useNavigate } from '@tanstack/react-router';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { queryClient } from '@/api/queryClient';
@@ -7,6 +8,7 @@ import { linesQueryOptions, stationsQueryOptions } from '@/api/transit';
 import { ReportsTabBar } from '@/components/reports/ReportsTabBar';
 import { NAMESPACE } from '@/components/reports/Reports.i18n';
 import { PageHeader } from '@/components/templates/PageHeader';
+import { track } from '@/lib/analytics';
 
 export const Route = createFileRoute('/reports')({
   staticData: { legalDisclaimer: false },
@@ -26,6 +28,15 @@ function ReportsOverviewLayout() {
   const { t } = useTranslation(NAMESPACE);
   const navigate = useNavigate();
   const { data: reports } = useReports(DAY_MS);
+
+  // One open event per visit, fired once the count is known (so report_count is the real figure
+  // shown, not 0 before the prefetch resolves). The ref guards against re-firing on data refetch.
+  const openTracked = useRef(false);
+  useEffect(() => {
+    if (openTracked.current || reports === undefined) return;
+    openTracked.current = true;
+    track('reports_overview_opened', { report_count: reports.length });
+  }, [reports]);
 
   return (
     <div className="bg-card animate-in fade-in fixed inset-0 z-30 duration-150">


### PR DESCRIPTION
## What

Instruments the in-app **/reports overview page** so we can see how it's actually used, and adds a dedicated PostHog dashboard for it.

Three new events on the typed `analytics.ts` facade:

| Event | Where | Properties |
|---|---|---|
| `reports_overview_opened` | `routes/reports.tsx` — once per visit (layout mount, ref-guarded against refetch) | `report_count` (24h count shown) |
| `reports_tab_selected` | `components/reports/ReportsTabBar.tsx` — real tab taps only | `tab: summary \| lines \| reports` |
| `report_row_selected` | `components/reports/ReportRow.tsx` — both recent & older rows | `recent`, `has_line`, `has_direction` |

## Why

We had no visibility into how the reports page is used — which tabs people look at, whether they drill into individual reports, or whether a fuller list drives opens. `report_row_selected` is the list-tap counterpart to the existing `report_marker_selected` (map tap).

`reports_overview_opened` is kept rather than relying on `$pageview` because it carries `report_count` (which a pageview can't) and fires **once per visit** — the `/reports` layout stays mounted across tab switches, so a raw `/reports*` pageview count would be inflated by tab navigation.

## Dashboard

New **"Reports Page Usage"** dashboard (separate from the existing "Reports" dashboard, which tracks incident-report *data* from the warehouse — not page usage): https://eu.i.posthog.com/project/200383/dashboard/747134

Tiles: opens over time · tab selections by tab · row taps recent vs older · avg reports waiting at open · open→tab funnel · open→row-tap funnel.

## Testing

`tsc --noEmit` and ESLint pass. Tiles populate once this build ships (30-day event window).