### PR TITLE
feat: track report_row_selected age instead of recent flag

### DIFF
--- a/packages/frontend-next/src/components/reports/ReportRow.tsx
+++ b/packages/frontend-next/src/components/reports/ReportRow.tsx
@@ -40,7 +40,7 @@ export function ReportRow({ report, recent }: { report: Report; recent: boolean 
 
   const trackSelection = () =>
     track('report_row_selected', {
-      recent,
+      report_age_minutes: Math.round((Date.now() - new Date(report.timestamp).getTime()) / 60000),
       has_line: report.lineId !== null,
       has_direction: report.directionId !== null,
     });

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -42,7 +42,7 @@ type AnalyticsEvents = {
   report_marker_selected: { report_age_minutes: number };
   reports_overview_opened: { report_count: number };
   reports_tab_selected: { tab: 'summary' | 'lines' | 'reports' };
-  report_row_selected: { recent: boolean; has_line: boolean; has_direction: boolean };
+  report_row_selected: { report_age_minutes: number; has_line: boolean; has_direction: boolean };
 };
 
 export function track<E extends keyof AnalyticsEvents>(


### PR DESCRIPTION
## What

Swaps the `recent: boolean` property on `report_row_selected` for `report_age_minutes: number` (the raw report age at tap time).

## Why

This mirrors the existing `report_marker_selected: { report_age_minutes }` event. The raw age lets us find the real engagement-vs-freshness threshold from the data, rather than baking in the 1-hour recent/older split — which the UI only uses to decide *which* detail route to open. `recent` is still computed in `ReportRow` for that routing; it's just no longer in the event payload (and is trivially derivable from age if ever needed).

## Dashboard

Repointed the "Report row taps" tile on the [Reports Page Usage dashboard](https://eu.i.posthog.com/project/200383/dashboard/747134) to bin taps by `report_age_minutes` (10 histogram bins) instead of the removed `recent` breakdown.

## Testing

`tsc --noEmit` and ESLint pass.