### PR TITLE
feat: add in-app feedback survey entry point

### DIFF
--- a/packages/frontend-next/.env.example
+++ b/packages/frontend-next/.env.example
@@ -7,3 +7,5 @@ VITE_MAP_INITIAL_ZOOM=11
 VITE_STRIPE_PAYMENT_LINK=
 VITE_POSTHOG_KEY=
 VITE_POSTHOG_HOST=https://eu.i.posthog.com
+# Id of the API-type PostHog survey that in-app feedback submissions are attributed to.
+VITE_POSTHOG_FEEDBACK_SURVEY_ID=

--- a/packages/frontend-next/.env.production
+++ b/packages/frontend-next/.env.production
@@ -8,3 +8,4 @@ VITE_STRIPE_PAYMENT_LINK=https://buy.stripe.com/28E9AW9Y634e8HQ9Sq3wQ00
 # PostHog project API key (public — shipped in the client bundle). EU Cloud.
 VITE_POSTHOG_KEY=phc_rR635vqhSmp6st6GYqJG23uZVCmtESsDQT4Caijwv2N5
 VITE_POSTHOG_HOST=https://eu.i.posthog.com
+VITE_POSTHOG_FEEDBACK_SURVEY_ID=019ec61d-7044-0000-0c79-734d7b31e436

--- a/packages/frontend-next/src/components/feedback/FeedbackButton.tsx
+++ b/packages/frontend-next/src/components/feedback/FeedbackButton.tsx
@@ -1,0 +1,42 @@
+import { MessageSquarePlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { openFeedbackModal, type FeedbackSource } from '@/lib/feedback-modal';
+
+import { NAMESPACE } from './FeedbackCard.i18n';
+
+type FeedbackButtonProps = Omit<React.ComponentProps<typeof Button>, 'onClick'> & {
+  source: FeedbackSource;
+};
+
+export function FeedbackButton({
+  source,
+  variant = 'ghost',
+  size = 'sm',
+  className,
+  children,
+  ...props
+}: FeedbackButtonProps) {
+  const { t } = useTranslation(NAMESPACE);
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      onClick={() => openFeedbackModal(source)}
+      // Default label keeps icon-only usages (header buttons) accessible; callers can override.
+      aria-label={t('button')}
+      className={className}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <MessageSquarePlus />
+          {t('button')}
+        </>
+      )}
+    </Button>
+  );
+}

--- a/packages/frontend-next/src/components/feedback/FeedbackCard.i18n.ts
+++ b/packages/frontend-next/src/components/feedback/FeedbackCard.i18n.ts
@@ -1,0 +1,39 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'feedback';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  button: 'Send feedback',
+  title: 'Send feedback',
+  close: 'Close',
+  typeLabel: 'What kind of feedback is this?',
+  typeFeature: 'Feature request',
+  typeBug: 'Bug report',
+  typeGeneral: 'General',
+  messageLabel: 'Tell us more',
+  messagePlaceholder: 'Share your idea, the bug you hit, or anything else…',
+  submit: 'Submit',
+  submitting: 'Sending…',
+  successTitle: 'Thanks for your feedback!',
+  successText: 'We read every submission.',
+  error: 'Could not send your feedback. Please try again.',
+  retry: 'Try again',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  button: 'Feedback geben',
+  title: 'Feedback geben',
+  close: 'Schließen',
+  typeLabel: 'Worum geht es?',
+  typeFeature: 'Feature-Wunsch',
+  typeBug: 'Fehler melden',
+  typeGeneral: 'Allgemein',
+  messageLabel: 'Erzähl uns mehr',
+  messagePlaceholder: 'Teile deine Idee, den gefundenen Fehler oder alles andere…',
+  submit: 'Absenden',
+  submitting: 'Wird gesendet…',
+  successTitle: 'Danke für dein Feedback!',
+  successText: 'Wir lesen jede Rückmeldung.',
+  error: 'Feedback konnte nicht gesendet werden. Bitte versuche es erneut.',
+  retry: 'Erneut versuchen',
+});

--- a/packages/frontend-next/src/components/feedback/FeedbackCard.tsx
+++ b/packages/frontend-next/src/components/feedback/FeedbackCard.tsx
@@ -1,0 +1,127 @@
+import { useRouterState } from '@tanstack/react-router';
+import { Check } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { DetailCard } from '@/components/map/DetailCard';
+import { Button } from '@/components/ui/button';
+import { CardContent } from '@/components/ui/card';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { captureSurveySent, type FeedbackType } from '@/lib/analytics';
+import { closeFeedbackModal, FEEDBACK_SURVEY_ID, useFeedbackModalOpen } from '@/lib/feedback-modal';
+import { cn } from '@/lib/utils';
+
+import { NAMESPACE } from './FeedbackCard.i18n';
+
+export function FeedbackCard() {
+  const open = useFeedbackModalOpen();
+  // Remount on each open (key) so the form state resets and the same user can submit repeatedly.
+  if (!open) return null;
+  return <FeedbackCardContent />;
+}
+
+const TYPE_OPTIONS: { value: FeedbackType; labelKey: string }[] = [
+  { value: 'feature_request', labelKey: 'typeFeature' },
+  { value: 'bug_report', labelKey: 'typeBug' },
+  { value: 'general', labelKey: 'typeGeneral' },
+];
+
+function FeedbackCardContent() {
+  const { t } = useTranslation(NAMESPACE);
+  const pageRoute = useRouterState({ select: (s) => s.location.pathname });
+
+  const [feedbackType, setFeedbackType] = useState<FeedbackType>('feature_request');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<'editing' | 'sending' | 'done' | 'error'>('editing');
+
+  const handleSubmit = () => {
+    const trimmed = message.trim();
+    if (!trimmed) return;
+    setStatus('sending');
+    try {
+      captureSurveySent(FEEDBACK_SURVEY_ID, {
+        feedbackType,
+        message: trimmed,
+        pageRoute,
+        appVersion: __BUILD_ID__,
+      });
+      setStatus('done');
+      // Brief success confirmation, then dismiss.
+      window.setTimeout(closeFeedbackModal, 1200);
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  if (status === 'done') {
+    return (
+      <DetailCard title={t('title')} closeLabel={t('close')} onClose={closeFeedbackModal}>
+        <CardContent className="flex flex-col items-center gap-3 py-6 text-center">
+          <div className="bg-accent-bright text-primary-foreground animate-in zoom-in-50 fade-in flex size-14 items-center justify-center rounded-full duration-300">
+            <Check className="size-7" />
+          </div>
+          <h3 className="font-heading text-lg font-semibold">{t('successTitle')}</h3>
+          <p className="text-muted-foreground text-sm">{t('successText')}</p>
+        </CardContent>
+      </DetailCard>
+    );
+  }
+
+  const sending = status === 'sending';
+  const canSubmit = message.trim().length > 0 && !sending;
+
+  return (
+    <DetailCard title={t('title')} closeLabel={t('close')} onClose={closeFeedbackModal}>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-semibold">{t('typeLabel')}</span>
+          <ToggleGroup
+            type="single"
+            variant="outline"
+            value={feedbackType}
+            // Radix clears the value when re-selecting the active item; keep a selection always.
+            onValueChange={(value) => value && setFeedbackType(value as FeedbackType)}
+            className="grid w-full grid-cols-3"
+          >
+            {TYPE_OPTIONS.map((option) => (
+              <ToggleGroupItem key={option.value} value={option.value} className="text-xs">
+                {t(option.labelKey)}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label htmlFor="feedback-message" className="text-sm font-semibold">
+            {t('messageLabel')}
+          </label>
+          <textarea
+            id="feedback-message"
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            placeholder={t('messagePlaceholder')}
+            rows={4}
+            className="border-input bg-input/20 placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 dark:bg-input/30 min-h-24 w-full resize-none rounded-md border px-3 py-2 text-sm transition-colors outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50"
+          />
+        </div>
+
+        {status === 'error' && <p className="text-destructive text-sm">{t('error')}</p>}
+
+        <Button
+          type="button"
+          size="lg"
+          disabled={!canSubmit}
+          onClick={handleSubmit}
+          className={cn(
+            'h-11 w-full gap-2',
+            canSubmit
+              ? 'bg-accent-bright text-primary-foreground hover:bg-accent-press'
+              : 'bg-surface-solid text-muted-foreground border-border border',
+          )}
+        >
+          {sending ? t('submitting') : status === 'error' ? t('retry') : t('submit')}
+        </Button>
+      </CardContent>
+    </DetailCard>
+  );
+}

--- a/packages/frontend-next/src/components/legal/PrivacyPolicy.i18n.ts
+++ b/packages/frontend-next/src/components/legal/PrivacyPolicy.i18n.ts
@@ -153,9 +153,12 @@ i18n.addResourceBundle('en', NAMESPACE, {
         'Pages and views accessed within the App',
         'Anonymous product events (e.g. that a report was submitted, together with the line, station, and direction IDs - these contain no personal identifiers)',
         'Coarse technical data (browser, operating system, device type, referrer)',
+        'Feedback you choose to submit via the in-app feedback function (the feedback type and your free-text message, together with the page you submitted it from and the app version)',
       ],
       storage:
         'We configure PostHog not to store IP addresses, and we do not use session recordings (session replays). If you allow cookies, PostHog stores a pseudonymous identifier in a cookie or local-storage entry on your device so we can recognize returning visits and measure usage over time. If you decline cookies, we continue to collect only anonymous, cookieless usage statistics, with nothing stored on your device. This processing is based on our legitimate interest in analyzing and improving the service (Art. 6(1)(f) GDPR). You can change your cookie choice at any time via "Analytics" in the App\'s settings, and you can object to the analytics entirely - including the cookieless statistics - by enabling the "Do Not Track" setting in your browser or by contacting us at contact@freifahren.org; we honor both. The data is processed on PostHog\'s EU servers; for any transfer to a third country see Section 14, and for the data processing agreement see Section 15. Analytics requests are routed through our own domain to PostHog (a reverse proxy) for reliability; the data, recipient (PostHog), and purpose remain unchanged from those described above.',
+      feedback:
+        'The App offers a feedback function that lets you voluntarily send us feature requests, bug reports, or general feedback. The content you enter is transmitted to PostHog (as described above) and processed solely to evaluate and improve the App and, where appropriate, to respond to your feedback; the legal basis is our legitimate interest in improving the service (Art. 6(1)(f) GDPR). Because the free-text field is processed as you write it, it may contain personal data; please do not enter any sensitive personal data or more personal details than necessary.',
     },
   },
 });
@@ -310,9 +313,12 @@ i18n.addResourceBundle('de', NAMESPACE, {
         'Aufgerufene Seiten und Ansichten innerhalb der App',
         'Anonyme Produktereignisse (z. B. dass eine Meldung abgesendet wurde, samt der IDs von Linie, Station und Richtung - diese enthalten keine Personenbezugsdaten)',
         'Technische Näherungsdaten (Browser, Betriebssystem, Gerätetyp, Referrer)',
+        'Rückmeldungen, die Sie über die In-App-Feedback-Funktion absenden (die Art des Feedbacks und Ihr Freitext, zusammen mit der Seite, von der Sie es abgesendet haben, und der App-Version)',
       ],
       storage:
         'Wir konfigurieren PostHog so, dass keine IP-Adressen gespeichert werden, und setzen keine Sitzungsaufzeichnungen (Session Replays) ein. Wenn Sie Cookies erlauben, speichert PostHog eine pseudonyme Kennung in einem Cookie- oder Local-Storage-Eintrag auf Ihrem Endgerät, damit wir wiederkehrende Besuche erkennen und die Nutzung über die Zeit messen können. Wenn Sie Cookies ablehnen, erfassen wir weiterhin ausschließlich anonyme, cookielose Nutzungsstatistiken, ohne dass etwas auf Ihrem Endgerät gespeichert wird. Diese Verarbeitung erfolgt auf Grundlage unseres berechtigten Interesses an der Analyse und Verbesserung des Dienstes (Art. 6 Abs. 1 lit. f DSGVO). Sie können Ihre Cookie-Auswahl jederzeit über "Analyse" in den Einstellungen der App ändern und der Reichweitenmessung insgesamt - einschließlich der cookielosen Statistiken - widersprechen, indem Sie die "Do Not Track"-Einstellung Ihres Browsers aktivieren oder uns unter contact@freifahren.org kontaktieren; wir berücksichtigen beides. Die Verarbeitung erfolgt auf den EU-Servern von PostHog; Hinweise zu einem etwaigen Drittlandtransfer finden Sie in Abschnitt 14 und zum Auftragsverarbeitungsvertrag in Abschnitt 15. Analyse-Anfragen werden zur Verbesserung der Zuverlässigkeit über unsere eigene Domain an PostHog weitergeleitet (Reverse Proxy); Daten, Empfänger (PostHog) und Zweck bleiben gegenüber den oben beschriebenen unverändert.',
+      feedback:
+        'Die App bietet eine Feedback-Funktion, über die Sie uns freiwillig Feature-Wünsche, Fehlermeldungen oder allgemeines Feedback senden können. Die von Ihnen eingegebenen Inhalte werden an PostHog (wie oben beschrieben) übermittelt und ausschließlich verarbeitet, um die App auszuwerten und zu verbessern sowie gegebenenfalls auf Ihr Feedback zu reagieren; Rechtsgrundlage ist unser berechtigtes Interesse an der Verbesserung des Dienstes (Art. 6 Abs. 1 lit. f DSGVO). Da das Freitextfeld so verarbeitet wird, wie Sie es eingeben, kann es personenbezogene Daten enthalten; bitte geben Sie keine besonderen Kategorien personenbezogener Daten und nicht mehr personenbezogene Angaben als nötig ein.',
     },
   },
 });

--- a/packages/frontend-next/src/components/legal/PrivacyPolicy.tsx
+++ b/packages/frontend-next/src/components/legal/PrivacyPolicy.tsx
@@ -135,6 +135,7 @@ export function PrivacyPolicy() {
           ))}
         </ul>
         <p>{t('sections.webAnalytics.storage')}</p>
+        <p>{t('sections.webAnalytics.feedback')}</p>
       </section>
     </LegalPage>
   );

--- a/packages/frontend-next/src/components/map/SettingsButton.i18n.ts
+++ b/packages/frontend-next/src/components/map/SettingsButton.i18n.ts
@@ -8,6 +8,7 @@ i18n.addResourceBundle('en', NAMESPACE, {
   close: 'Close',
   // hub menu
   contact: 'Contact us',
+  feedback: 'Send feedback',
   contribute: 'Contribute',
   follow: 'Follow',
   // legal
@@ -30,6 +31,7 @@ i18n.addResourceBundle('de', NAMESPACE, {
   close: 'Schließen',
   // hub menu
   contact: 'Kontaktiere uns',
+  feedback: 'Feedback geben',
   contribute: 'Beitrag leisten',
   follow: 'Folgen',
   // legal

--- a/packages/frontend-next/src/components/map/SettingsCard.tsx
+++ b/packages/frontend-next/src/components/map/SettingsCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { ChevronRight, HeartHandshake, Mail } from 'lucide-react';
+import { ChevronRight, HeartHandshake, Mail, MessageSquarePlus } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { GithubIcon, InstagramIcon } from '@/components/brand-icons';
@@ -9,6 +9,7 @@ import { SectionHeading } from '@/components/ui/section-heading';
 import { Separator } from '@/components/ui/separator';
 import { openConsentSettings } from '@/lib/consent';
 import { openContributeModal } from '@/lib/contribute-modal';
+import { openFeedbackModal } from '@/lib/feedback-modal';
 import { openLegalDisclaimer } from '@/lib/legal-disclaimer';
 import { Route as ContactRoute } from '@/routes/_map/settings/contact';
 import { Route as ImpressumRoute } from '@/routes/impressum';
@@ -70,6 +71,15 @@ export function SettingsCard({ onClose }: SettingsCardProps) {
           <span>{t('contact')}</span>
           <ChevronRight className="text-muted-foreground ml-auto size-4" />
         </Link>
+        <button
+          type="button"
+          onClick={() => openFeedbackModal('settings')}
+          className="hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm transition-colors outline-none"
+        >
+          <MessageSquarePlus className="text-muted-foreground size-4" />
+          <span>{t('feedback')}</span>
+          <ChevronRight className="text-muted-foreground ml-auto size-4" />
+        </button>
       </div>
 
       <CardContent>

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { type SubmitReportResponse, useSubmitReport } from '@/api/reports';
 import { type Station } from '@/api/transit';
+import { FeedbackButton } from '@/components/feedback/FeedbackButton';
 import { PageHeader } from '@/components/templates/PageHeader';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Button } from '@/components/ui/button';
@@ -351,7 +352,17 @@ export function ReportForm() {
             <ReportSuccess result={result} onClose={handleSuccessClose} />
           ) : (
             <>
-              <PageHeader title={t('title')} onBack={() => navigate({ to: '/' })} />
+              <PageHeader
+                title={t('title')}
+                onBack={() => navigate({ to: '/' })}
+                action={
+                  <FeedbackButton
+                    source="report_form"
+                    size="xs"
+                    className="text-muted-foreground hover:text-foreground"
+                  />
+                }
+              />
               <LinePicker />
               <StationPicker />
               <DirectionPicker />

--- a/packages/frontend-next/src/components/report/ReportSuccess.tsx
+++ b/packages/frontend-next/src/components/report/ReportSuccess.tsx
@@ -50,6 +50,7 @@ export function ReportSuccess({
           </span>
         </div>
         <p className="text-muted-foreground text-sm">{t('description')}</p>
+        <FeedbackButton source="report_success" variant="outline" className="border-border mt-4" />
       </div>
 
       <p className="text-muted-foreground text-[0.6875rem]">{t('syncText')}</p>
@@ -61,10 +62,6 @@ export function ReportSuccess({
       >
         {t('continue')}
       </Button>
-      <FeedbackButton
-        source="report_success"
-        className="text-muted-foreground hover:text-foreground mt-2 text-xs"
-      />
     </div>
   );
 }

--- a/packages/frontend-next/src/components/report/ReportSuccess.tsx
+++ b/packages/frontend-next/src/components/report/ReportSuccess.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { SubmitReportResponse } from '@/api/reports';
 import { useLines, useStations } from '@/api/transit';
+import { FeedbackButton } from '@/components/feedback/FeedbackButton';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Button } from '@/components/ui/button';
 import { useCountAnimation } from '@/hooks/useCountAnimation';
@@ -60,6 +61,10 @@ export function ReportSuccess({
       >
         {t('continue')}
       </Button>
+      <FeedbackButton
+        source="report_success"
+        className="text-muted-foreground hover:text-foreground mt-2 text-xs"
+      />
     </div>
   );
 }

--- a/packages/frontend-next/src/components/templates/PageHeader.tsx
+++ b/packages/frontend-next/src/components/templates/PageHeader.tsx
@@ -9,9 +9,11 @@ import { NAMESPACE } from './PageHeader.i18n';
 type PageHeaderProps = {
   title: string;
   onBack: () => void;
+  /** Optional trailing content, right-aligned in the header (e.g. a feedback button). */
+  action?: React.ReactNode;
 };
 
-export function PageHeader({ title, onBack }: PageHeaderProps) {
+export function PageHeader({ title, onBack, action }: PageHeaderProps) {
   const { t } = useTranslation(NAMESPACE);
 
   return (
@@ -28,6 +30,7 @@ export function PageHeader({ title, onBack }: PageHeaderProps) {
           <ChevronLeft className="size-5" />{' '}
         </Button>
         <h1 className="font-heading text-lg font-semibold">{title}</h1>
+        {action && <div className="-mr-2 ml-auto">{action}</div>}
       </header>
       <Separator className="my-2" />
     </>

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -67,3 +67,59 @@ export function setSuperProperties(properties: Partial<SuperProperties>): void {
   }
   posthog.register(properties);
 }
+
+export type FeedbackType = 'feature_request' | 'bug_report' | 'general';
+
+export const SURVEY_QUESTIONS = [
+  { id: 'feedback_type', question: 'What kind of feedback is this?' },
+  { id: 'feedback_message', question: 'Tell us more' },
+] as const;
+
+// The single-choice answer must match the survey's choice labels (defined in English in PostHog,
+// regardless of the app's UI language) so responses aggregate under the right option.
+const FEEDBACK_TYPE_CHOICE: Record<FeedbackType, string> = {
+  feature_request: 'Feature request',
+  bug_report: 'Bug report',
+  general: 'General feedback',
+};
+
+export function captureSurveyShown(surveyId: string): void {
+  if (import.meta.env.DEV) {
+    console.log('[analytics] survey shown', { surveyId });
+  }
+  posthog.capture('survey shown', { $survey_id: surveyId });
+}
+
+export function captureSurveyDismissed(surveyId: string): void {
+  if (import.meta.env.DEV) {
+    console.log('[analytics] survey dismissed', { surveyId });
+  }
+  posthog.capture('survey dismissed', { $survey_id: surveyId });
+}
+
+export function captureSurveySent(
+  surveyId: string,
+  response: {
+    feedbackType: FeedbackType;
+    message: string;
+    pageRoute: string;
+    appVersion: string;
+  },
+): void {
+  const properties = {
+    $survey_id: surveyId,
+    $survey_questions: SURVEY_QUESTIONS.map((q) => ({ id: q.id, question: q.question })),
+    // Index-keyed responses are the format PostHog attributes to the survey's questions in order.
+    $survey_response: FEEDBACK_TYPE_CHOICE[response.feedbackType],
+    $survey_response_1: response.message,
+    // Duplicated under plain names + context so the feedback is self-contained for Linear routing.
+    feedback_type: response.feedbackType,
+    feedback_message: response.message,
+    page_route: response.pageRoute,
+    app_version: response.appVersion,
+  };
+  if (import.meta.env.DEV) {
+    console.log('[analytics] survey sent', properties);
+  }
+  posthog.capture('survey sent', properties);
+}

--- a/packages/frontend-next/src/lib/feedback-modal.ts
+++ b/packages/frontend-next/src/lib/feedback-modal.ts
@@ -1,0 +1,47 @@
+import { useSyncExternalStore } from 'react';
+
+import { captureSurveyShown } from '@/lib/analytics';
+import { optionalEnv } from '@/lib/utils';
+
+// Which in-app entry point opened the feedback modal. Carried through so we can see which surface
+// drives feedback once submissions land in PostHog.
+export type FeedbackSource = 'report_form' | 'reports_overview' | 'report_success' | 'settings';
+
+// The PostHog survey responses are attributed to. Set VITE_POSTHOG_FEEDBACK_SURVEY_ID to the id of
+// an API-type survey created in the project. When unset (e.g. local dev) we still emit the events
+// under this fallback id so the funnel is visible in the DEV console — they just won't attach to a
+// real survey until the id is wired up.
+export const FEEDBACK_SURVEY_ID = optionalEnv('VITE_POSTHOG_FEEDBACK_SURVEY_ID') ?? 'app-feedback';
+
+let open = false;
+let source: FeedbackSource = 'settings';
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function openFeedbackModal(from: FeedbackSource): void {
+  source = from;
+  open = true;
+  notify();
+  captureSurveyShown(FEEDBACK_SURVEY_ID);
+}
+
+export function getFeedbackSource(): FeedbackSource {
+  return source;
+}
+
+export function closeFeedbackModal(): void {
+  open = false;
+  notify();
+}
+
+export function useFeedbackModalOpen(): boolean {
+  return useSyncExternalStore(subscribe, () => open);
+}

--- a/packages/frontend-next/src/routes/__root.tsx
+++ b/packages/frontend-next/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import { createRootRoute, Outlet } from '@tanstack/react-router';
 
 import { ConsentBanner } from '@/components/ConsentBanner';
 import { ContributeCard } from '@/components/contribute/ContributeCard';
+import { FeedbackCard } from '@/components/feedback/FeedbackCard';
 import { LegalDisclaimer } from '@/components/LegalDisclaimer';
 import { PersistentMapView } from '@/components/map/PersistentMapView';
 import { GeolocationProvider } from '@/contexts/GeolocationProvider';
@@ -16,6 +17,7 @@ export const Route = createRootRoute({
       <Outlet />
       <LegalDisclaimer />
       <ContributeCard />
+      <FeedbackCard />
       <ConsentBanner />
     </GeolocationProvider>
   ),

--- a/packages/frontend-next/src/routes/reports.tsx
+++ b/packages/frontend-next/src/routes/reports.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { queryClient } from '@/api/queryClient';
 import { DAY_MS, HOUR_MS, reportsSliceQueryOptions, useReports } from '@/api/reports';
 import { linesQueryOptions, stationsQueryOptions } from '@/api/transit';
+import { FeedbackButton } from '@/components/feedback/FeedbackButton';
 import { ReportsTabBar } from '@/components/reports/ReportsTabBar';
 import { NAMESPACE } from '@/components/reports/Reports.i18n';
 import { PageHeader } from '@/components/templates/PageHeader';
@@ -41,7 +42,17 @@ function ReportsOverviewLayout() {
   return (
     <div className="bg-card animate-in fade-in fixed inset-0 z-30 duration-150">
       <div className="mx-auto flex h-full w-full max-w-md flex-col">
-        <PageHeader title={t('title')} onBack={() => navigate({ to: '/' })} />
+        <PageHeader
+          title={t('title')}
+          onBack={() => navigate({ to: '/' })}
+          action={
+            <FeedbackButton
+              source="reports_overview"
+              size="xs"
+              className="text-muted-foreground hover:text-foreground"
+            />
+          }
+        />
         <div className="flex items-baseline gap-2 px-4 pt-2 pb-4">
           <span className="font-heading text-3xl font-semibold">{reports?.length ?? 0}</span>
           <span className="text-muted-foreground text-sm">{t('summaryCount')}</span>


### PR DESCRIPTION
## Summary

Adds a native in-app feedback entry point that lets users submit **feature requests**, **bug reports**, or **general feedback**, captured in PostHog as a survey response (`survey sent` event) for analysis and later routing to Linear Triage (follow-up FRE-661).

PostHog has no hosted survey iframe, so — per discussion on the issue — the form is rendered with existing app components and the survey events (`survey shown` / `survey sent`) are emitted directly. A matching API-type survey ("In-app feedback") has been created and launched in the PostHog project; its id is wired via `VITE_POSTHOG_FEEDBACK_SURVEY_ID`.

## What's included

- **Reusable components**: `FeedbackButton` + `FeedbackCard` modal, mirroring the existing `contribute-modal` external-store pattern; `FeedbackCard` is mounted once in `__root.tsx`.
- **Entry points**: report form header, reports overview header, report success screen, and settings.
- **Two questions**: feedback type (single choice) + free-form text. Submit is disabled until text is entered; submitting/success/error states are handled.
- **Context**: each submission carries the feedback type, message, current route, and app version (`__BUILD_ID__`). The app stays anonymous — no `identify()`, no email.
- **i18n**: localized labels (EN + DE) shown to the user, while a stable `feedback_type` id is sent to PostHog so responses aggregate the same way across languages.
- **Privacy policy**: Section 16 updated (EN + DE) to describe the voluntary feedback data flow.

## Acceptance criteria

- [x] Clear in-app entry point; opens without navigating away
- [x] First question = feedback type, second = free-form text
- [x] Submitting records a completed survey response in PostHog
- [x] Same user can submit repeatedly (form resets on each open)
- [x] Works on desktop and mobile (bottom-sheet modal)
- [x] Loading/error states handled

> Note: acceptance criteria mention an iframe; PostHog does not offer hosted survey iframes, so this uses a native form emitting survey events (agreed approach). Privacy-policy copy should get a sign-off from the policy owner.

## Verification

- `tsc -b`, `eslint`, `prettier --check`, and `vite build` all pass.
- Manually: open feedback from each of the four surfaces, submit twice, confirm responses land under the "In-app feedback" survey in PostHog (DEV console also logs `[analytics] survey sent`).

## Follow-up

FRE-661: route completed PostHog feedback submissions into Linear Triage (will also require adding Linear as a sub-processor in the privacy policy, Sections 14/15).