### PR TITLE
feat: link GitHub and Instagram from the map

### DIFF
--- a/packages/frontend-next/.env.example
+++ b/packages/frontend-next/.env.example
@@ -9,3 +9,7 @@ VITE_POSTHOG_KEY=
 VITE_POSTHOG_HOST=https://eu.i.posthog.com
 # Id of the API-type PostHog survey that in-app feedback submissions are attributed to.
 VITE_POSTHOG_FEEDBACK_SURVEY_ID=
+
+# Social links shown in the app (settings + map).
+VITE_GITHUB_URL=https://github.com/FreiFahren/FreiFahren
+VITE_INSTAGRAM_URL=https://www.instagram.com/frei.fahren

--- a/packages/frontend-next/.env.production
+++ b/packages/frontend-next/.env.production
@@ -9,3 +9,7 @@ VITE_STRIPE_PAYMENT_LINK=https://buy.stripe.com/28E9AW9Y634e8HQ9Sq3wQ00
 VITE_POSTHOG_KEY=phc_rR635vqhSmp6st6GYqJG23uZVCmtESsDQT4Caijwv2N5
 VITE_POSTHOG_HOST=https://eu.i.posthog.com
 VITE_POSTHOG_FEEDBACK_SURVEY_ID=019ec61d-7044-0000-0c79-734d7b31e436
+
+# Social links shown in the app (settings + map).
+VITE_GITHUB_URL=https://github.com/FreiFahren/FreiFahren
+VITE_INSTAGRAM_URL=https://www.instagram.com/frei.fahren

--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -52,14 +52,17 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
         {report && (
           <p className="text-muted-foreground text-sm">{formatElapsed(report.timestamp, t)}</p>
         )}
-        {stationDistance !== undefined && (
-          <p className="text-muted-foreground flex items-center gap-1 text-sm">
-            <MapPin className="size-3.5 shrink-0" />
-            {stationDistance <= 1
-              ? t('oneStationAway')
-              : t('stationsAway', { count: stationDistance })}
-          </p>
-        )}
+        {/* Reserve the line height so the distance resolving in does not shift layout. */}
+        <p className="text-muted-foreground flex min-h-5 items-center gap-1 text-sm">
+          {stationDistance !== undefined && (
+            <>
+              <MapPin className="size-3.5 shrink-0" />
+              {stationDistance <= 1
+                ? t('oneStationAway')
+                : t('stationsAway', { count: stationDistance })}
+            </>
+          )}
+        </p>
         {/* Reserve the line height so the count loading in does not shift layout. */}
         <p className="min-h-5 text-sm">
           {numberOfReports !== undefined && numberOfReports > 0 && (

--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -10,6 +10,7 @@ import { optionalEnv } from '@/lib/utils';
 
 import { DetailCard } from './DetailCard';
 import { NAMESPACE } from './ReportDetail.i18n';
+import { SocialLinks } from './SocialLinks';
 
 type ReportDetailProps = {
   station: Station;
@@ -71,9 +72,12 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
           )}
         </p>
       </CardContent>
-      <CardContent className="text-muted-foreground space-y-0.5 text-xs">
-        <p>{t('inviteText')}</p>
-        <p>{t('syncText', { group: REPORTS_GROUP_HANDLE })}</p>
+      <CardContent className="text-muted-foreground flex items-end justify-between gap-3 text-xs">
+        <div className="space-y-0.5">
+          <p>{t('inviteText')}</p>
+          <p>{t('syncText', { group: REPORTS_GROUP_HANDLE })}</p>
+        </div>
+        <SocialLinks appearance="inline" className="-mr-2 shrink-0" />
       </CardContent>
     </DetailCard>
   );

--- a/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
+++ b/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
@@ -3,19 +3,13 @@ import { useTranslation } from 'react-i18next';
 
 import { HOUR_MS, useReports } from '@/api/reports';
 import { useLines, useStations } from '@/api/transit';
-import { GithubIcon, InstagramIcon } from '@/components/brand-icons';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Button } from '@/components/ui/button';
 import { markReportViewed, useReportViewed } from '@/lib/viewed-reports';
 import { Route as ReportsSummaryRoute } from '@/routes/reports/index';
 
 import { NAMESPACE } from './ReportsOverviewButton.i18n';
-
-const GITHUB_URL = 'https://github.com/FreiFahren/FreiFahren';
-const INSTAGRAM_URL = 'https://www.instagram.com/frei.fahren';
-
-const socialButtonClass =
-  'bg-card text-card-foreground hover:bg-card/80 pointer-events-auto size-8 rounded-lg shadow-[0_6px_16px_rgba(0,0,0,0.28)]';
+import { SocialLinks } from './SocialLinks';
 
 export function ReportsOverviewButton() {
   const { t } = useTranslation(NAMESPACE);
@@ -40,30 +34,7 @@ export function ReportsOverviewButton() {
 
   return (
     <div className="pointer-events-none fixed bottom-0 left-0 z-20 flex flex-col items-start gap-1.5 p-3">
-      <div className="flex gap-1.5">
-        <Button
-          asChild
-          variant="secondary"
-          size="icon-sm"
-          aria-label="GitHub"
-          className={socialButtonClass}
-        >
-          <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
-            <GithubIcon />
-          </a>
-        </Button>
-        <Button
-          asChild
-          variant="secondary"
-          size="icon-sm"
-          aria-label="Instagram"
-          className={socialButtonClass}
-        >
-          <a href={INSTAGRAM_URL} target="_blank" rel="noopener noreferrer">
-            <InstagramIcon />
-          </a>
-        </Button>
-      </div>
+      <SocialLinks />
       <Button
         asChild
         variant="secondary"

--- a/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
+++ b/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
@@ -3,12 +3,19 @@ import { useTranslation } from 'react-i18next';
 
 import { HOUR_MS, useReports } from '@/api/reports';
 import { useLines, useStations } from '@/api/transit';
+import { GithubIcon, InstagramIcon } from '@/components/brand-icons';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Button } from '@/components/ui/button';
 import { markReportViewed, useReportViewed } from '@/lib/viewed-reports';
 import { Route as ReportsSummaryRoute } from '@/routes/reports/index';
 
 import { NAMESPACE } from './ReportsOverviewButton.i18n';
+
+const GITHUB_URL = 'https://github.com/FreiFahren/FreiFahren';
+const INSTAGRAM_URL = 'https://www.instagram.com/frei.fahren';
+
+const socialButtonClass =
+  'bg-card text-card-foreground hover:bg-card/80 pointer-events-auto size-8 rounded-lg shadow-[0_6px_16px_rgba(0,0,0,0.28)]';
 
 export function ReportsOverviewButton() {
   const { t } = useTranslation(NAMESPACE);
@@ -32,7 +39,31 @@ export function ReportsOverviewButton() {
   const stationName = stations?.[latest.stationId]?.name;
 
   return (
-    <div className="pointer-events-none fixed bottom-0 left-0 z-20 p-3">
+    <div className="pointer-events-none fixed bottom-0 left-0 z-20 flex flex-col items-start gap-1.5 p-3">
+      <div className="flex gap-1.5">
+        <Button
+          asChild
+          variant="secondary"
+          size="icon-sm"
+          aria-label="GitHub"
+          className={socialButtonClass}
+        >
+          <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+            <GithubIcon />
+          </a>
+        </Button>
+        <Button
+          asChild
+          variant="secondary"
+          size="icon-sm"
+          aria-label="Instagram"
+          className={socialButtonClass}
+        >
+          <a href={INSTAGRAM_URL} target="_blank" rel="noopener noreferrer">
+            <InstagramIcon />
+          </a>
+        </Button>
+      </div>
       <Button
         asChild
         variant="secondary"

--- a/packages/frontend-next/src/components/map/SettingsCard.tsx
+++ b/packages/frontend-next/src/components/map/SettingsCard.tsx
@@ -2,7 +2,6 @@ import { Link } from '@tanstack/react-router';
 import { ChevronRight, HeartHandshake, Mail, MessageSquarePlus } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-import { GithubIcon, InstagramIcon } from '@/components/brand-icons';
 import { Button } from '@/components/ui/button';
 import { CardContent } from '@/components/ui/card';
 import { SectionHeading } from '@/components/ui/section-heading';
@@ -17,9 +16,8 @@ import { Route as PrivacyRoute } from '@/routes/privacy';
 
 import { DetailCard } from './DetailCard';
 import { NAMESPACE } from './SettingsButton.i18n';
+import { SocialLinks } from './SocialLinks';
 
-const GITHUB_URL = 'https://github.com/FreiFahren/FreiFahren';
-const INSTAGRAM_URL = 'https://www.instagram.com/frei.fahren';
 const WEBSITE_URL = 'https://freifahren.org';
 
 function LegalLink({
@@ -97,18 +95,7 @@ export function SettingsCard({ onClose }: SettingsCardProps) {
 
       <CardContent className="flex flex-col gap-2">
         <SectionHeading className="text-muted-foreground">{t('follow')}</SectionHeading>
-        <div className="flex -space-x-2">
-          <Button asChild variant="ghost" size="icon" aria-label="GitHub">
-            <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
-              <GithubIcon />
-            </a>
-          </Button>
-          <Button asChild variant="ghost" size="icon" aria-label="Instagram">
-            <a href={INSTAGRAM_URL} target="_blank" rel="noopener noreferrer">
-              <InstagramIcon />
-            </a>
-          </Button>
-        </div>
+        <SocialLinks appearance="inline" className="-ml-2" />
       </CardContent>
 
       <Separator className="my-1" />

--- a/packages/frontend-next/src/components/map/SocialLinks.tsx
+++ b/packages/frontend-next/src/components/map/SocialLinks.tsx
@@ -1,0 +1,51 @@
+import { GithubIcon, InstagramIcon } from '@/components/brand-icons';
+import { Button } from '@/components/ui/button';
+import { cn, optionalEnv } from '@/lib/utils';
+
+const GITHUB_URL = optionalEnv('VITE_GITHUB_URL') ?? 'https://github.com/FreiFahren/FreiFahren';
+const INSTAGRAM_URL = optionalEnv('VITE_INSTAGRAM_URL') ?? 'https://www.instagram.com/frei.fahren';
+
+// Two appearances: 'floating' for map overlays (needs its own card background + shadow to read over
+// the map) and 'inline' for use inside an existing card (plain ghost buttons, like in settings).
+const APPEARANCE_CLASS = {
+  floating:
+    'bg-card text-card-foreground hover:bg-card/80 pointer-events-auto size-8 rounded-lg shadow-[0_6px_16px_rgba(0,0,0,0.28)]',
+  inline: 'text-muted-foreground hover:text-foreground',
+} as const;
+
+type SocialLinksProps = {
+  className?: string;
+  appearance?: keyof typeof APPEARANCE_CLASS;
+};
+
+// Small GitHub + Instagram icon buttons reused on the map (above the reports-overview button and
+// inside the report card). Layout (row vs column) is left to the caller via className.
+export function SocialLinks({ className, appearance = 'floating' }: SocialLinksProps) {
+  const buttonClass = APPEARANCE_CLASS[appearance];
+  return (
+    <div className={cn('flex gap-1.5', className)}>
+      <Button
+        asChild
+        variant="secondary"
+        size="icon-sm"
+        aria-label="GitHub"
+        className={buttonClass}
+      >
+        <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+          <GithubIcon />
+        </a>
+      </Button>
+      <Button
+        asChild
+        variant="secondary"
+        size="icon-sm"
+        aria-label="Instagram"
+        className={buttonClass}
+      >
+        <a href={INSTAGRAM_URL} target="_blank" rel="noopener noreferrer">
+          <InstagramIcon />
+        </a>
+      </Button>
+    </div>
+  );
+}

--- a/packages/frontend-next/src/components/report/ReportSuccess.tsx
+++ b/packages/frontend-next/src/components/report/ReportSuccess.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import type { SubmitReportResponse } from '@/api/reports';
 import { useLines, useStations } from '@/api/transit';
 import { FeedbackButton } from '@/components/feedback/FeedbackButton';
+import { SocialLinks } from '@/components/map/SocialLinks';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Button } from '@/components/ui/button';
 import { useCountAnimation } from '@/hooks/useCountAnimation';
@@ -62,6 +63,7 @@ export function ReportSuccess({
       >
         {t('continue')}
       </Button>
+      <SocialLinks appearance="inline" className="mt-3 justify-center" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds small **GitHub** and **Instagram** icon links stacked just above the reports-overview button on the map, giving users a quick path to the project's socials from the main screen (previously only reachable from Settings).

## Details

- Two `icon-sm` buttons reusing the existing `GithubIcon` / `InstagramIcon` brand icons and the same card/shadow styling as the overview button, so they read as a set.
- Open in a new tab (`target="_blank"` + `rel="noopener noreferrer"`), with `aria-label`s for accessibility.
- They share the overview button's fixed bottom-left container, so they appear/disappear together with it.

## Verification

- `tsc -b`, `eslint`, and `prettier --check` pass.