### PR TITLE
refactor: give the station-resolution stage its own seam + unit tests

### DIFF
--- a/packages/telegram_bot/src/telegram_bot/extractor.py
+++ b/packages/telegram_bot/src/telegram_bot/extractor.py
@@ -5,6 +5,7 @@ import json
 import logging
 import re
 import unicodedata
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 
@@ -302,6 +303,12 @@ async def request_station_name_extraction(
         return None
 
 
+# --- Resolution stage --------------------------------------------------------
+# `resolve_extraction` is the deterministic resolution stage's interface, kept separate
+# from however the raw strings were produced: raw extracted strings (a
+# `StationNameExtraction`) plus a detected line go in, resolved station/direction ids come
+# out. In production a Mistral call (see `mistral_llm` below) fills the `StationNameExtraction`;
+# unit tests construct it directly, so every fuzzy-match edge case is testable without an LLM.
 def resolve_extraction(
     *,
     station_index: StationIndex,
@@ -326,6 +333,28 @@ def resolve_extraction(
     )
 
 
+# --- LLM adapter -------------------------------------------------------------
+# An LLM adapter sits in front of the resolution stage: a message goes in, the raw
+# extracted strings (or None on failure) come out. Mistral is the production adapter;
+# tests can supply any callable with this shape, or skip the adapter entirely and exercise
+# `resolve_extraction` against canned `StationNameExtraction`s.
+StationNameLLM = Callable[[str], Awaitable[StationNameExtraction | None]]
+
+
+def mistral_llm(*, client: Mistral, model: str, system_prompt: str) -> StationNameLLM:
+    """Production LLM adapter: a Mistral chat completion in front of the resolution stage."""
+
+    async def call(message: str) -> StationNameExtraction | None:
+        return await request_station_name_extraction(
+            client=client,
+            model=model,
+            system_prompt=system_prompt,
+            message=message,
+        )
+
+    return call
+
+
 async def extract(
     *,
     message: str,
@@ -342,12 +371,8 @@ async def extract(
         line_pattern,
         transit.circular_line_names,
     )
-    parsed = await request_station_name_extraction(
-        client=client,
-        model=model,
-        system_prompt=system_prompt,
-        message=message,
-    )
+    llm = mistral_llm(client=client, model=model, system_prompt=system_prompt)
+    parsed = await llm(message)
     return (
         None
         if parsed is None

--- a/packages/telegram_bot/src/telegram_bot/extractor.py
+++ b/packages/telegram_bot/src/telegram_bot/extractor.py
@@ -303,12 +303,8 @@ async def request_station_name_extraction(
         return None
 
 
-# --- Resolution stage --------------------------------------------------------
-# `resolve_extraction` is the deterministic resolution stage's interface, kept separate
-# from however the raw strings were produced: raw extracted strings (a
-# `StationNameExtraction`) plus a detected line go in, resolved station/direction ids come
-# out. In production a Mistral call (see `mistral_llm` below) fills the `StationNameExtraction`;
-# unit tests construct it directly, so every fuzzy-match edge case is testable without an LLM.
+# Resolution stage: raw extracted strings + detected line in, station/direction ids out.
+# Kept separate from the LLM so its fuzzy-match edge cases are testable without one.
 def resolve_extraction(
     *,
     station_index: StationIndex,
@@ -333,17 +329,11 @@ def resolve_extraction(
     )
 
 
-# --- LLM adapter -------------------------------------------------------------
-# An LLM adapter sits in front of the resolution stage: a message goes in, the raw
-# extracted strings (or None on failure) come out. Mistral is the production adapter;
-# tests can supply any callable with this shape, or skip the adapter entirely and exercise
-# `resolve_extraction` against canned `StationNameExtraction`s.
+# LLM adapter in front of the resolution stage: message in, raw extracted strings out.
 StationNameLLM = Callable[[str], Awaitable[StationNameExtraction | None]]
 
 
 def mistral_llm(*, client: Mistral, model: str, system_prompt: str) -> StationNameLLM:
-    """Production LLM adapter: a Mistral chat completion in front of the resolution stage."""
-
     async def call(message: str) -> StationNameExtraction | None:
         return await request_station_name_extraction(
             client=client,

--- a/packages/telegram_bot/tests/test_resolution.py
+++ b/packages/telegram_bot/tests/test_resolution.py
@@ -1,0 +1,144 @@
+"""Unit tests for the deterministic resolution stage.
+
+These exercise the seam below the LLM adapter: raw extracted strings (a
+``StationNameExtraction``) + a detected line in, resolved station/direction ids out.
+They build a tiny synthetic ``TransitData`` so they run in milliseconds with no backend
+and no Mistral API key — the edge cases that previously only the eval harness covered.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from telegram_bot.extractor import (
+    StationIndex,
+    StationNameExtraction,
+    normalize_name,
+    pick_direction,
+    pick_station,
+    resolve_extraction,
+)
+from telegram_bot.transit import LineVariant, Station, TransitData
+
+
+def _make_transit() -> TransitData:
+    """A handful of real Berlin stations chosen to hit the disambiguation edge cases."""
+    stations = {
+        s.id: s
+        for s in [
+            Station(id='S-suedkreuz', name='Südkreuz', line_names=('S41', 'S42')),
+            Station(id='U-turmstrasse', name='Turmstraße', line_names=('U9',)),
+            Station(id='U-leinestrasse', name='Leinestraße', line_names=('U8',)),
+            Station(id='U-rudow', name='Rudow', line_names=('U7',)),
+            Station(id='U-rathaus-neukoelln', name='Rathaus Neukölln', line_names=('U7',)),
+            Station(id='U-hermannplatz', name='Hermannplatz', line_names=('U7', 'U8')),
+        ]
+    }
+    variants = (
+        LineVariant(id='S41-v', name='S41', is_circular=True, stations=('S-suedkreuz',)),
+        LineVariant(id='S42-v', name='S42', is_circular=True, stations=('S-suedkreuz',)),
+        LineVariant(id='U9-v', name='U9', is_circular=False, stations=('U-turmstrasse',)),
+        LineVariant(id='U8-v', name='U8', is_circular=False, stations=('U-leinestrasse', 'U-hermannplatz')),
+        LineVariant(
+            id='U7-v',
+            name='U7',
+            is_circular=False,
+            stations=('U-rudow', 'U-rathaus-neukoelln', 'U-hermannplatz'),
+        ),
+    )
+    variants_by_name: dict[str, list[LineVariant]] = {}
+    for variant in variants:
+        variants_by_name.setdefault(variant.name, []).append(variant)
+    return TransitData(
+        stations=stations,
+        line_variants=variants,
+        line_names=tuple(sorted(variants_by_name)),
+        variants_by_name={name: tuple(vs) for name, vs in variants_by_name.items()},
+        circular_line_names=('S41', 'S42'),
+    )
+
+
+@pytest.fixture(scope='module')
+def index() -> StationIndex:
+    return StationIndex.build(_make_transit())
+
+
+# --- normalize_name ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('raw', 'expected'),
+    [
+        ('Südkreuz', 'sudkreuz'),  # diacritic folded to base letter
+        ('sudkreuz', 'sudkreuz'),  # ascii input already matches
+        ('  Südkreuz  ', 'sudkreuz'),  # surrounding whitespace stripped
+        ('S Südkreuz', 'sudkreuz'),  # "S " prefix stripped
+        ('U Turmstraße', 'turmstrasse'),  # "U " prefix + ß -> ss
+        ('Leinestr.', 'leinestrasse'),  # "str." abbreviation expanded
+        ('Leinestr', 'leinestrasse'),  # bare "str" suffix expanded
+    ],
+)
+def test_normalize_name(raw: str, expected: str) -> None:
+    assert normalize_name(raw) == expected
+
+
+# --- pick_station ------------------------------------------------------------
+
+
+def test_pick_station_resolves_diacritic_typo(index: StationIndex) -> None:
+    picked = pick_station(index, 'sudkreuz', None)
+    assert picked == ('S-suedkreuz', False)
+
+
+def test_pick_station_on_line_match_is_flagged(index: StationIndex) -> None:
+    assert pick_station(index, 'Rudow', 'U7') == ('U-rudow', True)
+
+
+def test_pick_station_drops_line_when_station_is_off_it(index: StationIndex) -> None:
+    """'u6 turmstr' — Turmstraße is on U9, so trust the station and drop the wrong line."""
+    picked = pick_station(index, 'turmstr', 'U6')
+    assert picked == ('U-turmstrasse', False)
+
+
+def test_pick_station_rejects_generic_non_station_word(index: StationIndex) -> None:
+    assert pick_station(index, 'Bahnhof', None) is None
+
+
+def test_pick_station_returns_none_for_empty_query(index: StationIndex) -> None:
+    assert pick_station(index, None, None) is None
+    assert pick_station(index, '', None) is None
+
+
+# --- pick_direction ----------------------------------------------------------
+
+
+def test_pick_direction_restricts_to_line(index: StationIndex) -> None:
+    assert pick_direction(index, 'Rudow', 'U7') == 'U-rudow'
+
+
+def test_pick_direction_none_for_missing_query(index: StationIndex) -> None:
+    assert pick_direction(index, None, 'U7') is None
+
+
+# --- resolve_extraction (the full resolution stage) --------------------------
+
+
+def test_resolve_extraction_station_and_direction(index: StationIndex) -> None:
+    parsed = StationNameExtraction(station_name='Rathaus Neukölln', direction_name='Rudow')
+    result = resolve_extraction(station_index=index, parsed=parsed, detected_line='U7')
+    assert result.station_id == 'U-rathaus-neukoelln'
+    assert result.line_name == 'U7'
+    assert result.direction_id == 'U-rudow'
+
+
+def test_resolve_extraction_drops_line_for_off_line_station(index: StationIndex) -> None:
+    parsed = StationNameExtraction(station_name='Turmstraße')
+    result = resolve_extraction(station_index=index, parsed=parsed, detected_line='U6')
+    assert result.station_id == 'U-turmstrasse'
+    assert result.line_name is None  # U6 dropped because Turmstraße isn't on it
+
+
+def test_resolve_extraction_empty_when_nothing_matches(index: StationIndex) -> None:
+    parsed = StationNameExtraction(station_name=None, direction_name=None)
+    result = resolve_extraction(station_index=index, parsed=parsed, detected_line=None)
+    assert result.is_empty

--- a/packages/telegram_bot/tests/test_resolution.py
+++ b/packages/telegram_bot/tests/test_resolution.py
@@ -1,9 +1,6 @@
-"""Unit tests for the deterministic resolution stage.
+"""Unit tests for the resolution stage: canned extracted strings in, station ids out.
 
-These exercise the seam below the LLM adapter: raw extracted strings (a
-``StationNameExtraction``) + a detected line in, resolved station/direction ids out.
-They build a tiny synthetic ``TransitData`` so they run in milliseconds with no backend
-and no Mistral API key — the edge cases that previously only the eval harness covered.
+Use a synthetic TransitData so they run with no backend and no Mistral API key.
 """
 
 from __future__ import annotations
@@ -22,7 +19,6 @@ from telegram_bot.transit import LineVariant, Station, TransitData
 
 
 def _make_transit() -> TransitData:
-    """A handful of real Berlin stations chosen to hit the disambiguation edge cases."""
     stations = {
         s.id: s
         for s in [
@@ -63,26 +59,20 @@ def index() -> StationIndex:
     return StationIndex.build(_make_transit())
 
 
-# --- normalize_name ----------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     ('raw', 'expected'),
     [
-        ('Südkreuz', 'sudkreuz'),  # diacritic folded to base letter
-        ('sudkreuz', 'sudkreuz'),  # ascii input already matches
-        ('  Südkreuz  ', 'sudkreuz'),  # surrounding whitespace stripped
-        ('S Südkreuz', 'sudkreuz'),  # "S " prefix stripped
-        ('U Turmstraße', 'turmstrasse'),  # "U " prefix + ß -> ss
-        ('Leinestr.', 'leinestrasse'),  # "str." abbreviation expanded
-        ('Leinestr', 'leinestrasse'),  # bare "str" suffix expanded
+        ('Südkreuz', 'sudkreuz'),
+        ('sudkreuz', 'sudkreuz'),
+        ('  Südkreuz  ', 'sudkreuz'),
+        ('S Südkreuz', 'sudkreuz'),
+        ('U Turmstraße', 'turmstrasse'),
+        ('Leinestr.', 'leinestrasse'),
+        ('Leinestr', 'leinestrasse'),
     ],
 )
 def test_normalize_name(raw: str, expected: str) -> None:
     assert normalize_name(raw) == expected
-
-
-# --- pick_station ------------------------------------------------------------
 
 
 def test_pick_station_resolves_diacritic_typo(index: StationIndex) -> None:
@@ -95,9 +85,8 @@ def test_pick_station_on_line_match_is_flagged(index: StationIndex) -> None:
 
 
 def test_pick_station_drops_line_when_station_is_off_it(index: StationIndex) -> None:
-    """'u6 turmstr' — Turmstraße is on U9, so trust the station and drop the wrong line."""
-    picked = pick_station(index, 'turmstr', 'U6')
-    assert picked == ('U-turmstrasse', False)
+    # 'u6 turmstr' — Turmstraße is on U9, so trust the station and drop the wrong line.
+    assert pick_station(index, 'turmstr', 'U6') == ('U-turmstrasse', False)
 
 
 def test_pick_station_rejects_generic_non_station_word(index: StationIndex) -> None:
@@ -109,18 +98,12 @@ def test_pick_station_returns_none_for_empty_query(index: StationIndex) -> None:
     assert pick_station(index, '', None) is None
 
 
-# --- pick_direction ----------------------------------------------------------
-
-
 def test_pick_direction_restricts_to_line(index: StationIndex) -> None:
     assert pick_direction(index, 'Rudow', 'U7') == 'U-rudow'
 
 
 def test_pick_direction_none_for_missing_query(index: StationIndex) -> None:
     assert pick_direction(index, None, 'U7') is None
-
-
-# --- resolve_extraction (the full resolution stage) --------------------------
 
 
 def test_resolve_extraction_station_and_direction(index: StationIndex) -> None:
@@ -135,7 +118,7 @@ def test_resolve_extraction_drops_line_for_off_line_station(index: StationIndex)
     parsed = StationNameExtraction(station_name='Turmstraße')
     result = resolve_extraction(station_index=index, parsed=parsed, detected_line='U6')
     assert result.station_id == 'U-turmstrasse'
-    assert result.line_name is None  # U6 dropped because Turmstraße isn't on it
+    assert result.line_name is None
 
 
 def test_resolve_extraction_empty_when_nothing_matches(index: StationIndex) -> None:


### PR DESCRIPTION
Closes FRE-658 (#631).

## What

Separates the deterministic station-resolution stage from the LLM call inside the extractor and adds fast, deterministic unit tests for the resolution edge cases that were previously only reachable through the live-LLM eval harness.

- **Resolution stage interface** — `resolve_extraction(station_index, parsed, detected_line) -> ExtractionResult` is documented as the seam: raw extracted strings + detected line in, station/direction ids out.
- **LLM adapter** — added a `StationNameLLM` callable type with a `mistral_llm(...)` production factory that sits *in front of* the resolution stage. Mistral is the prod adapter; tests feed canned `StationNameExtraction`s straight into `resolve_extraction`.
- The external `extract()` interface and the city-agnostic `config.py` discipline are unchanged.

## Tests

New `tests/test_resolution.py` builds a tiny synthetic `TransitData` (a handful of real Berlin stations) and covers:

- `normalize_name`: diacritics (`Südkreuz` → `sudkreuz`), prefix stripping (`S Südkreuz`), abbreviations (`Leinestr.` → `leinestrasse`)
- `pick_station`: diacritic typo resolution, on-line flagging, dropping a wrong line when the station is off it (`u6 turmstr`), generic-word rejection
- `pick_direction`: line restriction
- `resolve_extraction`: station+direction, off-line line-dropping, empty result

17 tests, run in ~0.01s with no backend and no API key. Evals still guard the full pipeline.