### PR TITLE
feat: privacy-friendly Sentry error & performance monitoring

### DIFF
--- a/.github/workflows/frontend-next-deploy.yml
+++ b/.github/workflows/frontend-next-deploy.yml
@@ -43,6 +43,10 @@ jobs:
 
             - name: Build (type-checks via tsc; fails the job on any error)
               run: bun run build
+              # Enables Sentry source-map upload during the build. If unset, the build still
+              # succeeds and simply skips the upload (see vite.config.ts).
+              env:
+                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
             # ---------------------------------------------------------------------
 
             - name: Deploy to Cloudflare Workers

--- a/packages/frontend-next/.env.example
+++ b/packages/frontend-next/.env.example
@@ -10,6 +10,10 @@ VITE_POSTHOG_HOST=https://eu.i.posthog.com
 # Id of the API-type PostHog survey that in-app feedback submissions are attributed to.
 VITE_POSTHOG_FEEDBACK_SURVEY_ID=
 
+# Sentry DSN for error monitoring (public — shipped in the client bundle). Must be an EU-region DSN
+# (*.ingest.de.sentry.io). Leave empty to disable error monitoring (e.g. local dev).
+VITE_SENTRY_DSN=
+
 # Social links shown in the app (settings + map).
 VITE_GITHUB_URL=https://github.com/FreiFahren/FreiFahren
 VITE_INSTAGRAM_URL=https://www.instagram.com/frei.fahren

--- a/packages/frontend-next/.env.production
+++ b/packages/frontend-next/.env.production
@@ -10,6 +10,9 @@ VITE_POSTHOG_KEY=phc_rR635vqhSmp6st6GYqJG23uZVCmtESsDQT4Caijwv2N5
 VITE_POSTHOG_HOST=https://eu.i.posthog.com
 VITE_POSTHOG_FEEDBACK_SURVEY_ID=019ec61d-7044-0000-0c79-734d7b31e436
 
+# Sentry DSN for error monitoring (public — shipped in the client bundle). EU region (ingest.de.sentry.io).
+VITE_SENTRY_DSN=https://486df3ea1574e9bcaf77ed0b2b7442f7@o4508609338867712.ingest.de.sentry.io/4511564594479184
+
 # Social links shown in the app (settings + map).
 VITE_GITHUB_URL=https://github.com/FreiFahren/FreiFahren
 VITE_INSTAGRAM_URL=https://www.instagram.com/frei.fahren

--- a/packages/frontend-next/bun.lock
+++ b/packages/frontend-next/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fontsource/ibm-plex-sans": "^5.2.8",
+        "@sentry/react": "^10.57.0",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/query-async-storage-persister": "^5.101.0",
         "@tanstack/react-query": "^5.101.0",
@@ -34,6 +35,7 @@
         "@babel/core": "^7.29.6",
         "@eslint/js": "^10.0.1",
         "@rolldown/plugin-babel": "^0.2.3",
+        "@sentry/vite-plugin": "^5.3.0",
         "@tanstack/eslint-plugin-query": "^5.100.14",
         "@tanstack/eslint-plugin-router": "^1.162.0",
         "@tanstack/router-cli": "^1.167.10",
@@ -595,6 +597,46 @@
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
+    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.57.0", "", { "dependencies": { "@sentry/core": "10.57.0" } }, "sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A=="],
+
+    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.57.0", "", { "dependencies": { "@sentry/core": "10.57.0" } }, "sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ=="],
+
+    "@sentry-internal/replay": ["@sentry-internal/replay@10.57.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.57.0", "@sentry/core": "10.57.0" } }, "sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg=="],
+
+    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.57.0", "", { "dependencies": { "@sentry-internal/replay": "10.57.0", "@sentry/core": "10.57.0" } }, "sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A=="],
+
+    "@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@5.3.0", "", {}, "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA=="],
+
+    "@sentry/browser": ["@sentry/browser@10.57.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.57.0", "@sentry-internal/feedback": "10.57.0", "@sentry-internal/replay": "10.57.0", "@sentry-internal/replay-canvas": "10.57.0", "@sentry/core": "10.57.0" } }, "sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA=="],
+
+    "@sentry/bundler-plugin-core": ["@sentry/bundler-plugin-core@5.3.0", "", { "dependencies": { "@babel/core": "^7.18.5", "@sentry/babel-plugin-component-annotate": "5.3.0", "@sentry/cli": "^2.58.5", "dotenv": "^16.3.1", "find-up": "^5.0.0", "glob": "^13.0.6", "magic-string": "~0.30.8" } }, "sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q=="],
+
+    "@sentry/cli": ["@sentry/cli@2.58.6", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.58.6", "@sentry/cli-linux-arm": "2.58.6", "@sentry/cli-linux-arm64": "2.58.6", "@sentry/cli-linux-i686": "2.58.6", "@sentry/cli-linux-x64": "2.58.6", "@sentry/cli-win32-arm64": "2.58.6", "@sentry/cli-win32-i686": "2.58.6", "@sentry/cli-win32-x64": "2.58.6" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg=="],
+
+    "@sentry/cli-darwin": ["@sentry/cli-darwin@2.58.6", "", { "os": "darwin" }, "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA=="],
+
+    "@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw=="],
+
+    "@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g=="],
+
+    "@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg=="],
+
+    "@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q=="],
+
+    "@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.58.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A=="],
+
+    "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg=="],
+
+    "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.6", "", { "os": "win32", "cpu": "x64" }, "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA=="],
+
+    "@sentry/core": ["@sentry/core@10.57.0", "", {}, "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg=="],
+
+    "@sentry/react": ["@sentry/react@10.57.0", "", { "dependencies": { "@sentry/browser": "10.57.0", "@sentry/core": "10.57.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-6QThwQ4XWQ2rwKZEVQ9P9WKl7JlowC7S5LpAvmMdrwlfJBpLDFOsM7tycnIvbXTXf0ZOOuLFPa4L4YYbdyNGmA=="],
+
+    "@sentry/rollup-plugin": ["@sentry/rollup-plugin@5.3.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.3.0", "magic-string": "~0.30.8" }, "peerDependencies": { "rollup": ">=3.2.0" }, "optionalPeers": ["rollup"] }, "sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w=="],
+
+    "@sentry/vite-plugin": ["@sentry/vite-plugin@5.3.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.3.0", "@sentry/rollup-plugin": "5.3.0" } }, "sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A=="],
+
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
@@ -919,7 +961,7 @@
 
     "dompurify": ["dompurify@3.4.9", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ=="],
 
-    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -1099,7 +1141,7 @@
 
     "gl-matrix": ["gl-matrix@3.4.4", "", {}, "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ=="],
 
-    "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -1485,11 +1527,15 @@
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
     "protocol-buffers-schema": ["protocol-buffers-schema@3.6.1", "", {}, "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -2077,6 +2123,8 @@
 
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
+    "@dotenvx/dotenvx/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
@@ -2088,6 +2136,10 @@
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
+
+    "@sentry/cli/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
+    "@sentry/cli/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -2180,6 +2232,8 @@
     "workbox-build/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "workbox-build/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
+
+    "workbox-build/glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 
     "workbox-build/pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
@@ -2454,6 +2508,10 @@
     "@dotenvx/dotenvx/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "@sentry/cli/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "@tanstack/router-plugin/@babel/core/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
 
@@ -2784,6 +2842,10 @@
     "@babel/preset-env/@babel/plugin-transform-modules-commonjs/@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/preset-env/@babel/plugin-transform-modules-commonjs/@babel/helper-module-transforms/@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
+
+    "@sentry/cli/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "@sentry/cli/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "eslint-plugin-jsx-a11y/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/packages/frontend-next/package.json
+++ b/packages/frontend-next/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@fontsource/ibm-plex-mono": "^5.2.7",
     "@fontsource/ibm-plex-sans": "^5.2.8",
+    "@sentry/react": "^10.57.0",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/query-async-storage-persister": "^5.101.0",
     "@tanstack/react-query": "^5.101.0",
@@ -42,6 +43,7 @@
     "@babel/core": "^7.29.6",
     "@eslint/js": "^10.0.1",
     "@rolldown/plugin-babel": "^0.2.3",
+    "@sentry/vite-plugin": "^5.3.0",
     "@tanstack/eslint-plugin-query": "^5.100.14",
     "@tanstack/eslint-plugin-router": "^1.162.0",
     "@tanstack/router-cli": "^1.167.10",

--- a/packages/frontend-next/src/components/legal/PrivacyPolicy.i18n.ts
+++ b/packages/frontend-next/src/components/legal/PrivacyPolicy.i18n.ts
@@ -96,7 +96,7 @@ i18n.addResourceBundle('en', NAMESPACE, {
     policyChanges: {
       title: '10. Changes to the Privacy Policy',
       content:
-        'We reserve the right to change this Privacy Policy to reflect changes in legal conditions, the App, or data processing. Users are encouraged to regularly review the content of the Privacy Policy. Last updated: 12 June 2026.',
+        'We reserve the right to change this Privacy Policy to reflect changes in legal conditions, the App, or data processing. Users are encouraged to regularly review the content of the Privacy Policy. Last updated: 14 June 2026.',
     },
     telegramMessages: {
       title: '11. Processing of Telegram Messages',
@@ -104,7 +104,7 @@ i18n.addResourceBundle('en', NAMESPACE, {
         "Messages from the Freifahren_BE group are evaluated by the Freifahren Telegram Bot with the consent of the administrators. Messages are not stored and are only used for real-time evaluation. Only the non-deterministically extracted information (direction, line, and station) from the messages is stored. The timestamp is rounded to ensure anonymity. Even for this anonymized report data, an indirect link to an individual cannot be fully excluded; see Section 5 in this regard. Message evaluation is performed using an AI language model from Mistral AI (Mistral AI SAS, Paris, France). For this, the message text is transmitted for real-time extraction to Mistral AI's API, which is hosted exclusively in the EU. Mistral AI acts as a processor pursuant to Art. 28 GDPR on our instruction; the content is not used to train the models and is retained by Mistral AI only briefly (max. 30 days) for abuse monitoring, if at all. FreiFahren does not store the message texts.",
     },
     errorMonitoring: {
-      title: '12. Error Monitoring and Diagnostics',
+      title: '12. Error Monitoring and Performance Diagnostics',
       description:
         "We use Sentry for error monitoring and crash reporting to maintain and improve our service. The provider is Functional Software, Inc. (Sentry), 45 Fremont Street, 8th Floor, San Francisco, CA 94105, USA. We use Sentry's EU region, so the technical data is processed on servers located within the European Union. When the App encounters an error, we collect anonymized diagnostic information including:",
       dataPoints: {
@@ -113,8 +113,10 @@ i18n.addResourceBundle('en', NAMESPACE, {
         device: 'Device type',
         state: 'App state at the time of the error',
       },
+      performance:
+        'In addition, we collect aggregated performance metrics - such as page-load times and Web Vitals (timings for rendering and responsiveness) - on a sampled basis to detect and fix performance problems. These metrics are technical and contain no personal identifiers; they reference only in-app screen paths and our own API endpoints, and no IP addresses.',
       storage:
-        'This technical data is stored for a maximum period of 30 days. We explicitly configure Sentry not to collect IP addresses. All data collection is anonymized and used solely for the purpose of identifying and fixing technical issues. Processing is based on legitimate interests pursuant to Art. 6(1)(f) GDPR (ensuring the functionality of the service). As Functional Software, Inc. is headquartered in the United States, a transfer of data to a third country (in particular within its corporate group or in the context of support and maintenance services) cannot be entirely excluded. Please refer to Section 15 for information on the safeguards in place.',
+        'This technical data is stored for a maximum period of 30 days. We explicitly configure Sentry not to collect IP addresses, and we do not use Session Replay. All data collection is anonymized and used solely for the purpose of identifying and fixing technical and performance issues. Processing is based on legitimate interests pursuant to Art. 6(1)(f) GDPR (ensuring the functionality of the service). As Functional Software, Inc. is headquartered in the United States, a transfer of data to a third country (in particular within its corporate group or in the context of support and maintenance services) cannot be entirely excluded. Please refer to Section 15 for information on the safeguards in place.',
     },
     appStores: {
       title: '13. Distribution via App Stores',
@@ -256,7 +258,7 @@ i18n.addResourceBundle('de', NAMESPACE, {
     policyChanges: {
       title: '10. Änderungen an der Datenschutzerklärung',
       content:
-        'Wir behalten uns vor, diese Datenschutzerklärung zu ändern, um sie an geänderte Rechtslagen oder Änderungen der App sowie der Datenverarbeitung anzupassen. Nutzer werden gebeten, sich regelmäßig über den Inhalt der Datenschutzerklärung zu informieren. Stand: 12. Juni 2026.',
+        'Wir behalten uns vor, diese Datenschutzerklärung zu ändern, um sie an geänderte Rechtslagen oder Änderungen der App sowie der Datenverarbeitung anzupassen. Nutzer werden gebeten, sich regelmäßig über den Inhalt der Datenschutzerklärung zu informieren. Stand: 14. Juni 2026.',
     },
     telegramMessages: {
       title: '11. Verarbeitung von Telegram-Nachrichten',
@@ -264,7 +266,7 @@ i18n.addResourceBundle('de', NAMESPACE, {
         'Durch den Freifahren Telegram Bot werden Nachrichten aus der Freifahren_BE-Gruppe mit Zustimmung der Administratoren ausgewertet. Die Nachrichten werden nicht gespeichert und nur für die Echtzeit-Auswertung verwendet. Es werden lediglich die nicht deterministisch extrahierten Informationen (Richtung, Linie und Station) aus den Nachrichten gespeichert. Die Uhrzeit wird abgerundet, um die Anonymität zu gewährleisten. Auch bei diesen anonymisierten Meldedaten kann ein indirekter Personenbezug nicht vollständig ausgeschlossen werden; siehe hierzu Abschnitt 5. Die Auswertung der Nachrichten erfolgt mithilfe eines KI-gestützten Sprachmodells des Anbieters Mistral AI (Mistral AI SAS, Paris, Frankreich). Hierzu wird der Nachrichtentext zur Echtzeit-Extraktion an die ausschließlich in der EU gehostete API von Mistral AI übermittelt. Mistral AI wird dabei als Auftragsverarbeiter nach Art. 28 DSGVO auf unsere Weisung tätig; die Inhalte werden nicht zum Training der Modelle verwendet und von Mistral AI allenfalls kurzfristig (max. 30 Tage) zur Missbrauchserkennung vorgehalten. Eine Speicherung der Nachrichtentexte durch FreiFahren erfolgt nicht.',
     },
     errorMonitoring: {
-      title: '12. Fehlererkennung und Diagnose',
+      title: '12. Fehlererkennung und Leistungsanalyse',
       description:
         'Wir verwenden Sentry zur Fehlererkennung und Absturzberichterstattung, um unseren Service zu warten und zu verbessern. Anbieter ist die Functional Software, Inc. (Sentry), 45 Fremont Street, 8th Floor, San Francisco, CA 94105, USA. Wir nutzen die EU-Region von Sentry, sodass die technischen Daten auf Servern innerhalb der Europäischen Union verarbeitet werden. Wenn die App einen Fehler feststellt, sammeln wir anonymisierte Diagnoseinformationen, einschließlich:',
       dataPoints: {
@@ -273,8 +275,10 @@ i18n.addResourceBundle('de', NAMESPACE, {
         device: 'Gerätetyp',
         state: 'App-Status zum Zeitpunkt des Fehlers',
       },
+      performance:
+        'Darüber hinaus erheben wir stichprobenartig aggregierte Leistungsdaten - etwa Seitenladezeiten und Web Vitals (Messwerte zu Darstellung und Reaktionsgeschwindigkeit) -, um Leistungsprobleme zu erkennen und zu beheben. Diese Daten sind technischer Natur und enthalten keine Personenbezugsdaten; sie beziehen sich lediglich auf In-App-Seitenpfade und unsere eigenen API-Endpunkte und keine IP-Adressen.',
       storage:
-        'Diese technischen Daten werden für maximal 30 Tage gespeichert. Wir konfigurieren Sentry ausdrücklich so, dass keine IP-Adressen erfasst werden. Alle Datenerfassung erfolgt anonymisiert und dient ausschließlich der Identifizierung und Behebung technischer Probleme. Die Verarbeitung erfolgt auf Grundlage berechtigter Interessen gemäß Art. 6 Abs. 1 lit. f DSGVO (Sicherstellung der Funktionsfähigkeit des Dienstes). Da die Functional Software, Inc. ihren Sitz in den USA hat, kann ein Drittlandtransfer (insbesondere im Rahmen des Konzernverbunds bzw. bei Support- und Wartungsleistungen) nicht ausgeschlossen werden. Hinweise zu den hierfür getroffenen Garantien finden Sie in Abschnitt 15.',
+        'Diese technischen Daten werden für maximal 30 Tage gespeichert. Wir konfigurieren Sentry ausdrücklich so, dass keine IP-Adressen erfasst werden, und setzen kein Session Replay ein. Alle Datenerfassung erfolgt anonymisiert und dient ausschließlich der Identifizierung und Behebung technischer und leistungsbezogener Probleme. Die Verarbeitung erfolgt auf Grundlage berechtigter Interessen gemäß Art. 6 Abs. 1 lit. f DSGVO (Sicherstellung der Funktionsfähigkeit des Dienstes). Da die Functional Software, Inc. ihren Sitz in den USA hat, kann ein Drittlandtransfer (insbesondere im Rahmen des Konzernverbunds bzw. bei Support- und Wartungsleistungen) nicht ausgeschlossen werden. Hinweise zu den hierfür getroffenen Garantien finden Sie in Abschnitt 15.',
     },
     appStores: {
       title: '13. Bezug der App über App-Stores',

--- a/packages/frontend-next/src/components/legal/PrivacyPolicy.tsx
+++ b/packages/frontend-next/src/components/legal/PrivacyPolicy.tsx
@@ -102,6 +102,7 @@ export function PrivacyPolicy() {
           <li>{t('sections.errorMonitoring.dataPoints.device')}</li>
           <li>{t('sections.errorMonitoring.dataPoints.state')}</li>
         </ul>
+        <p>{t('sections.errorMonitoring.performance')}</p>
         <p>{t('sections.errorMonitoring.storage')}</p>
       </section>
 

--- a/packages/frontend-next/src/lib/error-monitoring.ts
+++ b/packages/frontend-next/src/lib/error-monitoring.ts
@@ -1,0 +1,40 @@
+import * as Sentry from '@sentry/react';
+
+import { optionalEnv } from '@/lib/utils';
+
+// Provider-agnostic error-monitoring facade. The rest of the app never imports the Sentry SDK
+// directly — swapping providers is a single-file change here, mirroring lib/analytics.ts. When no
+// VITE_SENTRY_DSN is set (e.g. local dev) the SDK is never initialized and nothing is ever sent.
+
+function doNotTrackEnabled(): boolean {
+  const nav = navigator as Navigator & { msDoNotTrack?: string };
+  const win = window as Window & { doNotTrack?: string };
+  // Standard signal plus the legacy IE/old-Firefox vendor-prefixed variants.
+  const dnt = nav.doNotTrack ?? win.doNotTrack ?? nav.msDoNotTrack;
+  return dnt === '1' || dnt === 'yes';
+}
+
+export function initErrorMonitoring(): void {
+  const dsn = optionalEnv('VITE_SENTRY_DSN');
+  // No DSN configured (local dev) or the user opted out via Do Not Track: stay uninitialized so
+  // every capture is a silent no-op and nothing leaves the device.
+  if (!dsn || doNotTrackEnabled()) return;
+
+  Sentry.init({
+    dsn,
+    // The build timestamp doubles as the release/app version so issues group by deploy. Matches the
+    // "App version" data point disclosed in the privacy policy.
+    release: __BUILD_ID__,
+    environment: import.meta.env.MODE,
+    // No IP address, cookies, or request payloads — see the file header.
+    sendDefaultPii: false,
+    // Performance: capture page-load/navigation timing and Web Vitals (LCP, INP, CLS, ...) on a 10%
+    // sample. These spans carry only in-app route + own-API URLs (no personal data); disclosed in
+    // the privacy policy alongside error diagnostics.
+    integrations: [Sentry.browserTracingIntegration()],
+    tracesSampleRate: 0.1,
+    // Same-origin only: never attach sentry-trace/baggage headers to the cross-origin API (its CORS
+    // config doesn't allow them, and we don't do distributed tracing into the backend).
+    tracePropagationTargets: ['localhost', /^\//],
+  });
+}

--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -7,9 +7,14 @@ import { get, set, del } from 'idb-keyval';
 import { PostHogProvider } from 'posthog-js/react';
 import { queryClient, PERSISTED_CACHE_MAX_AGE } from './api/queryClient';
 import { optionalEnv } from './lib/utils';
+import { initErrorMonitoring } from './lib/error-monitoring';
 import './lib/i18n';
 import { routeTree } from './routeTree.gen';
 import './index.css';
+
+// Initialize error monitoring before anything else renders so errors during startup are captured.
+// No-ops without VITE_SENTRY_DSN or when Do Not Track is set (see lib/error-monitoring.ts).
+initErrorMonitoring();
 
 // Persist the React Query cache to IndexedDB so the last-known transit data, reports, and risk
 // survive a cold start with no network — the user opens the app in a tunnel and still sees the

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -5,11 +5,17 @@ import babel from '@rolldown/plugin-babel';
 import tailwindcss from '@tailwindcss/vite';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 import { VitePWA } from 'vite-plugin-pwa';
+import { sentryVitePlugin } from '@sentry/vite-plugin';
 
 // Stamped into the bundle so the React Query cache persister can `buster` (drop) a persisted
 // cache whose query shapes predate this build, rather than hydrating an incompatible snapshot.
 // Date is read at build time only (Node), never at runtime.
 const BUILD_ID = new Date().toISOString();
+
+// Source maps are uploaded to Sentry only when SENTRY_AUTH_TOKEN is present (set in the deploy
+// workflow, never on PRs/forks). Without it the build is byte-for-byte unchanged: no maps emitted,
+// plugin not loaded.
+const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
 
 // The 400 (regular) weight is our body font and is on the critical render path, but it's only
 // discovered after the CSS chain resolves (index.html -> index.css -> @font-face), several round
@@ -52,6 +58,9 @@ export default defineConfig({
   define: {
     __BUILD_ID__: JSON.stringify(BUILD_ID),
   },
+  // 'hidden' emits source maps for the upload but ships no sourceMappingURL comment, so the maps are
+  // never referenced by (or served to) clients; the Sentry plugin deletes them after upload.
+  build: { sourcemap: sentryAuthToken ? 'hidden' : false },
   plugins: [
     tanstackRouter({ target: 'react', autoCodeSplitting: true }),
     react(),
@@ -108,6 +117,23 @@ export default defineConfig({
       },
       devOptions: { enabled: false },
     }),
+    // Must be last so it sees the final emitted bundle + maps. No-op without an auth token.
+    ...(sentryAuthToken
+      ? [
+          sentryVitePlugin({
+            org: 'freifahren-web',
+            project: 'web-app',
+            authToken: sentryAuthToken,
+            // EU region: upload to the de.sentry.io API, matching the org's data region.
+            url: 'https://de.sentry.io',
+            // Tie uploaded maps to the same release name the SDK reports at runtime (__BUILD_ID__).
+            release: { name: BUILD_ID },
+            // Don't deploy the maps as public assets — Sentry has them after upload.
+            sourcemaps: { filesToDeleteAfterUpload: ['./dist/**/*.map'] },
+            telemetry: false,
+          }),
+        ]
+      : []),
   ],
   server: {
     port: 1871,


### PR DESCRIPTION
## What

Wires up Sentry in `frontend-next`. The privacy policy already described Sentry error monitoring in detail (§12, §14, §15) but the SDK was never actually installed — this implements it to honor exactly those promises, and adds performance tracing + source-map upload.

## Changes

- **SDK + facade** — `@sentry/react` behind a provider-agnostic facade (`lib/error-monitoring.ts`), initialized in `main.tsx`. No-ops without `VITE_SENTRY_DSN` (local dev) or when the browser sends Do Not Track.
- **Privacy-friendly config** — EU-region DSN (`ingest.de.sentry.io`); `sendDefaultPii: false` (no IP, cookies, or request payloads); no Session Replay.
- **Performance tracing** — `browserTracingIntegration` at `tracesSampleRate: 0.1` (Web Vitals + page-load/navigation). Trace propagation is locked to same-origin, so no `sentry-trace` headers reach the cross-origin API and no CORS change is needed.
- **Source maps** — `@sentry/vite-plugin` uploads hidden source maps tied to the build release, then deletes them so they never ship publicly. Gated on `SENTRY_AUTH_TOKEN`, so local and PR builds are byte-for-byte unchanged.
- **Privacy policy §12 (EN + DE)** — disclose performance metrics, note "no Session Replay", retitle to "Error Monitoring and Performance Diagnostics", bump last-updated date.
- **Env docs** — `VITE_SENTRY_DSN` added to `.env.example` and `.env.production`.

## Manual steps before this is fully live

- [x] Add `SENTRY_AUTH_TOKEN` as a GitHub Actions secret (scope `project:releases`) — without it, deploys still succeed but stack traces stay minified.
- [x] Enable **"Prevent Storing of IP Addresses"** in the `web-app` project's Security & Privacy settings (defense-in-depth behind the policy's IP claim).
- [x] Decide retention wording: §12 says **30 days**, but Sentry's default error/transaction retention is **90 days** — either adjust the plan setting or update the policy text.

## Notes

The live tunnel was intentionally dropped (Sentry has no managed reverse proxy like PostHog; not worth a dedicated Worker right now). Events go directly to the EU DSN, so ad-blockers may drop some reports — easy to revisit later.

Couldn't end-to-end test the live source-map upload here (no Sentry network in the dev environment); it activates on the next deploy. Local lint, typecheck, format, and build all pass.