### PR TITLE
fix: stop active toast from blocking map controls on its row

### DIFF
--- a/packages/frontend-next/src/components/ui/toaster.tsx
+++ b/packages/frontend-next/src/components/ui/toaster.tsx
@@ -27,7 +27,7 @@ export function Toaster() {
           key={item.id}
           role="status"
           className={cn(
-            'pointer-events-auto flex w-full justify-center',
+            'pointer-events-auto flex w-fit max-w-full',
             // Duration must match EXIT_MS in @/lib/toast, which unmounts after the animation.
             item.leaving && 'animate-out fade-out zoom-out-95 fill-mode-forwards duration-200',
           )}


### PR DESCRIPTION
## The bug

On the map, the toast container (`Toaster`) renders each toast item in a wrapper styled `pointer-events-auto flex w-full justify-center`. The `w-full` made that wrapper span the entire `inset-x-4` band at the top of the screen — so even though the visible pill was narrow and centered, the **invisible full-width row** sat at `z-25`, above the settings button (top-left) and risk button (top-right) which live at `z-20` on the same horizontal line. Because the wrapper was `pointer-events-auto`, it intercepted clicks across the whole row.

## Impact

While **any** toast was active on the map (e.g. the stats pill or a refresh notification), tapping the **settings** or **risk** buttons did nothing — the clicks landed on the invisible toast row instead. As soon as the toast cleared, the buttons worked again. Most visible on mobile, where these controls are the primary entry points.

## The fix

Shrink the toast wrapper to its content (`w-fit max-w-full`). The parent already centers children via `items-center`, so centering is unchanged, but now only the visible pill captures pointer events — the left/right edges where the buttons sit become click-through again. Z-ordering and layout are otherwise untouched.

This fixes the whole class of overlap rather than just nudging the z-index or offset (which would only trade one collision for another).

## Testing

Verified manually: trigger a toast on the map and confirm both buttons remain clickable while it's visible. No automated test added — frontend-next has no browser test harness, and the regression only reproduces under real layout/pointer hit-testing (jsdom can't observe it).