### PR TITLE
perf: lazy-load PostHog and capture pageviews manually

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,14 @@ Example: `fix: return 404 instead of 500 when station id is unknown`
 
 The codebase should not assume Berlin. Keep city-specific data (station lists, line colors, network names, timezone, language) in **config files** under `packages/hono-backend/src/db/seed/config.ts` and similar locations — never hard-coded in business logic. Config files are the only sanctioned escape hatch for city-specific values.
 
+## Comments
+
+Comment sparingly — code should read for itself, and a comment earns its place only when it tells the reader something the code can't.
+
+- **Minimal.** Add a comment only when something is out of the ordinary or hard to understand. Don't restate what the code already says.
+- **Explain why, not what.** Capture the reason — the constraint, the trade-off, the non-obvious consequence — not a paraphrase of the statement below it.
+- **Write comments that don't expire.** Don't reference things that drift, like specific line numbers — the code moves but the comment won't. Anchor to rationale, which stays true as the surrounding code changes.
+
 ## Frontend conventions
 
 - **kebab-case for filenames.** Components, hooks, routes, utilities — all kebab-case (`report-card.tsx`, `use-reports.ts`, `format-timestamp.ts`). The default export inside still uses PascalCase for components and camelCase for hooks/utils; only the filename changes.

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -1,11 +1,10 @@
-import posthog from 'posthog-js';
-
 import type { ContributeSource } from '@/lib/contribute-modal';
 import type { GeolocationPermissionState } from '@/lib/location-prompt';
+import { enqueuePostHog } from '@/lib/posthog-client';
 
-// Provider-agnostic analytics facade. The rest of the app calls `track(...)` and never imports the
-// analytics SDK directly, so swapping PostHog for another provider is a single-file change here.
-// When no VITE_POSTHOG_KEY is set the SDK is never initialized (see main.tsx) and capture() no-ops.
+// Provider-agnostic analytics facade: the app calls these helpers and never imports the SDK
+// directly. Events stamp their own `timestamp` because PostHog is lazy-loaded and calls buffer
+// until it's ready — otherwise a startup burst would all collapse to the SDK's init time.
 
 export type LocationRequestTrigger = 'auto' | 'soft_prompt';
 type SuperProperties = {
@@ -50,22 +49,30 @@ export function track<E extends keyof AnalyticsEvents>(
   properties: AnalyticsEvents[E],
 ): void {
   if (import.meta.env.DEV) {
-    // In development we usually run without a PostHog key, so capture() no-ops. Log instead so the
-    // funnel events are visible in the console while wiring up tracking.
+    // No PostHog key in local dev, so capture() no-ops — log instead for visibility.
     console.log('[analytics]', event, properties);
   }
-  posthog.capture(event, properties);
+  const timestamp = new Date();
+  enqueuePostHog((posthog) => posthog.capture(event, properties, { timestamp }));
 }
 
-/**
- * Register super properties — attached to every event sent afterwards. Used to stamp the current
- * map layer onto all events so adoption and retention can be broken down by it.
- */
+// Pageviews are driven manually from the router; PostHog's automatic capture is off so they don't
+// depend on SDK load timing.
+export function capturePageview(url: string): void {
+  if (import.meta.env.DEV) {
+    console.log('[analytics] pageview', url);
+  }
+  const timestamp = new Date();
+  enqueuePostHog((posthog) => posthog.capture('$pageview', { $current_url: url }, { timestamp }));
+}
+
+// Super properties are attached to every later event — used to stamp the current map layer so
+// metrics can be broken down by it.
 export function setSuperProperties(properties: Partial<SuperProperties>): void {
   if (import.meta.env.DEV) {
     console.log('[analytics] register', properties);
   }
-  posthog.register(properties);
+  enqueuePostHog((posthog) => posthog.register(properties));
 }
 
 export type FeedbackType = 'feature_request' | 'bug_report' | 'general';
@@ -87,14 +94,18 @@ export function captureSurveyShown(surveyId: string): void {
   if (import.meta.env.DEV) {
     console.log('[analytics] survey shown', { surveyId });
   }
-  posthog.capture('survey shown', { $survey_id: surveyId });
+  const timestamp = new Date();
+  enqueuePostHog((posthog) => posthog.capture('survey shown', { $survey_id: surveyId }, { timestamp }));
 }
 
 export function captureSurveyDismissed(surveyId: string): void {
   if (import.meta.env.DEV) {
     console.log('[analytics] survey dismissed', { surveyId });
   }
-  posthog.capture('survey dismissed', { $survey_id: surveyId });
+  const timestamp = new Date();
+  enqueuePostHog((posthog) =>
+    posthog.capture('survey dismissed', { $survey_id: surveyId }, { timestamp }),
+  );
 }
 
 export function captureSurveySent(
@@ -121,5 +132,6 @@ export function captureSurveySent(
   if (import.meta.env.DEV) {
     console.log('[analytics] survey sent', properties);
   }
-  posthog.capture('survey sent', properties);
+  const timestamp = new Date();
+  enqueuePostHog((posthog) => posthog.capture('survey sent', properties, { timestamp }));
 }

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -95,7 +95,9 @@ export function captureSurveyShown(surveyId: string): void {
     console.log('[analytics] survey shown', { surveyId });
   }
   const timestamp = new Date();
-  enqueuePostHog((posthog) => posthog.capture('survey shown', { $survey_id: surveyId }, { timestamp }));
+  enqueuePostHog((posthog) =>
+    posthog.capture('survey shown', { $survey_id: surveyId }, { timestamp }),
+  );
 }
 
 export function captureSurveyDismissed(surveyId: string): void {

--- a/packages/frontend-next/src/lib/consent.ts
+++ b/packages/frontend-next/src/lib/consent.ts
@@ -1,5 +1,6 @@
-import posthog from 'posthog-js';
 import { useSyncExternalStore } from 'react';
+
+import { enqueuePostHog } from '@/lib/posthog-client';
 
 // Capture is ON by default (see main.tsx). The banner asks for cookie consent specifically; either
 // choice keeps analytics running, but at different privacy levels:
@@ -68,14 +69,19 @@ function subscribe(listener: () => void): () => void {
 
 // Bring PostHog in line with the current choice. Safe to call before a decision is made.
 function applyToPostHog(value: ConsentChoice | null): void {
+  // Ops buffer until the lazily-loaded SDK is ready.
   if (value === 'denied') {
     // Cookieless: keep capturing but store nothing on the device. reset() clears any id/cookie set
     // earlier (e.g. while undecided) so declining cookies genuinely leaves no device storage.
-    posthog.reset();
-    posthog.set_config({ persistence: 'memory' });
+    enqueuePostHog((posthog) => {
+      posthog.reset();
+      posthog.set_config({ persistence: 'memory' });
+    });
   } else if (value === 'granted') {
-    posthog.set_config({ persistence: 'localStorage+cookie' });
-    posthog.opt_in_capturing();
+    enqueuePostHog((posthog) => {
+      posthog.set_config({ persistence: 'localStorage+cookie' });
+      posthog.opt_in_capturing();
+    });
   }
   // null: leave PostHog in its init default (persistent capture).
 }

--- a/packages/frontend-next/src/lib/posthog-client.ts
+++ b/packages/frontend-next/src/lib/posthog-client.ts
@@ -1,0 +1,56 @@
+import type { PostHog } from 'posthog-js';
+
+import { optionalEnv } from './utils';
+
+// posthog-js is lazy-loaded after first paint to keep it out of the eager bundle. Calls made before
+// it finishes loading are buffered here and flushed in order, so startup events aren't lost.
+
+type PostHogOp = (ph: PostHog) => void;
+
+let instance: PostHog | null = null;
+let disabled = false;
+let loadPromise: Promise<void> | null = null;
+const queue: PostHogOp[] = [];
+// Cap the buffer so a session that never loads the SDK (dev without a key) can't grow it unbounded.
+const MAX_QUEUED = 500;
+
+export function enqueuePostHog(op: PostHogOp): void {
+  if (instance) {
+    op(instance);
+    return;
+  }
+  if (disabled) return;
+  if (queue.length >= MAX_QUEUED) queue.shift();
+  queue.push(op);
+}
+
+export function loadPostHog(): Promise<void> {
+  if (loadPromise) return loadPromise;
+
+  const apiKey = optionalEnv('VITE_POSTHOG_KEY');
+  if (!apiKey) {
+    disabled = true;
+    queue.length = 0;
+    loadPromise = Promise.resolve();
+    return loadPromise;
+  }
+  const apiHost = optionalEnv('VITE_POSTHOG_HOST') ?? 'https://eu.i.posthog.com';
+
+  loadPromise = import('posthog-js').then(({ default: posthog }) => {
+    posthog.init(apiKey, {
+      api_host: apiHost,
+      defaults: '2025-05-24',
+      autocapture: false,
+      capture_performance: false,
+      disable_session_recording: true,
+      respect_dnt: true,
+      // Pageviews are captured manually from the router so they don't depend on when this
+      // lazily-loaded SDK initializes; capture_pageleave stays on by default.
+      capture_pageview: false,
+    });
+    instance = posthog;
+    for (const op of queue) op(posthog);
+    queue.length = 0;
+  });
+  return loadPromise;
+}

--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -4,9 +4,10 @@ import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
 import { get, set, del } from 'idb-keyval';
-import { PostHogProvider } from 'posthog-js/react';
 import { queryClient, PERSISTED_CACHE_MAX_AGE } from './api/queryClient';
-import { optionalEnv } from './lib/utils';
+import { capturePageview } from './lib/analytics';
+import { syncConsentToPostHog } from './lib/consent';
+import { loadPostHog } from './lib/posthog-client';
 import { initErrorMonitoring } from './lib/error-monitoring';
 import './lib/i18n';
 import { routeTree } from './routeTree.gen';
@@ -41,8 +42,15 @@ declare module '@tanstack/react-router' {
   }
 }
 
-const posthogKey = optionalEnv('VITE_POSTHOG_KEY');
-const posthogHost = optionalEnv('VITE_POSTHOG_HOST') ?? 'https://eu.i.posthog.com';
+// Pageviews are captured here manually (PostHog's automatic capture is off). Module scope, not an
+// effect, so StrictMode doesn't double-subscribe; the href dedupe drops redundant resolves
+// (search-only navigations, StrictMode re-runs).
+let lastPageviewHref: string | null = null;
+router.subscribe('onResolved', ({ toLocation }) => {
+  if (toLocation.href === lastPageviewHref) return;
+  lastPageviewHref = toLocation.href;
+  capturePageview(toLocation.href);
+});
 
 const app = (
   <StrictMode>
@@ -79,31 +87,14 @@ const app = (
   </StrictMode>
 );
 
-createRoot(document.getElementById('root')!).render(
-  posthogKey ? (
-    <PostHogProvider
-      apiKey={posthogKey}
-      // Analytics config (see src/lib/consent.ts for the opt-out flow):
-      // - autocapture off: no DOM click/input capture; domain events go through track().
-      // - Capture is ON by default (opt-out model): the banner is informational and lets users opt
-      //   out via posthog.opt_out_capturing(). This gives retention + cross-session funnels out of
-      //   the box. NOTE: opt-out (vs opt-in) for cookie-based analytics is a deliberate product/
-      //   legal choice — reflect it in the privacy policy's legal basis.
-      // - session recording stays off; DNT is honored as an automatic opt-out signal.
-      // - capture_performance off: no web-vitals/network capture even before remote config loads
-      //   (the '2025-05-24' defaults would otherwise enable it at init); matches the project settings.
-      options={{
-        api_host: posthogHost,
-        defaults: '2025-05-24',
-        autocapture: false,
-        capture_performance: false,
-        disable_session_recording: true,
-        respect_dnt: true,
-      }}
-    >
-      {app}
-    </PostHogProvider>
-  ) : (
-    app
-  ),
-);
+createRoot(document.getElementById('root')!).render(app);
+
+// Load PostHog when the main thread is idle, off the critical render path. Calls made before it
+// resolves are buffered; syncConsentToPostHog reapplies the stored choice once it's initialized.
+const onIdle = (cb: () => void) =>
+  typeof window.requestIdleCallback === 'function'
+    ? window.requestIdleCallback(cb)
+    : window.setTimeout(cb, 1);
+onIdle(() => {
+  void loadPostHog().then(syncConsentToPostHog);
+});


### PR DESCRIPTION
## Why

PostHog (`posthog-js`, **~66 kB gz**) was imported statically on the eager startup path (`main.tsx` via `<PostHogProvider>`, plus `lib/analytics.ts` and `lib/consent.ts`), so it was baked into the main `index` chunk and blocked first paint — even though analytics aren't needed to render the map. Measured, the two SDKs (PostHog + Sentry) were ~43% of the main JS chunk.

This defers PostHog off the critical render path. Sentry is **intentionally left eager** — it was just given performance monitoring (#650), and lazy-loading `browserTracingIntegration` would degrade the initial pageload transaction. So this PR does the high-value, low-risk half.

## What changed

- **New `lib/posthog-client.ts`** — the lazy-load boundary. Owns the dynamic `import('posthog-js')`, the singleton, and an ordered buffer. `enqueuePostHog(op)` runs immediately if loaded, else queues (capped); `loadPostHog()` is idempotent, inits, and flushes the queue in order. No key → SDK chunk never fetched.
- **`lib/analytics.ts`** — routes every call through the buffer instead of importing `posthog` directly. Each event stamps its own `timestamp` so a startup burst keeps its real time rather than collapsing to the SDK's init time. Adds `capturePageview(url)`.
- **`lib/consent.ts`** — `applyToPostHog` enqueues its `reset`/`set_config`/`opt_in_capturing` ops, so consent works even before the SDK loads.
- **`main.tsx`** — removes `<PostHogProvider>` (renders the app directly), schedules `loadPostHog()` on `requestIdleCallback` after first paint, and captures `$pageview` manually.

### Manual pageviews
Dropping the provider removes PostHog's automatic pageview capture, so `capture_pageview` is now off and pageviews are captured from the TanStack Router's `onResolved` event (deduped on `href`). This is **deterministic regardless of SDK load timing** — the landing pageview is buffered and flushed rather than racing init — and is more correct than the previous history-patch approach. `capture_pageleave` stays on.

## Impact on bundle size

| | before | after |
|---|---|---|
| main `index` chunk (gz) | **262 kB** | **190 kB** |
| PostHog | in `index` | separate **~62 kB gz** chunk, fetched on idle |

~72 kB gz off the critical path — a TTI/first-paint win, most noticeable on mobile/slow connections. Verified with `bun run build`.

## Notes
- Also documents the project's comment conventions in `AGENTS.md` (minimal; explain why not what; don't reference things that drift like line numbers).
- The double `[analytics] register` logs in dev are StrictMode double-invoking the `useRiskLayer` effect — dev-only, idempotent, and not introduced here.

## Testing
- `tsc -b` and `eslint` pass; `bun run build` confirms the chunk split.
- Recommended manual check before merge (needs a real `VITE_POSTHOG_KEY` + browser): confirm the PostHog chunk loads after first paint, one `$pageview` per navigation incl. the landing view, an event fired immediately on load still arrives, and consent toggles take effect.