### PR TITLE
feat: fly the map camera to the selected station/report

### DIFF
--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -9,6 +9,7 @@ import { useSegments } from '@/api/transit';
 import { requireEnv } from '@/lib/utils';
 
 import { LineLayer } from './LineLayer';
+import { MapCameraController } from './MapCameraController';
 import { ReportsLayer } from './ReportsLayer';
 import { RiskLayer } from './RiskLayer';
 import { STATIONS_LAYER_ID, StationsLayer } from './StationsLayer';
@@ -78,6 +79,7 @@ export function MapView() {
             {riskVisible ? <RiskLayer /> : <LineLayer />}
             <ReportsLayer />
             <UserLocationControl />
+            <MapCameraController />
           </>
         )}
       </MapGL>

--- a/packages/frontend-next/src/components/map/MapCameraController.tsx
+++ b/packages/frontend-next/src/components/map/MapCameraController.tsx
@@ -1,0 +1,44 @@
+import { useParams } from '@tanstack/react-router';
+import { useEffect, useRef } from 'react';
+import { useMap } from 'react-map-gl/maplibre';
+
+import { useStations } from '@/api/transit';
+
+// Only ever zoom *in* to frame a target — never pull back a user already closer (see Math.max below).
+const DETAIL_ZOOM = 14;
+// Keep the marker above the detail bottom sheet by padding the camera's bottom by ~the sheet height.
+const DETAIL_PANEL_PADDING_BOTTOM = 320;
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+export function MapCameraController() {
+  const { current: map } = useMap();
+  const { data: stations } = useStations();
+  const targetId = useParams({ strict: false, select: (params) => params.stationId });
+
+  // The id last framed. Guards against re-flying to a station already in view — including when the
+  // panel closes and the same station is re-selected, or when `stations`/`map` change identity.
+  const positionedForIdRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!map || !stations || !targetId) return;
+    if (targetId === positionedForIdRef.current) return;
+
+    const station = stations[targetId];
+    if (!station) return;
+
+    positionedForIdRef.current = targetId;
+    const { longitude, latitude } = station.coordinates;
+    const camera = {
+      center: [longitude, latitude] as [number, number],
+      zoom: Math.max(map.getZoom(), DETAIL_ZOOM),
+      padding: { bottom: DETAIL_PANEL_PADDING_BOTTOM },
+    };
+
+    if (prefersReducedMotion()) map.jumpTo(camera);
+    else map.flyTo(camera);
+  }, [map, stations, targetId]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Animates the map camera to a station/report whenever it becomes the selected target — on click/search/overview selection **and** when the app is entered via a deep link (e.g. the Telegram bot's `/station/:id`). Previously the camera never moved on selection and deep links booted at the city-center `INITIAL_VIEW`.

## Approach

Selection state already lives in the URL, not in click handlers. So instead of hooking "fly" into each click path, a single headless **`MapCameraController`** (rendered inside `<MapGL>`, sibling of `StationsLayer`/`UserLocationControl`) reacts to the route's `$stationId` param changing. One mechanism covers map clicks, `StationSearch`, the reports overview, deep links, and browser back/forward. No changes to `handleMapClick`, `StationSearch`, or the route files.

## Behavior

- **Reacts to the route** — `useParams({ strict: false })` reads `$stationId` across both `/station/:id` and `/reports/:id`, `undefined` on the bare map.
- **flyTo on selection**, `jumpTo` when `prefers-reduced-motion` is set.
- **Zoom in only** — `Math.max(map.getZoom(), DETAIL_ZOOM)` never pulls back a user already zoomed in closer.
- **Detail-sheet offset** — pads the camera bottom so the marker lands above the bottom sheet, not under it.
- **Doesn't recenter on close** — no-ops when there's no target, leaving the camera where the user left it.
- A ref tracks the framed id so a station already in view isn't re-flown (including close → re-select of the same station).
