### PR TITLE
fix: reload on stale lazy-chunk import after deploy

### DIFF
--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -20,6 +20,18 @@ initErrorMonitoring();
 
 void initNativePlatform();
 
+// Vite's documented recovery for a failed lazy import: a deploy purges the old chunks, so reload to
+// fetch the fresh shell. Skip when offline — a reload can't fetch a new chunk and the SW already
+// serves the precached shell, so it'd only wipe UI state. The timestamp bounds repeated reloads.
+window.addEventListener('vite:preloadError', (event) => {
+  if (!navigator.onLine) return;
+  const KEY = 'vite:preloadError:lastReload';
+  if (Date.now() - Number(sessionStorage.getItem(KEY) ?? 0) < 10_000) return;
+  sessionStorage.setItem(KEY, String(Date.now()));
+  event.preventDefault();
+  window.location.reload();
+});
+
 // Persist the React Query cache to IndexedDB so the last-known transit data, reports, and risk
 // survive a cold start with no network — the user opens the app in a tunnel and still sees the
 // map populated. IndexedDB (not localStorage) because the transit-segments GeoJSON can exceed the


### PR DESCRIPTION
## Problem

After a deploy, the service worker (`registerType: 'autoUpdate'`) activates and Workbox's `cleanupOutdatedCaches` deletes the old content-hashed chunks from the precache. A tab still running the previous build then triggers a lazy `import()` — via TanStack Router's `defaultPreload: 'viewport'` or the eager map import — for a chunk hash that no longer exists in cache **or** on the server. The import rejects and surfaces as:

- `TypeError: Importing a module script failed.` (WEB-APP-2)
- `TypeError: Load failed` (WEB-APP-8)
- `Unable to preload CSS for /assets/Map-*.css` (WEB-APP-4)
- `Failed to fetch dynamically imported module: /assets/maplibre-gl-*.js` (WEB-APP-6)

All four are the same root cause; all show `0 users impacted` and cluster around deploys.

## Fix

Handle Vite's [documented](https://vite.dev/guide/build) `vite:preloadError` event with a guarded full reload, so the tab fetches the fresh shell (new `index.html` → valid chunk hashes) instead of throwing. This is Vite's recommended recovery pattern, adapted for this app:

- **`navigator.onLine` guard** — skip the reload when offline. A reload can't fetch a new chunk, and the SW already serves the precached shell, so reloading would only wipe in-memory UI state. Offline import failures (subway tunnels) are the most common *non-deploy* trigger here, and they're transient.
- **`sessionStorage` timestamp (10 s)** — Vite leans on `Cache-Control: no-cache` HTML for loop-prevention, but the SW serves a precached `index.html` that can briefly bypass that header. The timestamp bounds repeated reloads into a slow retry rather than a hammering loop in edge cases (CDN still propagating a deploy).

## Notes

- `preventDefault()` stops Vite from rethrowing the handled error, so the recovering events will go quiet in Sentry — this is expected, and is how we'll know the cluster is resolved.
- No new dependencies; 12-line addition to `main.tsx`.

## Closes

WEB-APP-2, WEB-APP-4, WEB-APP-6, WEB-APP-8