### PR TITLE
fix: clear map attribution off the Report button on mobile

### DIFF
--- a/packages/frontend-next/src/components/map/Map.css
+++ b/packages/frontend-next/src/components/map/Map.css
@@ -22,10 +22,13 @@ Custom CSS Overwrite to avoid CLS
   display: block;
 }
 
-/*
-Lift the bottom-right attribution control above the floating Report button
-(which sits flush at the bottom) so the two no longer overlap.
-*/
+/* Clear the attribution control off the floating Report button: button footprint
+   (h-14 + pb-safe-3 + inset) plus a gap-1.5 to match the opposite corner. */
 .maplibregl-ctrl-bottom-right {
-  bottom: 4rem;
+  bottom: calc(3.5rem + 0.75rem + 0.375rem + env(safe-area-inset-bottom));
+}
+
+/* Zero MapLibre's default bottom margin (else the gap is 10px too large) and match px-3. */
+.maplibregl-ctrl-bottom-right .maplibregl-ctrl {
+  margin: 0 0.75rem 0 0;
 }


### PR DESCRIPTION
## Summary

On mobile the MapLibre attribution toggle (compact "ⓘ", bottom-right) rendered **behind the floating Report button** and couldn't be tapped. The control's lift was a fixed `4rem` that ignored the bottom safe-area inset, so on home-indicator devices it didn't clear the button's footprint.

## Fix

- Make the attribution `bottom` offset safe-area-aware and size it to the button's real footprint — `h-14` (3.5rem) + `pb-safe-3` base (0.75rem) + `env(safe-area-inset-bottom)` — plus a 6px gap (`gap-1.5`) so it matches the spacing between the SocialLinks and the ReportsOverview card in the opposite corner.
- Zero MapLibre's default `margin: 0 10px 10px 0` on the control (the 10px bottom margin was stacking on top of the offset and making the gap too large), and set the right inset to `0.75rem` to match the buttons' `px-3`.

No z-index changes, so taps meant for the Report button are never intercepted — the two simply no longer overlap.

## Testing

Verified on the Capacitor iOS build: the ⓘ is fully visible and tappable above the Report button, with the gap matching the bottom-left corner. No regression on no-inset viewports (`env(safe-area-inset-bottom)` resolves to 0).

Fixes FRE-668 / closes #662