### PR TITLE
chore: track consent state as PostHog super-property

### DIFF
--- a/packages/frontend-next/src/lib/consent.ts
+++ b/packages/frontend-next/src/lib/consent.ts
@@ -68,6 +68,11 @@ function subscribe(listener: () => void): () => void {
 }
 
 // Bring PostHog in line with the current choice. Safe to call before a decision is made.
+// Every branch also stamps the choice as a super-property so traffic can be split by consent
+// state: 'denied' users get a fresh anonymous id each visit and can never register as "returned",
+// so a breakdown on `cookie_consent` sizes that retention blind spot and lets retention be read
+// cleanly on the non-'denied' slice. The value rides along in memory for 'denied' sessions, which
+// is exactly the slice we want to count, so it stays readable without cookies.
 function applyToPostHog(value: ConsentChoice | null): void {
   // Ops buffer until the lazily-loaded SDK is ready.
   if (value === 'denied') {
@@ -76,14 +81,21 @@ function applyToPostHog(value: ConsentChoice | null): void {
     enqueuePostHog((posthog) => {
       posthog.reset();
       posthog.set_config({ persistence: 'memory' });
+      // register() after reset() so the super-property survives the clear (in memory for this session).
+      posthog.register({ cookie_consent: 'denied', persistence_mode: 'memory' });
     });
   } else if (value === 'granted') {
     enqueuePostHog((posthog) => {
       posthog.set_config({ persistence: PERSISTENT_PERSISTENCE });
       posthog.opt_in_capturing();
+      posthog.register({ cookie_consent: 'granted', persistence_mode: PERSISTENT_PERSISTENCE });
+    });
+  } else {
+    // null: leave PostHog in its init default (persistent capture), just label the slice.
+    enqueuePostHog((posthog) => {
+      posthog.register({ cookie_consent: 'undecided', persistence_mode: PERSISTENT_PERSISTENCE });
     });
   }
-  // null: leave PostHog in its init default (persistent capture).
 }
 
 export function setConsent(value: ConsentChoice): void {


### PR DESCRIPTION
## Describe the issue:

PostHog analytics needs to track user consent state to properly segment traffic and understand retention metrics. Currently, the consent choice is applied to PostHog's persistence settings but not explicitly tracked as a property, making it difficult to analyze behavior by consent state.

## Explain how you solved the issue:

Added `cookie_consent` and `persistence_mode` as super-properties registered with PostHog for all consent states:

- **'denied'**: Resets PostHog to memory-only persistence and registers `cookie_consent: 'denied'`. This ensures denied users get a fresh anonymous ID each visit and never appear as "returned", allowing retention metrics to be cleanly read on the non-denied slice.
- **'granted'**: Registers `cookie_consent: 'granted'` with persistent storage enabled.
- **'undecided'** (null): Registers `cookie_consent: 'undecided'` while leaving PostHog in its default persistent capture mode.

The super-properties ride along in memory for denied sessions (the exact slice we want to count), making consent state readable without relying on cookies.

## Additional notes or considerations:

- The `register()` call for denied users happens after `reset()` to ensure the super-property survives the persistence clear within the session.
- This change enables better analytics segmentation and retention analysis without requiring additional cookie infrastructure.

https://claude.ai/code/session_01JznvE75t1fZK9J4AHQCqhq