### PR TITLE
feat: track detail modal open duration in PostHog

### DIFF
--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -6,6 +6,7 @@ import { type Station, useLines, useStations, useStationDistance } from '@/api/t
 import { LineBadge } from '@/components/transit/LineBadge';
 import { CardContent } from '@/components/ui/card';
 import { useGeolocation } from '@/contexts/Geolocation.context';
+import { useModalViewDuration } from '@/hooks/useModalViewDuration';
 import { optionalEnv } from '@/lib/utils';
 
 import { DetailCard } from './DetailCard';
@@ -22,6 +23,7 @@ const REPORTS_GROUP_HANDLE = optionalEnv('VITE_REPORTS_GROUP_HANDLE') ?? '@FreiF
 
 export function ReportDetail({ station, onClose }: ReportDetailProps) {
   const { t } = useTranslation(NAMESPACE);
+  useModalViewDuration('report');
   const { data: reports } = useReports(HOUR_MS);
   const { data: lines } = useLines();
   const { data: stations } = useStations();

--- a/packages/frontend-next/src/components/map/StationDetail.tsx
+++ b/packages/frontend-next/src/components/map/StationDetail.tsx
@@ -5,6 +5,7 @@ import { resolveStationLineNames, type Station, useLines } from '@/api/transit';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Button } from '@/components/ui/button';
 import { CardContent } from '@/components/ui/card';
+import { useModalViewDuration } from '@/hooks/useModalViewDuration';
 import { Route as ReportRoute } from '@/routes/report';
 
 import { DetailCard } from './DetailCard';
@@ -19,6 +20,7 @@ export function StationDetail({ station, onClose }: StationDetailProps) {
   const { t } = useTranslation(NAMESPACE);
   const { data: lines } = useLines();
   const lineNames = resolveStationLineNames(station.lines, lines);
+  useModalViewDuration('station');
 
   return (
     <DetailCard title={station.name} closeLabel={t('close')} onClose={onClose}>

--- a/packages/frontend-next/src/hooks/useModalViewDuration.ts
+++ b/packages/frontend-next/src/hooks/useModalViewDuration.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+import { track } from '@/lib/analytics';
+
+// Measures how long a detail modal stays open and fires `detail_modal_closed` on unmount. Both the
+// station and report modals are router routes, so they mount on navigate-in and unmount on close —
+// that lifecycle is the open window. We use performance.now() (monotonic) so a wall-clock shift
+// can't produce garbage durations. A page close/refresh while open won't unmount cleanly, so those
+// sessions are dropped — acceptable for an engagement metric.
+export function useModalViewDuration(modal: 'station' | 'report'): void {
+  useEffect(() => {
+    const openedAt = performance.now();
+    return () => {
+      track('detail_modal_closed', {
+        modal,
+        duration_ms: Math.round(performance.now() - openedAt),
+      });
+    };
+  }, [modal]);
+}

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -39,6 +39,7 @@ type AnalyticsEvents = {
   reports_overview_opened: { report_count: number };
   reports_tab_selected: { tab: 'summary' | 'lines' | 'reports' };
   report_row_selected: { report_age_minutes: number; has_line: boolean; has_direction: boolean };
+  detail_modal_closed: { modal: 'station' | 'report'; duration_ms: number };
 };
 
 export function track<E extends keyof AnalyticsEvents>(


### PR DESCRIPTION
Closes FRE-669 / #665.

## What

Measures how long users keep the **station** and **report** detail modals open, via a single new event fired on unmount:

```ts
detail_modal_closed: { modal: 'station' | 'report'; duration_ms: number };
```

Opens were already tracked (`station_selected`, `report_marker_selected`); this adds the engagement-duration signal.

## How

- New hook `hooks/useModalViewDuration.ts` — records `performance.now()` on mount, fires `track('detail_modal_closed', { modal, duration_ms })` in the effect cleanup. Both modals are TanStack Router routes, so mount/unmount *is* the open window.
- Registers `detail_modal_closed` in `AnalyticsEvents` (`lib/analytics.ts`).
- Calls `useModalViewDuration('station')` in `StationDetail.tsx` and `useModalViewDuration('report')` in `ReportDetail.tsx`.

## Notes

- One event with a `modal` discriminator (not two events) → single dashboard tile broken down by `modal`, extensible to the other modals later.
- `performance.now()` (monotonic) so a wall-clock shift can't produce garbage durations.
- StrictMode double-invokes effects in dev → a spurious ~0ms event, but dev has no PostHog key (only `console.log`), so production is clean.
- Page close/refresh while open won't unmount cleanly, so those sessions are dropped — acceptable for an engagement metric.

## Dashboard

The Map Interactions PostHog dashboard has been pre-provisioned with the tiles for this event (avg + p90 `duration_ms` broken down by `modal`, plus a distribution histogram); data flows in once this deploys.