### PR TITLE
feat: migrate the basemap tile-server to static PMTiles on Cloudflare R2

### DIFF
--- a/.github/workflows/tile-server-ci.yml
+++ b/.github/workflows/tile-server-ci.yml
@@ -1,0 +1,32 @@
+name: tile-server CI
+
+on:
+    pull_request:
+        branches: [main]
+        paths:
+            - 'packages/tile-server/**'
+            - '.github/workflows/tile-server-ci.yml'
+
+jobs:
+    typecheck:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        defaults:
+            run:
+                working-directory: packages/tile-server
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Set up Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install dependencies
+              run: bun install --frozen-lockfile
+
+            - name: Typecheck
+              run: bun run typecheck

--- a/.github/workflows/tile-server-deploy.yml
+++ b/.github/workflows/tile-server-deploy.yml
@@ -49,10 +49,10 @@ jobs:
 
             # The commit sha is the single version lever: it goes into both the style's archive URL
             # and the upload key below, so they can never diverge (the contract documented in
-            # rewrite-style.mjs).
+            # rewrite-style.ts).
             - name: Rewrite style for R2
               run: |
-                  node styles/rewrite-style.mjs --pmtiles \
+                  bun styles/rewrite-style.ts --pmtiles \
                       source/freifahren-style.json dist/styles/berlin.json \
                       "${{ vars.TILES_BASE_URL }}" "${GITHUB_SHA::8}"
 

--- a/.github/workflows/tile-server-deploy.yml
+++ b/.github/workflows/tile-server-deploy.yml
@@ -1,0 +1,81 @@
+name: tile-server Deploy
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - 'packages/tile-server/**'
+            - '.github/workflows/tile-server-deploy.yml'
+    workflow_dispatch: {}
+
+# Newest commit wins; never run two deploys at once.
+concurrency:
+    group: deploy-tile-server
+    cancel-in-progress: true
+
+jobs:
+    deploy:
+        # Gated on the public base URL being configured. Set the `TILES_BASE_URL` repo variable
+        # (e.g. https://basemap.freifahren.org) only after the R2 bucket's custom domain + the
+        # "Respect Strong ETags" cache rule are in place. Until then this job is skipped, so merging
+        # this workflow never runs against an unconfigured edge and never affects existing users.
+        if: ${{ vars.TILES_BASE_URL != '' }}
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        defaults:
+            run:
+                working-directory: packages/tile-server
+        env:
+            OSM_URL: https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Set up Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Download Berlin OSM extract
+              run: |
+                  mkdir -p source
+                  curl -fsSL -o source/berlin-latest.osm.pbf "$OSM_URL"
+
+            # Reuses the committed npm script (single source of truth with local dev). Tilemaker runs
+            # in Docker and writes dist/berlin.pmtiles.
+            - name: Generate PMTiles
+              run: bun run pmtiles:generate
+
+            # The commit sha is the single version lever: it goes into both the style's archive URL
+            # and the upload key below, so they can never diverge (the contract documented in
+            # rewrite-style.mjs).
+            - name: Rewrite style for R2
+              run: |
+                  node styles/rewrite-style.mjs --pmtiles \
+                      source/freifahren-style.json dist/styles/berlin.json \
+                      "${{ vars.TILES_BASE_URL }}" "${GITHUB_SHA::8}"
+
+            - name: Upload to R2
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+              run: |
+                  set -euo pipefail
+                  SHA="${GITHUB_SHA::8}"
+
+                  # Immutable, versioned archive — long cache, never purged (the /v<sha>/ path is the
+                  # cache-bust).
+                  bunx wrangler@latest r2 object put "freifahren-tiles/v$SHA/berlin.pmtiles" \
+                      --file dist/berlin.pmtiles \
+                      --content-type application/octet-stream \
+                      --cache-control "public, max-age=31536000, immutable" \
+                      --remote
+
+                  # The style is the only mutable pointer — short TTL so a redeploy/cutover propagates
+                  # quickly. It already references this build's immutable /v<sha>/ archive.
+                  bunx wrangler@latest r2 object put "freifahren-tiles/styles/berlin.json" \
+                      --file dist/styles/berlin.json \
+                      --content-type application/json \
+                      --cache-control "public, max-age=60, must-revalidate" \
+                      --remote

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ packages/tile-server/source/*
 packages/tile-server/tileserver/data/
 packages/tile-server/tileserver/styles/freifahren-dark/style.json
 packages/tile-server/tileserver/styles/freifahren-dark.json
+packages/tile-server/dist/
 settings.json
 *.log
 *.tsbuildinfo

--- a/packages/frontend-next/bun.lock
+++ b/packages/frontend-next/bun.lock
@@ -30,6 +30,7 @@
         "idb-keyval": "^6.2.5",
         "lucide-react": "^1.16.0",
         "maplibre-gl": "^5.24.0",
+        "pmtiles": "^4.4.1",
         "posthog-js": "^1.386.6",
         "radix-ui": "^1.4.3",
         "react": "^19.2.6",
@@ -1340,7 +1341,7 @@
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
-    "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
@@ -1901,6 +1902,8 @@
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "plist": ["plist@3.1.1", "", { "dependencies": { "@xmldom/xmldom": "^0.9.10", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA=="],
+
+    "pmtiles": ["pmtiles@4.4.1", "", { "dependencies": { "fflate": "^0.8.2" } }, "sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA=="],
 
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
@@ -2875,6 +2878,8 @@
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
     "path-type/pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
+
+    "posthog-js/fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 

--- a/packages/frontend-next/package.json
+++ b/packages/frontend-next/package.json
@@ -39,6 +39,7 @@
     "idb-keyval": "^6.2.5",
     "lucide-react": "^1.16.0",
     "maplibre-gl": "^5.24.0",
+    "pmtiles": "^4.4.1",
     "posthog-js": "^1.386.6",
     "radix-ui": "^1.4.3",
     "react": "^19.2.6",

--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -1,8 +1,16 @@
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './Map.css';
 
+import maplibregl from 'maplibre-gl';
+import { Protocol } from 'pmtiles';
 import { useState } from 'react';
 import { Map as MapGL } from 'react-map-gl/maplibre';
+
+// Register the `pmtiles://` protocol so MapLibre can range-read the static PMTiles basemap archive
+// directly from R2 (see packages/tile-server). This runs once when the lazy map chunk loads, before
+// the map mounts. No-op until VITE_MAP_STYLE_URL points at a pmtiles-based style, so it's safe to
+// ship ahead of the cutover.
+maplibregl.addProtocol('pmtiles', new Protocol().tile);
 
 import { useRisk } from '@/api/risk';
 import { useSegments } from '@/api/transit';

--- a/packages/tile-server/.gitignore
+++ b/packages/tile-server/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/tile-server/Dockerfile
+++ b/packages/tile-server/Dockerfile
@@ -2,7 +2,7 @@
 # Stages:
 #   1. osm-source — download the OSM extract
 #   2. tiles      — run tilemaker to produce the .mbtiles
-#   3. style      — run rewrite-style.mjs against the committed source style
+#   3. style      — run rewrite-style.ts against the committed source style
 #   4. final      — Martin serving the baked artifacts
 
 ARG OSM_URL=https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
@@ -27,14 +27,14 @@ RUN mkdir -p /out \
       --process /work/tilemaker/process-freifahren.lua
 
 # ---------- Stage 3: rewrite MapLibre style ----------
-FROM node:20-alpine AS style
+FROM oven/bun:1-alpine AS style
 ARG STYLE_BASE_URL
 ARG BUILD_SHA
 WORKDIR /work
 COPY styles/ ./styles/
 COPY source/freifahren-style.json ./source/freifahren-style.json
 RUN mkdir -p /out \
- && node styles/rewrite-style.mjs \
+ && bun styles/rewrite-style.ts \
       source/freifahren-style.json \
       /out/freifahren-dark.json \
       "$STYLE_BASE_URL" \

--- a/packages/tile-server/README.md
+++ b/packages/tile-server/README.md
@@ -144,6 +144,33 @@ Vector tile endpoint:
 http://localhost:3000/freifahren/{z}/{x}/{y}
 ```
 
+## PMTiles (R2 migration)
+
+We're migrating off the Martin server to **static PMTiles read directly by the browser over HTTP
+range requests** (hosted on Cloudflare R2). The Martin path above still builds and deploys
+production today; the scripts below produce the static artifacts for the new path. Both share the
+same Tilemaker config/Lua and the same `source/freifahren-style.json`.
+
+```sh
+cd packages/tile-server
+npm run pmtiles:build   # generate dist/berlin.pmtiles + dist/styles/berlin.json
+npm run pmtiles:serve   # serve dist/ with range support + CORS on http://localhost:3000
+```
+
+What differs from the Martin path:
+
+- **Tiles**: Tilemaker writes `.pmtiles` purely by output extension — same config, same tile size.
+- **Style**: `rewrite-style.mjs --pmtiles` emits a single `pmtiles://` vector source (the browser
+  range-reads the archive via the `pmtiles` protocol the frontend registers) and points `glyphs`
+  at a static `{fontstack}/{range}.pbf` path. No `tiles[]` template, no Martin glyph endpoint.
+- **Cache-bust**: the version is a path segment (`/v<sha>/berlin.pmtiles`), not a `?v=` query — an
+  immutable versioned object, so a deploy never needs an edge purge.
+- **Glyphs**: the basemap style currently has no `text-field` layers, so glyphs are not fetched.
+  The `glyphs` URL is emitted for forward-compatibility; generating the static PBF tree is a
+  follow-up (needed only once labels are added).
+
+`dist/` is git-ignored. Output layout mirrors the R2 bucket: `berlin.pmtiles` and `styles/berlin.json`.
+
 ## Frontend Setup
 
 Set:

--- a/packages/tile-server/README.md
+++ b/packages/tile-server/README.md
@@ -174,6 +174,38 @@ What differs from the Martin path:
 
 `dist/` is git-ignored. Output layout mirrors the R2 bucket: `berlin.pmtiles` and `styles/berlin.json`.
 
+### Deploy
+
+`.github/workflows/tile-server-deploy.yml` runs on every push to `main` that touches this package
+(and via manual dispatch). It downloads the OSM extract, generates `dist/`, and uploads to the
+`freifahren-tiles` R2 bucket: `v<sha>/berlin.pmtiles` (immutable, 1-year cache) and
+`styles/berlin.json` (60s TTL — the only mutable pointer, already referencing this build's archive).
+
+The deploy job is **gated on the `TILES_BASE_URL` repo variable** — until it's set the job is
+skipped, so this can merge with zero effect on production or existing users.
+
+### Cutover (one-time, manual)
+
+This is what flips traffic from Martin to R2. Everything above ships dormant; these are the only
+steps that change what users see.
+
+1. **Prepare the edge** (Cloudflare dashboard, R2 → `freifahren-tiles`):
+   - Attach a custom domain (e.g. `basemap.freifahren.org`).
+   - Add a Cache Rule for that hostname with **Respect Strong ETags** enabled, so byte-range reads
+     return `206` through the proxy. _Verify before flipping:_
+     `curl -I -H 'Range: bytes=0-99' https://basemap.freifahren.org/v<sha>/berlin.pmtiles` → `206`.
+   - Set the `TILES_BASE_URL` repo variable to that origin and re-run the deploy workflow so the
+     style is uploaded pointing at the live archive.
+2. **Flip the frontend**: change `VITE_MAP_STYLE_URL` in `packages/frontend-next/.env.production`
+   from the Martin style to `https://basemap.freifahren.org/styles/berlin.json`. The frontend
+   already registers the `pmtiles://` protocol, so this is the only frontend change. Merging it
+   redeploys the app onto R2.
+3. **Decommission**: once the new app is live and verified, remove the Coolify Martin service.
+
+Stale service-worker clients self-heal on reload (web-only, `autoUpdate`); pmtiles served from a new
+origin aren't matched by the existing `map-tiles` cache rule, so there's no range-cache poisoning to
+worry about. (Offline caching of pmtiles is a separate follow-up.)
+
 ## Frontend Setup
 
 Set:

--- a/packages/tile-server/README.md
+++ b/packages/tile-server/README.md
@@ -9,7 +9,7 @@ It turns an OpenStreetMap extract into vector tiles, serves those tiles through 
 The package has three parts:
 
 - `tilemaker/`: Tilemaker config for generating Berlin vector tiles from OSM data.
-- `styles/rewrite-style.mjs`: helper for preparing a MapLibre style JSON for the configured tile host.
+- `styles/rewrite-style.ts`: helper for preparing a MapLibre style JSON for the configured tile host.
 - `martin/`: Martin config for serving the style, generated MBTiles, and font glyphs.
 - `fonts/`: TTF fonts Martin turns into MapLibre glyph PBFs (see [Fonts & Glyphs](#fonts--glyphs)).
 - `tileserver/`: generated tile/style artifacts and local Docker Compose entrypoint.
@@ -39,7 +39,7 @@ Only reproducible configs and scripts are committed.
 ## Prerequisites
 
 - Docker
-- Node.js/npm
+- Bun
 - A Berlin or Berlin/Brandenburg OSM extract at:
 
 ```text
@@ -52,7 +52,7 @@ A clipped Berlin extract is fastest for local iteration.
 
 ```sh
 cd packages/tile-server
-npm run generate:berlin
+bun run generate:berlin
 ```
 
 This runs Tilemaker in Docker and writes:
@@ -78,7 +78,7 @@ Then run:
 
 ```sh
 cd packages/tile-server
-npm run rewrite-style
+bun run rewrite-style
 ```
 
 This writes:
@@ -96,13 +96,13 @@ The rewrite script:
 For production URLs, run:
 
 ```sh
-npm run rewrite-style:prod
+bun run rewrite-style:prod
 ```
 
 The script accepts an optional 4th positional argument used as a cache-bust token. When set, it is appended to each tile URL as `?v=<token>`:
 
 ```sh
-node styles/rewrite-style.mjs source/freifahren-style.json out.json https://tiles.freifahren.org abc123
+bun styles/rewrite-style.ts source/freifahren-style.json out.json https://tiles.freifahren.org abc123
 # → tiles: ["https://tiles.freifahren.org/freifahren/{z}/{x}/{y}?v=abc123"]
 ```
 
@@ -111,7 +111,7 @@ This is how the Dockerfile threads the deploy SHA into the style — see [Cachin
 ## Fonts & Glyphs
 
 Martin serves MapLibre glyph PBFs from the TTF fonts in `fonts/` (`fonts.paths` in
-`martin/config.yaml`), and `rewrite-style.mjs` sets the style's `glyphs` to
+`martin/config.yaml`), and `rewrite-style.ts` sets the style's `glyphs` to
 `<base-url>/font/{fontstack}/{range}`. This is required for any `text-field` layer to render,
 including the frontend's line/station labels.
 
@@ -123,7 +123,7 @@ frontend symbol layers to match. Icons (`icon-image`) still need a sprite — a 
 
 ```sh
 cd packages/tile-server
-npm run serve
+bun run serve
 ```
 
 Martin listens on:
@@ -153,14 +153,14 @@ same Tilemaker config/Lua and the same `source/freifahren-style.json`.
 
 ```sh
 cd packages/tile-server
-npm run pmtiles:build   # generate dist/berlin.pmtiles + dist/styles/berlin.json
-npm run pmtiles:serve   # serve dist/ with range support + CORS on http://localhost:3000
+bun run pmtiles:build   # generate dist/berlin.pmtiles + dist/styles/berlin.json
+bun run pmtiles:serve   # serve dist/ with range support + CORS on http://localhost:3000
 ```
 
 What differs from the Martin path:
 
 - **Tiles**: Tilemaker writes `.pmtiles` purely by output extension — same config, same tile size.
-- **Style**: `rewrite-style.mjs --pmtiles` emits a single `pmtiles://` vector source (the browser
+- **Style**: `rewrite-style.ts --pmtiles` emits a single `pmtiles://` vector source (the browser
   range-reads the archive via the `pmtiles` protocol the frontend registers) and points `glyphs`
   at a static `{fontstack}/{range}.pbf` path. No `tiles[]` template, no Martin glyph endpoint.
 - **Cache-bust**: the version is a path segment (`/v<sha>/berlin.pmtiles`), not a `?v=` query — an

--- a/packages/tile-server/README.md
+++ b/packages/tile-server/README.md
@@ -164,7 +164,10 @@ What differs from the Martin path:
   range-reads the archive via the `pmtiles` protocol the frontend registers) and points `glyphs`
   at a static `{fontstack}/{range}.pbf` path. No `tiles[]` template, no Martin glyph endpoint.
 - **Cache-bust**: the version is a path segment (`/v<sha>/berlin.pmtiles`), not a `?v=` query — an
-  immutable versioned object, so a deploy never needs an edge purge.
+  immutable versioned object, so a deploy never needs an edge purge. Versioning is applied **only by
+  the deploy workflow**, which threads one git sha into both the style URL and the R2 upload key so
+  they can't diverge. The local `pmtiles:build`/`pmtiles:serve` flow passes no version: the style
+  points at a flat `dist/berlin.pmtiles` that the build actually produces.
 - **Glyphs**: the basemap style currently has no `text-field` layers, so glyphs are not fetched.
   The `glyphs` URL is emitted for forward-compatibility; generating the static PBF tree is a
   follow-up (needed only once labels are added).

--- a/packages/tile-server/bun.lock
+++ b/packages/tile-server/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "tile-server",
+      "devDependencies": {
+        "@types/bun": "^1.3.10",
+        "typescript": "~6.0.2",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/packages/tile-server/package.json
+++ b/packages/tile-server/package.json
@@ -4,15 +4,20 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "generate:berlin": "mkdir -p tileserver/data && docker run --rm -v \"$PWD/../..:/work\" -w /work ghcr.io/systemed/tilemaker:master /work/packages/tile-server/source/berlin-latest.osm.pbf --output /work/packages/tile-server/tileserver/data/freifahren-berlin.mbtiles --config /work/packages/tile-server/tilemaker/config-freifahren.json --process /work/packages/tile-server/tilemaker/process-freifahren.lua",
-    "rewrite-style": "node styles/rewrite-style.mjs source/freifahren-style.json tileserver/styles/freifahren-dark.json http://localhost:3000",
-    "rewrite-style:prod": "node styles/rewrite-style.mjs source/freifahren-style.json tileserver/styles/freifahren-dark.json https://tiles.freifahren.org",
+    "rewrite-style": "bun styles/rewrite-style.ts source/freifahren-style.json tileserver/styles/freifahren-dark.json http://localhost:3000",
+    "rewrite-style:prod": "bun styles/rewrite-style.ts source/freifahren-style.json tileserver/styles/freifahren-dark.json https://tiles.freifahren.org",
     "serve": "docker compose -f tileserver/compose.yaml up",
     "serve:prod": "docker build -t freifahren-tiles --build-arg STYLE_BASE_URL=http://localhost:3000 . && docker run --rm -p 3000:3000 freifahren-tiles",
     "pmtiles:generate": "mkdir -p dist && docker run --rm -v \"$PWD/../..:/work\" -w /work ghcr.io/systemed/tilemaker:master /work/packages/tile-server/source/berlin-latest.osm.pbf --output /work/packages/tile-server/dist/berlin.pmtiles --config /work/packages/tile-server/tilemaker/config-freifahren.json --process /work/packages/tile-server/tilemaker/process-freifahren.lua",
-    "pmtiles:style": "node styles/rewrite-style.mjs --pmtiles source/freifahren-style.json dist/styles/berlin.json http://localhost:3000",
-    "pmtiles:style:prod": "node styles/rewrite-style.mjs --pmtiles source/freifahren-style.json dist/styles/berlin.json https://tiles.freifahren.org",
-    "pmtiles:build": "npm run pmtiles:generate && npm run pmtiles:style",
-    "pmtiles:serve": "npx -y http-server dist -p 3000 --cors -c-1"
+    "pmtiles:style": "bun styles/rewrite-style.ts --pmtiles source/freifahren-style.json dist/styles/berlin.json http://localhost:3000",
+    "pmtiles:style:prod": "bun styles/rewrite-style.ts --pmtiles source/freifahren-style.json dist/styles/berlin.json https://tiles.freifahren.org",
+    "pmtiles:build": "bun run pmtiles:generate && bun run pmtiles:style",
+    "pmtiles:serve": "bun styles/serve.ts dist 3000"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.10",
+    "typescript": "~6.0.2"
   }
 }

--- a/packages/tile-server/package.json
+++ b/packages/tile-server/package.json
@@ -8,6 +8,11 @@
     "rewrite-style": "node styles/rewrite-style.mjs source/freifahren-style.json tileserver/styles/freifahren-dark.json http://localhost:3000",
     "rewrite-style:prod": "node styles/rewrite-style.mjs source/freifahren-style.json tileserver/styles/freifahren-dark.json https://tiles.freifahren.org",
     "serve": "docker compose -f tileserver/compose.yaml up",
-    "serve:prod": "docker build -t freifahren-tiles --build-arg STYLE_BASE_URL=http://localhost:3000 . && docker run --rm -p 3000:3000 freifahren-tiles"
+    "serve:prod": "docker build -t freifahren-tiles --build-arg STYLE_BASE_URL=http://localhost:3000 . && docker run --rm -p 3000:3000 freifahren-tiles",
+    "pmtiles:generate": "mkdir -p dist && docker run --rm -v \"$PWD/../..:/work\" -w /work ghcr.io/systemed/tilemaker:master /work/packages/tile-server/source/berlin-latest.osm.pbf --output /work/packages/tile-server/dist/berlin.pmtiles --config /work/packages/tile-server/tilemaker/config-freifahren.json --process /work/packages/tile-server/tilemaker/process-freifahren.lua",
+    "pmtiles:style": "node styles/rewrite-style.mjs --pmtiles source/freifahren-style.json dist/styles/berlin.json http://localhost:3000",
+    "pmtiles:style:prod": "node styles/rewrite-style.mjs --pmtiles source/freifahren-style.json dist/styles/berlin.json https://tiles.freifahren.org",
+    "pmtiles:build": "npm run pmtiles:generate && npm run pmtiles:style",
+    "pmtiles:serve": "npx -y http-server dist -p 3000 --cors -c-1"
   }
 }

--- a/packages/tile-server/styles/rewrite-style.mjs
+++ b/packages/tile-server/styles/rewrite-style.mjs
@@ -35,6 +35,11 @@ if (pmtiles) {
     // The browser reads the PMTiles archive directly over HTTP range requests via the `pmtiles://`
     // protocol (registered in the frontend). The version segment is the cache-bust: a new deploy
     // writes an immutable `/v<sha>/berlin.pmtiles`, so the URL changes and no edge purge is needed.
+    //
+    // Contract: `version` is the single lever shared with the upload — whoever passes it MUST also
+    // upload the archive to the matching `/v<version>/berlin.pmtiles` key (the deploy workflow owns
+    // both, keyed off one git sha), or the basemap 404s. The local `pmtiles:*` scripts pass no
+    // version and serve a flat `dist/berlin.pmtiles`, so the style and artifact stay in lockstep.
     const archivePath = version ? `/v${version}/berlin.pmtiles` : '/berlin.pmtiles'
 
     style.sources[sourceName] = {

--- a/packages/tile-server/styles/rewrite-style.mjs
+++ b/packages/tile-server/styles/rewrite-style.mjs
@@ -1,10 +1,19 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-const [, , inputPath, outputPath, baseUrl = 'http://localhost:3000', cacheBust = ''] = process.argv
+// Two output modes:
+//   default  — Martin/xyz: vector `tiles[]` template + `?v=<token>` cache-bust + Martin glyph endpoint.
+//   --pmtiles — static PMTiles on R2: single `pmtiles://` vector source, versioned path (no query
+//               token), and a static `{fontstack}/{range}.pbf` glyph path.
+// The default is what the prod Dockerfile/Martin image still bakes; --pmtiles is the R2 migration path.
+const argv = process.argv.slice(2)
+const pmtiles = argv.includes('--pmtiles')
+const [inputPath, outputPath, baseUrl = 'http://localhost:3000', version = ''] = argv.filter(
+    (arg) => arg !== '--pmtiles',
+)
 
 if (!inputPath || !outputPath) {
-    console.error('Usage: node rewrite-style.mjs <input-style.json> <output-style.json> [base-url]')
+    console.error('Usage: node rewrite-style.mjs [--pmtiles] <input-style.json> <output-style.json> [base-url] [version]')
     process.exit(1)
 }
 
@@ -19,23 +28,40 @@ if (!inputSourceName) {
 
 delete style.sprite
 
-// `?v=<cacheBust>` invalidates Cloudflare's 1-year edge cache on each deploy.
-const withCacheBust = (url) => (cacheBust ? `${url}?v=${cacheBust}` : url)
+const attribution =
+    "<a href='https://www.openstreetmap.org/copyright' target='_blank'>&copy; OpenStreetMap contributors</a>"
 
-const tileUrl = withCacheBust(`${baseUrl}/${sourceName}/{z}/{x}/{y}`)
+if (pmtiles) {
+    // The browser reads the PMTiles archive directly over HTTP range requests via the `pmtiles://`
+    // protocol (registered in the frontend). The version segment is the cache-bust: a new deploy
+    // writes an immutable `/v<sha>/berlin.pmtiles`, so the URL changes and no edge purge is needed.
+    const archivePath = version ? `/v${version}/berlin.pmtiles` : '/berlin.pmtiles'
 
-// Glyphs are served by Martin from the fonts baked into the image (see martin/config.yaml).
-// MapLibre requires a top-level `glyphs` URL before any layer may use `text-field`, including
-// the symbol layers the frontend adds at runtime (line labels, station names).
-// Martin's `/font/{fontstack}/{start}-{end}` endpoint maps directly onto MapLibre's `{range}`.
-style.glyphs = withCacheBust(`${baseUrl}/font/{fontstack}/{range}`)
+    style.sources[sourceName] = {
+        type: 'vector',
+        url: `pmtiles://${baseUrl}${archivePath}`,
+        attribution,
+    }
 
-style.sources[sourceName] = {
-    type: 'vector',
-    tiles: [tileUrl],
-    maxzoom: 14,
-    attribution:
-        "<a href='https://www.openstreetmap.org/copyright' target='_blank'>&copy; OpenStreetMap contributors</a>",
+    // Static glyph PBF tree on R2 (immutable). MapLibre only fetches these when a layer uses
+    // `text-field`; the current basemap has none, but keep the URL so labels work when added.
+    style.glyphs = `${baseUrl}/fonts/{fontstack}/{range}.pbf`
+} else {
+    // `?v=<version>` invalidates Cloudflare's 1-year edge cache on each deploy.
+    const withCacheBust = (url) => (version ? `${url}?v=${version}` : url)
+
+    style.sources[sourceName] = {
+        type: 'vector',
+        tiles: [withCacheBust(`${baseUrl}/${sourceName}/{z}/{x}/{y}`)],
+        maxzoom: 14,
+        attribution,
+    }
+
+    // Glyphs are served by Martin from the fonts baked into the image (see martin/config.yaml).
+    // MapLibre requires a top-level `glyphs` URL before any layer may use `text-field`, including
+    // the symbol layers the frontend adds at runtime (line labels, station names).
+    // Martin's `/font/{fontstack}/{start}-{end}` endpoint maps directly onto MapLibre's `{range}`.
+    style.glyphs = withCacheBust(`${baseUrl}/font/{fontstack}/{range}`)
 }
 
 if (inputSourceName !== sourceName) {

--- a/packages/tile-server/styles/rewrite-style.ts
+++ b/packages/tile-server/styles/rewrite-style.ts
@@ -1,11 +1,35 @@
-import fs from 'node:fs/promises'
-import path from 'node:path'
-
+// Prepares a MapLibre style JSON for the configured tile host. Run with bun (`bun rewrite-style.ts`).
+//
 // Two output modes:
 //   default  — Martin/xyz: vector `tiles[]` template + `?v=<token>` cache-bust + Martin glyph endpoint.
 //   --pmtiles — static PMTiles on R2: single `pmtiles://` vector source, versioned path (no query
 //               token), and a static `{fontstack}/{range}.pbf` glyph path.
 // The default is what the prod Dockerfile/Martin image still bakes; --pmtiles is the R2 migration path.
+
+type Source = {
+    type: string
+    url?: string
+    tiles?: string[]
+    maxzoom?: number
+    attribution?: string
+}
+
+type Layer = {
+    id?: string
+    type?: string
+    source?: string
+    layout?: Record<string, unknown>
+    [key: string]: unknown
+}
+
+type Style = {
+    sources?: Record<string, Source>
+    layers?: Layer[]
+    glyphs?: string
+    sprite?: string
+    [key: string]: unknown
+}
+
 const argv = process.argv.slice(2)
 const pmtiles = argv.includes('--pmtiles')
 const [inputPath, outputPath, baseUrl = 'http://localhost:3000', version = ''] = argv.filter(
@@ -13,14 +37,18 @@ const [inputPath, outputPath, baseUrl = 'http://localhost:3000', version = ''] =
 )
 
 if (!inputPath || !outputPath) {
-    console.error('Usage: node rewrite-style.mjs [--pmtiles] <input-style.json> <output-style.json> [base-url] [version]')
+    console.error(
+        'Usage: bun rewrite-style.ts [--pmtiles] <input-style.json> <output-style.json> [base-url] [version]',
+    )
     process.exit(1)
 }
 
-const style = JSON.parse(await fs.readFile(inputPath, 'utf8'))
+const style = (await Bun.file(inputPath).json()) as Style
 const sourceName = 'freifahren'
 
-const inputSourceName = Object.keys(style.sources ?? {}).find((name) => style.sources[name]?.type === 'vector')
+const inputSourceName = Object.keys(style.sources ?? {}).find(
+    (name) => style.sources?.[name]?.type === 'vector',
+)
 
 if (!inputSourceName) {
     throw new Error('Expected a vector source in the style JSON')
@@ -30,6 +58,8 @@ delete style.sprite
 
 const attribution =
     "<a href='https://www.openstreetmap.org/copyright' target='_blank'>&copy; OpenStreetMap contributors</a>"
+
+const sources = (style.sources ??= {})
 
 if (pmtiles) {
     // The browser reads the PMTiles archive directly over HTTP range requests via the `pmtiles://`
@@ -42,7 +72,7 @@ if (pmtiles) {
     // version and serve a flat `dist/berlin.pmtiles`, so the style and artifact stay in lockstep.
     const archivePath = version ? `/v${version}/berlin.pmtiles` : '/berlin.pmtiles'
 
-    style.sources[sourceName] = {
+    sources[sourceName] = {
         type: 'vector',
         url: `pmtiles://${baseUrl}${archivePath}`,
         attribution,
@@ -53,9 +83,9 @@ if (pmtiles) {
     style.glyphs = `${baseUrl}/fonts/{fontstack}/{range}.pbf`
 } else {
     // `?v=<version>` invalidates Cloudflare's 1-year edge cache on each deploy.
-    const withCacheBust = (url) => (version ? `${url}?v=${version}` : url)
+    const withCacheBust = (url: string) => (version ? `${url}?v=${version}` : url)
 
-    style.sources[sourceName] = {
+    sources[sourceName] = {
         type: 'vector',
         tiles: [withCacheBust(`${baseUrl}/${sourceName}/{z}/{x}/{y}`)],
         maxzoom: 14,
@@ -70,7 +100,7 @@ if (pmtiles) {
 }
 
 if (inputSourceName !== sourceName) {
-    delete style.sources[inputSourceName]
+    delete sources[inputSourceName]
 }
 
 for (const layer of style.layers ?? []) {
@@ -79,11 +109,10 @@ for (const layer of style.layers ?? []) {
     }
 }
 
-style.layers = (style.layers ?? []).filter((layer) => {
-    const layout = layer.layout ?? {}
+style.layers = (style.layers ?? []).filter((layer) => (layer.layout ?? {})['icon-image'] === undefined)
 
-    return layout['icon-image'] === undefined
-})
+// Bun.write creates parent directories as needed.
+await Bun.write(outputPath, `${JSON.stringify(style, null, 2)}\n`)
 
-await fs.mkdir(path.dirname(outputPath), { recursive: true })
-await fs.writeFile(outputPath, `${JSON.stringify(style, null, 2)}\n`)
+// Mark the file as a module so top-level `await` is allowed under tsc.
+export {}

--- a/packages/tile-server/styles/serve.ts
+++ b/packages/tile-server/styles/serve.ts
@@ -1,0 +1,58 @@
+// Local static server for the PMTiles artifacts in `dist/`. Run with bun (`bun serve.ts [root] [port]`).
+//
+// Serves HTTP Range requests (206 + Content-Range) via `Bun.file().slice()` — exactly what pmtiles.js
+// needs — so it's a dependency-free stand-in for the production R2 edge during local development.
+import { resolve, join } from 'node:path'
+
+const root = resolve(process.argv[2] ?? 'dist')
+const port = Number(process.argv[3] ?? 3000)
+
+const CORS: Record<string, string> = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'range, if-match',
+    'Access-Control-Expose-Headers': 'etag, content-range, content-length, accept-ranges',
+    'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+}
+
+Bun.serve({
+    port,
+    async fetch(req) {
+        if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: CORS })
+
+        const { pathname } = new URL(req.url)
+        const filePath = resolve(join(root, decodeURIComponent(pathname)))
+        // Block path traversal outside the served root.
+        if (filePath !== root && !filePath.startsWith(root + '/')) {
+            return new Response('forbidden', { status: 403, headers: CORS })
+        }
+
+        const file = Bun.file(filePath)
+        if (!(await file.exists())) return new Response('not found', { status: 404, headers: CORS })
+
+        const size = file.size
+        const headers: Record<string, string> = {
+            ...CORS,
+            'Accept-Ranges': 'bytes',
+            'Content-Type': file.type,
+        }
+
+        const range = req.headers.get('range')
+        const match = range && /^bytes=(\d+)-(\d*)$/.exec(range)
+        if (match) {
+            const start = Number(match[1])
+            const end = match[2] ? Number(match[2]) : size - 1
+            return new Response(file.slice(start, end + 1), {
+                status: 206,
+                headers: {
+                    ...headers,
+                    'Content-Range': `bytes ${start}-${end}/${size}`,
+                    'Content-Length': String(end - start + 1),
+                },
+            })
+        }
+
+        return new Response(file, { headers: { ...headers, 'Content-Length': String(size) } })
+    },
+})
+
+console.log(`range server on http://localhost:${port} (root=${root})`)

--- a/packages/tile-server/tilemaker/process-freifahren.lua
+++ b/packages/tile-server/tilemaker/process-freifahren.lua
@@ -101,7 +101,7 @@ function road_z_order(class)
 end
 
 -- Matches the earliest zoom at which the style actually draws each class
--- (see styles/rewrite-style.mjs output) so tiles never carry invisible geometry.
+-- (see styles/rewrite-style.ts output) so tiles never carry invisible geometry.
 function road_minzoom(class, type)
   if class == "motorway" or class == "motorway_link" then return 5 end
   if class == "main" and type == "trunk" then return 7 end
@@ -156,7 +156,7 @@ function should_emit_landuse(class, area)
   return true
 end
 
--- The style renders no symbol layers (rewrite-style.mjs strips every layer with
+-- The style renders no symbol layers (rewrite-style.ts strips every layer with
 -- text-field/icon-image), so no label layers or name attributes are emitted.
 function node_function()
 end

--- a/packages/tile-server/tsconfig.json
+++ b/packages/tile-server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["bun"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["styles"]
+}


### PR DESCRIPTION
Migrates the basemap tile-server from the Martin/Coolify server to **static PMTiles on Cloudflare R2**, read directly by the browser via HTTP range requests. Everything here ships **dormant** — merging changes nothing for existing users. Cutover is two manual steps (below).

## What's in this PR
- **Tilemaker → PMTiles**: `pmtiles:generate` writes `dist/berlin.pmtiles` (same config/Lua/tile size — Tilemaker switches format by extension).
- **`rewrite-style.mjs --pmtiles`**: emits a single `pmtiles://` vector source + static glyphs URL, version as a `/v<sha>/` path segment (not `?v=`). Default Martin/xyz output untouched.
- **npm scripts**: `pmtiles:generate|style|build|serve`; `dist/` git-ignored.
- **Deploy workflow** (`tile-server-deploy.yml`): on push to main, generates + uploads to the `freifahren-tiles` R2 bucket (`v<sha>/berlin.pmtiles` immutable, `styles/berlin.json` 60s TTL). One git sha drives both the style URL and the upload key so they can't diverge. **Gated on a `TILES_BASE_URL` repo variable** — skipped until set, so merge is a no-op on prod.
- **Frontend**: registers the `pmtiles://` protocol (lazy map chunk) + adds the `pmtiles` dep. No-op until the style URL flips, so it ships safely ahead of cutover.

## Cutover (after merge — the only steps that change what users see)
1. **Edge**: attach a custom domain to `freifahren-tiles` + a Cache Rule with **Respect Strong ETags** (so range reads return `206`); verify with a `Range` curl; set the `TILES_BASE_URL` repo variable and re-run the deploy.
2. **Flip**: change `VITE_MAP_STYLE_URL` in `frontend-next/.env.production` to `https://<domain>/styles/berlin.json`. Then remove the Coolify Martin service.

(Full runbook in `packages/tile-server/README.md`.)

## Verification done
- Real 24 MB `berlin.pmtiles` generated (valid magic); static serve returns `206` + correct `Content-Range`/CORS.
- **End-to-end render**: frontend paints the Berlin basemap from the archive via 206 range reads, overlays intact, zero console errors.
- **Real R2**: artifacts uploaded to the private `freifahren-tiles` bucket; integrity confirmed; R2 serves byte ranges on the S3 data path.
- Frontend `build` + Prettier + ESLint all pass with the protocol change.

## Not included (deferred)
- The public custom-domain + cache-rule range check (needs the domain stood up — it's step 1 of cutover, gated behind public exposure).
- Static glyph PBF generation (basemap has no `text-field` layers, so glyphs aren't fetched yet).
- SW offline caching of pmtiles (the new origin isn't matched by the existing `map-tiles` rule, so no range-cache poisoning; offline tile caching is a separate follow-up).

@codex please review.
