### PR TITLE
feat: serve the production basemap from static PMTiles on R2

### DIFF
--- a/packages/frontend-next/.env.example
+++ b/packages/frontend-next/.env.example
@@ -1,5 +1,5 @@
 VITE_API_URL=http://localhost:3000
-VITE_MAP_STYLE_URL=https://tiles.freifahren.org/style/freifahren-dark
+VITE_MAP_STYLE_URL=https://basemap.freifahren.org/styles/berlin.json
 VITE_MAP_CENTER_LNG=13.388
 VITE_MAP_CENTER_LAT=52.5162
 VITE_MAP_INITIAL_ZOOM=11

--- a/packages/frontend-next/.env.production
+++ b/packages/frontend-next/.env.production
@@ -1,5 +1,5 @@
 VITE_API_URL=https://api.freifahren.org
-VITE_MAP_STYLE_URL=https://tiles.freifahren.org/style/freifahren-dark
+VITE_MAP_STYLE_URL=https://basemap.freifahren.org/styles/berlin.json
 VITE_MAP_CENTER_LNG=13.388
 VITE_MAP_CENTER_LAT=52.5162
 VITE_MAP_INITIAL_ZOOM=11


### PR DESCRIPTION
Cutover: points the production frontend at the static PMTiles basemap on R2.

Changes `VITE_MAP_STYLE_URL` (`.env.production` + `.env.example`) from the Martin style to `https://basemap.freifahren.org/styles/berlin.json`. The frontend already registers the `pmtiles://` protocol (shipped in #671), so this one line is the whole cutover.

**This is the moment users move onto R2.** Verified beforehand by running a local dev server against the live `basemap.freifahren.org` style — basemap renders from public 206 range reads, overlays intact, zero console errors.

Safe by design:
- Martin stays up (no `tiles.freifahren.org` change here), so still-open old tabs keep working until they reload.
- New origin isn't matched by the existing service-worker `map-tiles` cache rule, so no range-cache poisoning — no SW change needed.
- Rollback is reverting this one line.

Follow-ups (separate): repoint `tiles.freifahren.org` → R2 + switch the frontend back to it as part of removing the Coolify Martin service (with the SW cache-rule split)