### PR TITLE
feat: serve the basemap from tiles.freifahren.org and split the map service-worker cache

### DIFF
--- a/packages/frontend-next/.env.example
+++ b/packages/frontend-next/.env.example
@@ -1,5 +1,5 @@
 VITE_API_URL=http://localhost:3000
-VITE_MAP_STYLE_URL=https://basemap.freifahren.org/styles/berlin.json
+VITE_MAP_STYLE_URL=https://tiles.freifahren.org/styles/berlin.json
 VITE_MAP_CENTER_LNG=13.388
 VITE_MAP_CENTER_LAT=52.5162
 VITE_MAP_INITIAL_ZOOM=11

--- a/packages/frontend-next/.env.production
+++ b/packages/frontend-next/.env.production
@@ -1,5 +1,5 @@
 VITE_API_URL=https://api.freifahren.org
-VITE_MAP_STYLE_URL=https://basemap.freifahren.org/styles/berlin.json
+VITE_MAP_STYLE_URL=https://tiles.freifahren.org/styles/berlin.json
 VITE_MAP_CENTER_LNG=13.388
 VITE_MAP_CENTER_LAT=52.5162
 VITE_MAP_INITIAL_ZOOM=11

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -117,17 +117,36 @@ export default defineConfig({
           navigateFallback: '/index.html',
           runtimeCaching: [
             {
-              // Tiles + style are served immutable with a ?v=<hash>, so CacheFirst is safe and gives
-              // a zero-network repaint of a previously-viewed area. Bounded so storage can't grow
-              // unbounded as a rider pans around.
-              urlPattern: ({ url }) => url.origin === 'https://tiles.freifahren.org',
-              handler: 'CacheFirst',
+              // Style JSON is the one mutable pointer (it names the current immutable /v<sha>/ archive).
+              // StaleWhileRevalidate paints instantly from cache but refreshes in the background, so a
+              // new tile-server deploy is picked up on the next load — never the 30-day staleness a
+              // CacheFirst rule would impose.
+              urlPattern: ({ url }) =>
+                url.origin === 'https://tiles.freifahren.org' && url.pathname.endsWith('.json'),
+              handler: 'StaleWhileRevalidate',
               options: {
-                cacheName: 'map-tiles',
-                expiration: { maxEntries: 300, maxAgeSeconds: 60 * 60 * 24 * 30 },
+                cacheName: 'map-style',
+                expiration: { maxEntries: 4, maxAgeSeconds: 60 * 60 * 24 },
                 cacheableResponse: { statuses: [0, 200] },
               },
             },
+            {
+              // Glyph PBFs are immutable, so CacheFirst is safe (currently unused — the basemap has no
+              // text layers — but ready for when labels are added).
+              urlPattern: ({ url }) =>
+                url.origin === 'https://tiles.freifahren.org' && url.pathname.endsWith('.pbf'),
+              handler: 'CacheFirst',
+              options: {
+                cacheName: 'map-fonts',
+                expiration: { maxEntries: 256, maxAgeSeconds: 60 * 60 * 24 * 365 },
+                cacheableResponse: { statuses: [0, 200] },
+              },
+            },
+            // The PMTiles archive (.pmtiles) is deliberately NOT given a runtime cache rule: it's read
+            // via HTTP range requests, and a CacheFirst store could hand a full 200 back to a range
+            // request and corrupt the read. Range reads go straight to the network (the immutable
+            // /v<sha>/ archive is still cached by the browser's HTTP cache). Offline tile caching —
+            // which needs workbox-range-requests — is a separate follow-up.
           ],
         },
         devOptions: { enabled: false },


### PR DESCRIPTION
Second half of the tile-server migration: now that Coolify/Martin is removed and `tiles.freifahren.org` is attached to the R2 bucket, move the basemap back onto that hostname.

## Changes
- **Env flip** (`.env.production` + `.env.example`): `VITE_MAP_STYLE_URL` → `https://tiles.freifahren.org/styles/berlin.json` (same R2 bucket/style, preferred hostname).
- **Service-worker cache split** (`vite.config.ts`): the old blanket `CacheFirst` rule on the `tiles.freifahren.org` origin is wrong now that pmtiles live there again. Split by file type with fresh cache names:
  - `*.json` (style) → **StaleWhileRevalidate** (mutable pointer — avoids 30-day staleness; new deploys land on next load).
  - `*.pbf` (glyphs) → **CacheFirst** 1yr (immutable; currently unused).
  - `*.pmtiles` → **no rule** (range reads go to network; a cached full-200 would corrupt a range read). Browser HTTP cache still caches the immutable archive.

## Infra already done
- Dead Coolify A record removed; `tiles.freifahren.org` attached as R2 custom domain (SSL active, range `206` + CORS verified).
- `TILES_BASE_URL` repo variable → `https://tiles.freifahren.org`; tile-server deploy re-run, so the style now references `tiles.freifahren.org/v<sha>/berlin.pmtiles`.

## Trade-off
Offline pmtiles caching is dropped for now (range caching needs workbox-range-requests — separate follow-up). Online perf unaffected.

`basemap.freifahren.org` stays attached so already-loaded bundles keep working until they reload.