### PR TITLE
feat: offline basemap tiles for the Capacitor app

### DIFF
--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -1,16 +1,17 @@
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './Map.css';
 
-import maplibregl from 'maplibre-gl';
+import maplibregl, { type StyleSpecification } from 'maplibre-gl';
 import { Protocol } from 'pmtiles';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Map as MapGL } from 'react-map-gl/maplibre';
 
 // Register the `pmtiles://` protocol so MapLibre can range-read the static PMTiles basemap archive
 // directly from R2 (see packages/tile-server). This runs once when the lazy map chunk loads, before
-// the map mounts. No-op until VITE_MAP_STYLE_URL points at a pmtiles-based style, so it's safe to
-// ship ahead of the cutover.
-maplibregl.addProtocol('pmtiles', new Protocol().tile);
+// the map mounts. The shared instance lets the Capacitor offline path register a locally-cached
+// archive on it (see prepareOfflineBasemap).
+const pmtilesProtocol = new Protocol();
+maplibregl.addProtocol('pmtiles', pmtilesProtocol.tile);
 
 import { useRisk } from '@/api/risk';
 import { useSegments } from '@/api/transit';
@@ -50,6 +51,28 @@ export function MapView() {
   const { visible: riskVisible } = useRiskLayer();
   const [baseMapReady, setBaseMapReady] = useState(false);
 
+  // On web the style is just the URL (MapLibre fetches it, and the SW + immutable HTTP cache handle
+  // offline). The Capacitor build has no service worker, so it resolves the style + a locally-cached
+  // PMTiles archive itself; we hold the map until that's ready to avoid a network-style first paint.
+  const [mapStyle, setMapStyle] = useState<string | StyleSpecification | null>(
+    __CAPACITOR__ ? null : MAP_STYLE_URL,
+  );
+  useEffect(() => {
+    if (!__CAPACITOR__) return;
+    let cancelled = false;
+    void import('@/lib/offline-basemap')
+      .then(({ prepareOfflineBasemap }) => prepareOfflineBasemap(MAP_STYLE_URL, pmtilesProtocol))
+      .then((style) => {
+        if (!cancelled) setMapStyle(style);
+      })
+      .catch(() => {
+        if (!cancelled) setMapStyle(MAP_STYLE_URL);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // Fetch the overlay data now — in parallel with the base-map style and tiles — even though we
   // hold off *rendering* the overlays until the base map has painted (below). The fetches must
   // not wait for the layers to mount, or the lines/reports would visibly lag the map. (Stations
@@ -57,12 +80,16 @@ export function MapView() {
   useSegments();
   useRisk();
 
+  // Capacitor only: the offline basemap resolves async, so hold the container until it's ready. On
+  // web mapStyle is the URL synchronously, so this branch never runs.
+  if (!mapStyle) return <div className="fixed inset-0" />;
+
   return (
     <div className="fixed inset-0">
       <MapGL
         initialViewState={INITIAL_VIEW}
         minZoom={MIN_ZOOM}
-        mapStyle={MAP_STYLE_URL}
+        mapStyle={mapStyle}
         pixelRatio={PIXEL_RATIO}
         // 0 disables MapLibre's label cross-fade, which otherwise re-renders frames after every
         // pan/zoom and tile load — needless CPU churn on a dense transit map.

--- a/packages/frontend-next/src/lib/offline-basemap.ts
+++ b/packages/frontend-next/src/lib/offline-basemap.ts
@@ -46,15 +46,15 @@ function archiveUrlFromStyle(style: StyleSpecification): string | null {
 }
 
 // Fetch the style fresh and persist it; fall back to the last cached copy when offline.
-async function resolveStyle(styleUrl: string): Promise<StyleSpecification | null> {
+// Network fetch only — persistence is deferred to prepareOfflineBasemap, which pairs the saved style
+// with a confirmed-present archive.
+async function fetchStyle(styleUrl: string): Promise<StyleSpecification | null> {
   try {
     const res = await fetch(styleUrl);
     if (!res.ok) throw new Error(`style HTTP ${res.status}`);
-    const style = (await res.json()) as StyleSpecification;
-    await set(STYLE_KEY, style, store);
-    return style;
+    return (await res.json()) as StyleSpecification;
   } catch {
-    return (await get<StyleSpecification>(STYLE_KEY, store)) ?? null;
+    return null;
   }
 }
 
@@ -74,13 +74,12 @@ async function downloadArchive(archiveUrl: string, key: string): Promise<void> {
   const res = await fetch(archiveUrl);
   if (!res.ok) throw new Error(`archive HTTP ${res.status}`);
   await set(key, await res.blob(), store);
-  await pruneOldArchives(key);
 }
 
 /**
  * Resolve the basemap style and, when a local copy of its PMTiles archive exists, register it with
- * the pmtiles protocol so tiles render with no network. The archive is downloaded once in the
- * background — this launch still uses the network via the protocol's default FetchSource — and
+ * the pmtiles protocol so tiles render with no network. A new deploy's archive is downloaded once in
+ * the background — this launch still uses the network via the protocol's default FetchSource — and
  * reused on every later launch, including offline ones. Returns the original URL only as a last
  * resort: a first-ever launch while offline, when nothing is cached yet.
  */
@@ -88,19 +87,30 @@ export async function prepareOfflineBasemap(
   styleUrl: string,
   protocol: Protocol,
 ): Promise<string | StyleSpecification> {
-  const style = await resolveStyle(styleUrl);
+  // Prefer the fresh style; fall back to the last persisted one (which always has its archive) offline.
+  const fresh = await fetchStyle(styleUrl);
+  const style = fresh ?? (await get<StyleSpecification>(STYLE_KEY, store)) ?? null;
   if (!style) return styleUrl;
 
   const archiveUrl = archiveUrlFromStyle(style);
-  if (!archiveUrl) return style;
+  if (!archiveUrl) {
+    if (fresh) await set(STYLE_KEY, fresh, store);
+    return style;
+  }
 
   const key = archiveKeyFor(archiveUrl);
   const cached = await get<Blob>(key, store);
   if (cached) {
+    if (fresh) await set(STYLE_KEY, fresh, store);
     protocol.add(new PMTiles(new BufferSource(await cached.arrayBuffer(), archiveUrl)));
-  } else if (navigator.onLine) {
-    // Persist in the background so the next launch — including an offline one — is covered.
-    void downloadArchive(archiveUrl, key).catch(() => {});
+  } else if (fresh && navigator.onLine) {
+    // New deploy: its archive isn't downloaded yet. Persist the style only *after* its archive lands,
+    // and prune older archives only then — so the persisted style always has a matching archive and an
+    // interrupted download can never strand the next offline launch (the prior complete pair stays).
+    void downloadArchive(archiveUrl, key)
+      .then(() => set(STYLE_KEY, fresh, store))
+      .then(() => pruneOldArchives(key))
+      .catch(() => {});
   }
 
   return style;

--- a/packages/frontend-next/src/lib/offline-basemap.ts
+++ b/packages/frontend-next/src/lib/offline-basemap.ts
@@ -1,0 +1,107 @@
+import type { StyleSpecification } from 'maplibre-gl';
+import { createStore, del, get, keys, set } from 'idb-keyval';
+import { PMTiles, type Protocol, type RangeResponse, type Source } from 'pmtiles';
+
+// Capacitor-only offline basemap. The native build ships no service worker, so the web app's
+// HTTP-cache offline path doesn't apply; instead we persist the full PMTiles archive in IndexedDB
+// and read tiles from it locally. IndexedDB (not the Filesystem plugin) holds the ~25 MB archive as
+// a Blob with no base64 round-trip and survives WebView cold starts. Imported only behind
+// `__CAPACITOR__`, so it never enters the web bundle.
+
+const store = createStore('freifahren-basemap', 'cache');
+const STYLE_KEY = 'style';
+const ARCHIVE_PREFIX = 'archive:';
+
+/** A pmtiles Source backed by the whole archive held in memory, for offline range reads. */
+class BufferSource implements Source {
+  private readonly buffer: ArrayBuffer;
+  private readonly key: string;
+
+  constructor(buffer: ArrayBuffer, key: string) {
+    this.buffer = buffer;
+    this.key = key;
+  }
+
+  getKey(): string {
+    return this.key;
+  }
+
+  async getBytes(offset: number, length: number): Promise<RangeResponse> {
+    return { data: this.buffer.slice(offset, offset + length) };
+  }
+}
+
+// The immutable `/v<sha>/` segment makes each deploy's archive a stable cache key.
+function archiveKeyFor(archiveUrl: string): string {
+  const version = /\/v([^/]+)\//.exec(archiveUrl)?.[1];
+  return `${ARCHIVE_PREFIX}${version ?? archiveUrl}`;
+}
+
+function archiveUrlFromStyle(style: StyleSpecification): string | null {
+  const source = style.sources?.freifahren;
+  if (source && source.type === 'vector' && typeof source.url === 'string') {
+    return source.url.replace('pmtiles://', '');
+  }
+  return null;
+}
+
+// Fetch the style fresh and persist it; fall back to the last cached copy when offline.
+async function resolveStyle(styleUrl: string): Promise<StyleSpecification | null> {
+  try {
+    const res = await fetch(styleUrl);
+    if (!res.ok) throw new Error(`style HTTP ${res.status}`);
+    const style = (await res.json()) as StyleSpecification;
+    await set(STYLE_KEY, style, store);
+    return style;
+  } catch {
+    return (await get<StyleSpecification>(STYLE_KEY, store)) ?? null;
+  }
+}
+
+// Drop archives from older deploys so storage tracks only the current version.
+async function pruneOldArchives(keepKey: string): Promise<void> {
+  const all = await keys(store);
+  await Promise.all(
+    all
+      .filter(
+        (k): k is string => typeof k === 'string' && k.startsWith(ARCHIVE_PREFIX) && k !== keepKey,
+      )
+      .map((k) => del(k, store)),
+  );
+}
+
+async function downloadArchive(archiveUrl: string, key: string): Promise<void> {
+  const res = await fetch(archiveUrl);
+  if (!res.ok) throw new Error(`archive HTTP ${res.status}`);
+  await set(key, await res.blob(), store);
+  await pruneOldArchives(key);
+}
+
+/**
+ * Resolve the basemap style and, when a local copy of its PMTiles archive exists, register it with
+ * the pmtiles protocol so tiles render with no network. The archive is downloaded once in the
+ * background — this launch still uses the network via the protocol's default FetchSource — and
+ * reused on every later launch, including offline ones. Returns the original URL only as a last
+ * resort: a first-ever launch while offline, when nothing is cached yet.
+ */
+export async function prepareOfflineBasemap(
+  styleUrl: string,
+  protocol: Protocol,
+): Promise<string | StyleSpecification> {
+  const style = await resolveStyle(styleUrl);
+  if (!style) return styleUrl;
+
+  const archiveUrl = archiveUrlFromStyle(style);
+  if (!archiveUrl) return style;
+
+  const key = archiveKeyFor(archiveUrl);
+  const cached = await get<Blob>(key, store);
+  if (cached) {
+    protocol.add(new PMTiles(new BufferSource(await cached.arrayBuffer(), archiveUrl)));
+  } else if (navigator.onLine) {
+    // Persist in the background so the next launch — including an offline one — is covered.
+    void downloadArchive(archiveUrl, key).catch(() => {});
+  }
+
+  return style;
+}

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -145,8 +145,7 @@ export default defineConfig({
             // The PMTiles archive (.pmtiles) is deliberately NOT given a runtime cache rule: it's read
             // via HTTP range requests, and a CacheFirst store could hand a full 200 back to a range
             // request and corrupt the read. Range reads go straight to the network (the immutable
-            // /v<sha>/ archive is still cached by the browser's HTTP cache). Offline tile caching —
-            // which needs workbox-range-requests — is a separate follow-up.
+            // /v<sha>/ archive is still cached by the browser's HTTP cache).
           ],
         },
         devOptions: { enabled: false },


### PR DESCRIPTION
Adds offline basemap rendering for the **Capacitor** app. The native build ships no service worker (`!isCapacitor && VitePWA` in vite.config.ts), so the web app's HTTP-cache offline path doesn't apply there — instead we persist the full PMTiles archive locally and read tiles from it.

## How it works
- **`lib/offline-basemap.ts`**: resolves the style (network, falling back to the last cached copy), and persists the `/v<sha>/berlin.pmtiles` archive as a **Blob in IndexedDB** (same store mechanism the React Query cache already relies on to survive a tunnel). A `BufferSource` serves range reads from the in-memory archive, registered on the shared pmtiles `Protocol`.
- **`Map.tsx`**: on Capacitor, resolves the offline basemap before mounting the map. Everything is behind `__CAPACITOR__`, dynamically imported — the **web bundle and web behaviour are unchanged**.
- Archive is downloaded **once in the background** (this launch still uses the network); reused on every later launch, including offline ones. A new deploy (`/v<sha>/` change) triggers a re-download and prunes the old archive.

IndexedDB (not the Filesystem plugin) because it stores the ~25 MB Blob with no base64 round-trip and persists across WebView cold starts.

Also drops a now-stale `vite.config.ts` comment that said offline tiles were a follow-up.

## Verification
- Web path retested manually (dev server → R2 style + prod API): renders fine, zero console errors; the Capacitor branch correctly does not run on web. `tsc` + ESLint + Prettier pass; `bun run build:ios` succeeds and bundles the offline chunk.
- **On-device (pending, mine to confirm):** launch online once → ~25 MB archive lands in the `freifahren-basemap` IndexedDB store → kill app → airplane mode → relaunch → basemap renders offline.

@codex please review.
