### PR TITLE
docs: ADRs for the static PMTiles/R2 basemap and offline strategy

### DIFF
--- a/docs/adr/0004-static-pmtiles-basemap-on-cloudflare-r2.md
+++ b/docs/adr/0004-static-pmtiles-basemap-on-cloudflare-r2.md
@@ -1,0 +1,45 @@
+# Serve the basemap as static PMTiles on Cloudflare R2
+
+## Status
+
+accepted
+
+## Context
+
+The frontend basemap was served by a **Martin** vector-tile server (Docker on Coolify,
+`tiles.freifahren.org`) reading an MBTiles file. That's a stateful service to run, monitor, and pay
+for — with cold starts and a single point of failure — for what is effectively static, rarely-changing
+city data.
+
+## Decision
+
+Drop the server. Tilemaker outputs a single **PMTiles** archive; CI uploads it to an **R2 bucket**
+(`freifahren-tiles`) behind a custom domain (`tiles.freifahren.org`), and the browser reads it
+**directly via HTTP range requests** through MapLibre's `pmtiles://` protocol. A GitHub Actions
+workflow generates and uploads on push; the edge is read-only.
+
+Cache invalidation is **purge-free** by construction: the archive is written to an immutable,
+commit-versioned path `/v<sha>/berlin.pmtiles` (`Cache-Control: immutable`, 1 year), and the only
+mutable object is a small `styles/berlin.json` pointer (short TTL) that names the current archive. A
+deploy writes a new `/v<sha>/` and rewrites the pointer — old archives are simply unreferenced and
+age out. The same commit sha drives both the upload key and the style's source URL, so they can't
+diverge. A Cloudflare Cache Rule with **Respect Strong ETags** keeps range reads returning `206` once
+edge-cached.
+
+## Considered alternatives
+
+- **Keep Martin:** rejected — server/ops cost and a SPOF for data that barely changes.
+- **Hosted tile vendor:** rejected — recurring cost and a third-party dependency when we already run
+  on Cloudflare.
+
+## Consequences
+
+- No tile server to operate; tiles are globally edge-cached and range-served from the nearest PoP.
+- The frontend must register the `pmtiles://` protocol. Overlays are unaffected (separate GeoJSON
+  sources).
+- New cities become add-an-archive + pointer rather than a new server — the `cities.json`-driven
+  generalisation is a planned follow-up.
+- CORS is per-origin (`Vary: Origin` from R2); an unconditional `Access-Control-Allow-Origin: *`
+  transform rule is an option if cold-cache CORS races appear.
+- Provisioning (bucket, custom domain, cache rule) currently lives in the Cloudflare API/MCP, not
+  Terraform; import into the `infra` repo when it lands.

--- a/docs/adr/0005-offline-basemap-http-cache-web-indexeddb-capacitor.md
+++ b/docs/adr/0005-offline-basemap-http-cache-web-indexeddb-capacitor.md
@@ -1,0 +1,41 @@
+# Offline basemap: HTTP cache on web, IndexedDB archive in the Capacitor app
+
+## Status
+
+accepted
+
+## Context
+
+With the basemap now a static PMTiles archive ([ADR 0004](0004-static-pmtiles-basemap-on-cloudflare-r2.md)),
+offline support differs by platform. The web app runs a service worker; the Capacitor build
+deliberately ships **none** (FRE-649 — a SW inside the native WebView serves a stale shell), so
+SW-based caching is unavailable there.
+
+## Decision
+
+**Web — rely on the browser HTTP cache.** The `/v<sha>/` archive is immutable, so byte ranges fetched
+while online are reused on an offline reload with no extra code. The service worker caches the style
+(StaleWhileRevalidate) and glyphs (CacheFirst) but **deliberately does not cache `.pmtiles`** — a
+CacheFirst store could answer a range request with a full `200` and corrupt the read.
+
+**Capacitor — persist the archive in IndexedDB.** Download the full archive once in the background
+and store it as a Blob (the same store the React Query cache uses to survive a tunnel); serve tiles
+from it via an in-memory pmtiles `Source`. The cached style is kept **paired** with a present archive
+(persist the new style only after its archive lands), so an interrupted download can never strand the
+next offline launch with a style whose tiles are missing.
+
+## Considered alternatives
+
+- **`workbox-range-requests` to SW-cache `.pmtiles` on web:** rejected for now — meaningful complexity
+  for marginal gain over the immutable HTTP cache. Revisit if guaranteed full-city web offline is
+  wanted.
+- **Capacitor Filesystem instead of IndexedDB:** rejected — a base64 round-trip for the ~25 MB
+  archive, where IndexedDB stores the Blob directly and already persists across WebView cold starts.
+
+## Consequences
+
+- Web offline covers only previously-viewed areas, and the HTTP cache can be evicted — best-effort,
+  not guaranteed.
+- Capacitor gets guaranteed full-city offline at the cost of a one-time ~25 MB download and storage.
+- Native offline logic lives in app code (gated behind `__CAPACITOR__`), not the service worker, so
+  the two platforms diverge here by design.


### PR DESCRIPTION
Records the two architectural decisions behind the recent tile-server migration, in the repo's `docs/adr/` format.

- **0004 — Serve the basemap as static PMTiles on Cloudflare R2.** Why we dropped the Martin tile server for a single range-read archive on R2, and the purge-free cache-busting (immutable `/v<sha>/` archive + short-TTL style pointer).
- **0005 — Offline basemap: HTTP cache on web, IndexedDB archive in Capacitor.** Why the two platforms diverge — the Capacitor build ships no service worker, so it persists the archive in IndexedDB while web rides the immutable HTTP cache.

Both follow the short Context/Decision/Considered-alternatives/Consequences shape of ADR 0002. Deliberately *not* ADR'd: the one-time cutover runbook and the bun/TS tooling switch (easily reversible, no lock-in).