### PR TITLE
fix: download OSM extracts with curl instead of a stalling Bun fetch

### DIFF
--- a/packages/tile-server/scripts/generate.ts
+++ b/packages/tile-server/scripts/generate.ts
@@ -42,9 +42,13 @@ for (const city of selected) {
   const pbf = resolve(SOURCE, basename(new URL(city.osmUrl).pathname))
   if (!(await Bun.file(pbf).exists())) {
     console.log(`↓ ${city.name}: ${city.osmUrl}`)
-    const res = await fetch(city.osmUrl)
-    if (!res.ok) throw new Error(`OSM download failed (${res.status}) for ${city.name}`)
-    await Bun.write(pbf, res)
+    // curl, not fetch + Bun.write: streaming the ~100 MB extract through Bun.write stalled on CI
+    // (the whole deploy hung). curl streams straight to disk and retries.
+    const dl = Bun.spawn(['curl', '-fSL', '--retry', '3', '-o', pbf, city.osmUrl], {
+      stdout: 'inherit',
+      stderr: 'inherit',
+    })
+    if ((await dl.exited) !== 0) throw new Error(`OSM download failed for ${city.name}`)
   }
 
   // 2. Vector tiles via tilemaker (in Docker — paths resolved inside the /work mount).

--- a/packages/tile-server/scripts/generate.ts
+++ b/packages/tile-server/scripts/generate.ts
@@ -43,8 +43,9 @@ for (const city of selected) {
   if (!(await Bun.file(pbf).exists())) {
     console.log(`↓ ${city.name}: ${city.osmUrl}`)
     // curl, not fetch + Bun.write: streaming the ~100 MB extract through Bun.write stalled on CI
-    // (the whole deploy hung). curl streams straight to disk and retries.
-    const dl = Bun.spawn(['curl', '-fSL', '--retry', '3', '-o', pbf, city.osmUrl], {
+    // (the whole deploy hung). curl streams straight to disk and retries. --remove-on-error so an
+    // interrupted transfer can't leave a truncated file the exists() check above would later reuse.
+    const dl = Bun.spawn(['curl', '-fSL', '--retry', '3', '--remove-on-error', '-o', pbf, city.osmUrl], {
       stdout: 'inherit',
       stderr: 'inherit',
     })


### PR DESCRIPTION
The first deploy on the new cities.json pipeline **hung for 17 min** on the OSM download and was cancelled. The log shows it printed `↓ berlin: …geofabrik…/berlin-latest.osm.pbf` and then never progressed to tilemaker.

Cause: `scripts/generate.ts` downloaded the ~100 MB extract with `fetch()` + `Bun.write(response)`, which stalled on CI. The previous workflow did the same download with `curl` in **12 s** (tilemaker 17 s, upload 9 s — ~40 s total).

Fix: download via `curl -fSL --retry 3` (streams straight to disk, retries). Verified locally end-to-end (forced the download path): full generate — 100 MB download + tilemaker + style — completes in **~25 s** and produces a valid archive.

No prod impact from the hung run: it was cancelled before uploading, and the refactor produced byte-identical Berlin tiles, so R2 still serves the prior version. Once this merges, the deploy will run cleanly and publish the current sha.

@codex please review.