### PR TITLE
chore: add iOS App Store release signing config

### DIFF
--- a/packages/frontend-next/fastlane/.gitignore
+++ b/packages/frontend-next/fastlane/.gitignore
@@ -1,0 +1,6 @@
+# Secrets and generated artifacts — never commit.
+.env
+*.p8
+*.p12
+*.mobileprovision
+report.xml

--- a/packages/frontend-next/fastlane/Appfile
+++ b/packages/frontend-next/fastlane/Appfile
@@ -1,0 +1,4 @@
+app_identifier(ENV["APP_BUNDLE_ID"])
+apple_id(ENV["APPLE_ID"])
+itc_team_id(ENV["APPSTORE_CONNECT_TEAM_ID"])
+team_id(ENV["APPLE_DEVELOPER_TEAM_ID"])

--- a/packages/frontend-next/fastlane/Matchfile
+++ b/packages/frontend-next/fastlane/Matchfile
@@ -1,0 +1,6 @@
+storage_mode("git")
+type("appstore")
+
+git_url(ENV["MATCH_GIT_URL"])
+app_identifier(ENV["APP_BUNDLE_ID"])
+username(ENV["APPLE_ID"])

--- a/packages/frontend-next/ios/App/App/Info.plist
+++ b/packages/frontend-next/ios/App/App/Info.plist
@@ -4,6 +4,14 @@
 <dict>
     <key>CAPACITOR_DEBUG</key>
 	<string>$(CAPACITOR_DEBUG)</string>
+	<!-- Let the WebView render above 60 Hz on ProMotion (120 Hz) devices; without this, WKWebView
+	     caps web content at 60 Hz and map pan/zoom animations feel sluggish next to the rest of iOS. -->
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<!-- App uses only standard HTTPS/TLS (exempt). Declaring this skips the App Store Connect
+	     export-compliance prompt on every TestFlight build. -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
Sets up repeatable iOS App Store releases for the Capacitor app (`packages/frontend-next`) by adding the `match`-based signing config, mirroring `packages/app/fastlane`.

## What's included
- **`fastlane/Appfile` + `fastlane/Matchfile`** — `match` signing config. Entirely env-driven; no secrets.
- **`fastlane/.gitignore`** — defensive ignore for `.env`, `*.p8`, `*.p12`, `*.mobileprovision` so credentials can't be committed.
- **`Info.plist`** — two flags:
  - `ITSAppUsesNonExemptEncryption=false` (standard HTTPS only → skips the App Store Connect export-compliance prompt every build).
  - `CADisableMinimumFrameDurationOnPhone=true` (lets the WebView render above 60 Hz on ProMotion devices).

## Deliberately not included
- No secrets (match password, Apple ID, API key, app-specific password) — those live only in a git-ignored `fastlane/.env`.
- No `project.pbxproj` signing edits — distribution signing is applied at archive time, keeping the committed project on the local-device build config.
- No deploy runbook — kept out of this public repo intentionally.
- No SPM lockfile churn.