### PR TITLE
refactor: drop the report security microservice call

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -230,7 +230,7 @@ export function useSubmitReport() {
       const lineId = resolveLineId(input, lines);
       const response = await fetch(`${API_URL}/v0/reports`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'ff-platform': 'web' },
         body: JSON.stringify({
           stationId: input.stationId,
           lineId,

--- a/packages/hono-backend/README.md
+++ b/packages/hono-backend/README.md
@@ -8,7 +8,6 @@ The .env file contains the following variables:
 - `DATABASE_URL_TEST`: The URL of the test database to use.
 - `NLP_SERVICE_URL`: The URL of the NLP service to use.
 - `REPORT_PASSWORD`: The password to use for the report API.
-- `SECURITY_MICROSERVICE_URL`: The URL of the security microservice to use.
 - `CORS_ORIGINS`: Comma-separated list of frontend origins allowed to call the API, for example `http://localhost:1871,https://freifahren.org`.
 
 ## Start containers

--- a/packages/hono-backend/compose-hono.test.yaml
+++ b/packages/hono-backend/compose-hono.test.yaml
@@ -26,7 +26,6 @@ services:
             DATABASE_URL: postgres://postgres:postgres@postgres:5432/freifahren
             NLP_SERVICE_URL: http://localhost:6000
             REPORT_PASSWORD: password
-            SECURITY_MICROSERVICE_URL: http://localhost:4000
             CORS_ORIGINS: http://localhost:1871,http://127.0.0.1:1871,capacitor://localhost
         ports:
             - '3000:3000'

--- a/packages/hono-backend/src/modules/reports/reports-routes.ts
+++ b/packages/hono-backend/src/modules/reports/reports-routes.ts
@@ -3,7 +3,6 @@ import { DateTime } from 'luxon'
 import { z } from 'zod'
 
 import { Env } from '../../app-env'
-import { AppError } from '../../common/errors'
 import { defineRoute } from '../../common/router'
 import { insertReportSchema } from '../../db'
 
@@ -156,27 +155,6 @@ export const postReport = defineRoute<Env>()({
     handler: async (c) => {
         const reportsService = c.get('reportsService')
         const logger = c.get('logger')
-
-        try {
-            await reportsService.verifyRequest(c.req.header())
-        } catch (err) {
-            if (err instanceof AppError && err.internalCode === 'SPAM_REPORT_DETECTED') {
-                logger.warn('Spam report blocked by security service')
-                return c.json(
-                    {
-                        message: err.message,
-                    },
-                    err.statusCode
-                )
-            }
-            logger.error(err, 'Error verifying request with security service')
-            return c.json(
-                {
-                    message: 'Failed to verify request',
-                },
-                500
-            )
-        }
 
         const reportData = c.req.valid('json')
 

--- a/packages/hono-backend/src/modules/reports/reports-service.ts
+++ b/packages/hono-backend/src/modules/reports/reports-service.ts
@@ -3,7 +3,6 @@ import { DateTime } from 'luxon'
 import { z } from 'zod'
 
 import { AppError } from '../../common/errors'
-import { logger } from '../../common/logger'
 import { DbConnection, InsertReport, reports } from '../../db/'
 import type { TransitNetworkDataService } from '../transit/transit-network-data-service'
 import type { StationId } from '../transit/types'
@@ -110,53 +109,6 @@ export class ReportsService {
             }
 
             throw error
-        }
-    }
-
-    async verifyRequest(headers: Record<string, string>): Promise<void> {
-        const reportPassword = process.env.REPORT_PASSWORD
-        const isDev = process.env.NODE_ENV === 'development'
-
-        // Exceptions for dev mode and the Telegram Bot (Identified by the X-Password header)
-        if (
-            (reportPassword !== undefined && reportPassword !== '' && headers['x-password'] === reportPassword) ||
-            isDev
-        ) {
-            return
-        }
-
-        const securityServiceUrl = process.env.SECURITY_MICROSERVICE_URL
-        if (securityServiceUrl === undefined || securityServiceUrl === '') {
-            throw new Error('security service configuration error')
-        }
-
-        let response: Response
-        try {
-            response = await fetch(`${securityServiceUrl.replace(/\/$/, '')}/check`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ headers }),
-            })
-        } catch (err) {
-            logger.warn(err, 'Security service unreachable, skipping spam verification')
-            return
-        }
-
-        if (!response.ok) {
-            throw new Error(`failed to verify request with status ${response.status}: ${await response.text()}`)
-        }
-
-        const result = (await response.json()) as { valid: boolean }
-
-        if (!result.valid) {
-            throw new AppError({
-                message:
-                    'Spam reports are not allowed, if you have an issue with us contact us and we can hash it out.',
-                statusCode: 403,
-                internalCode: 'SPAM_REPORT_DETECTED',
-            })
         }
     }
 

--- a/packages/hono-backend/tests/postReport.test.ts
+++ b/packages/hono-backend/tests/postReport.test.ts
@@ -8,7 +8,6 @@ import { and, desc, eq, sql } from 'drizzle-orm'
 import { sendReportRequest } from './test-utils'
 
 let fakeNlpServer: ReturnType<typeof Bun.serve> | null = null
-let fakeSecurityServer: ReturnType<typeof Bun.serve> | null = null
 
 type CapturedRequest = {
     body: unknown
@@ -16,7 +15,6 @@ type CapturedRequest = {
 }
 
 const capturedRequests: CapturedRequest[] = []
-let securityValidResponse = true
 
 describe('Telegram notification', () => {
     let shouldFail: boolean
@@ -42,31 +40,18 @@ describe('Telegram notification', () => {
             fetch: fakeNlp.fetch,
         })
 
-        const fakeSecurity = new Hono()
-        fakeSecurity.post('/check', async (c) => {
-            return c.json({ valid: securityValidResponse })
-        })
-
-        fakeSecurityServer = Bun.serve({
-            port: 0,
-            fetch: fakeSecurity.fetch,
-        })
-
         process.env.NLP_SERVICE_URL = `http://127.0.0.1:${fakeNlpServer.port}`
-        process.env.SECURITY_MICROSERVICE_URL = `http://127.0.0.1:${fakeSecurityServer.port}`
         process.env.REPORT_PASSWORD = 'test-password'
         process.env.NODE_ENV = 'production'
     })
 
     afterAll(() => {
         fakeNlpServer?.stop()
-        fakeSecurityServer?.stop()
     })
 
     beforeEach(() => {
         capturedRequests.length = 0
         shouldFail = false
-        securityValidResponse = true
     })
 
     it('sends a Telegram notification when source is not telegram and returns 200', async () => {
@@ -142,24 +127,9 @@ describe('Telegram notification', () => {
     })
 })
 
-describe('Security Verification', () => {
-    it('bypasses security check when the correct X-Password is provided', async () => {
-        const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
-        securityValidResponse = false // Even if security would have blocked it
-
-        const response = await sendReportRequest({
-            stationId: station.id,
-        })
-
-        // Should succeed because password bypasses security service call
-        expect(response.status).toBe(200)
-    })
-})
-
 describe('Report API contract', () => {
     beforeAll(async () => {
         process.env.NODE_ENV = 'production'
-        process.env.REPORT_PASSWORD = 'test-password' // To pass the security check
     })
 
     it('rejects reports without station, line, and direction', async () => {


### PR DESCRIPTION
## What

Report anti-spam verification is now handled upstream at the network edge, so the backend no longer calls a separate security microservice to validate `POST /v0/reports`.

- Remove `ReportsService.verifyRequest()` and its call site in the report route.
- Drop the `SECURITY_MICROSERVICE_URL` env wiring (README, test compose, tests).
- Tag the web client's report requests with `ff-platform` so official clients are distinguishable upstream — the mobile app already sends this header; the Telegram bot is identified separately.

## Why

Consolidates the spam gate into a single upstream rule instead of a self-hosted microservice the backend had to reach on every report. The edge rule is already live and verified (official clients pass, unsigned traffic is dropped before it reaches the origin).

## Notes

- The integration suite in `packages/hono-backend/tests` needs a seeded Postgres test DB and runs in CI; the edits here are deletions of the security-service test fakes. `tsc` and `eslint` pass locally.