### PR TITLE
fix: fade station list bottom edge so it reads as scrollable

### DIFF
--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -211,7 +211,7 @@ function StationPicker() {
               autoComplete="off"
             />
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="min-h-0 flex-1 overflow-y-auto mask-b-from-[calc(100%-2.5rem)] mask-b-to-100% pb-2">
             {nearby.length > 0 && (
               <>
                 <div className="text-muted-foreground flex items-center gap-1.5 px-3 py-2 text-[0.625rem] font-semibold tracking-wide uppercase">


### PR DESCRIPTION
## What

On the **Report sighting** screen, the station list ran flush against the **Submit report** button with a hard cut, making it look like the list ended there even when more stations were scrollable below.

This adds a bottom fade to the station list so the last rows fade out into the background — the standard "there's more below, keep scrolling" affordance.

## How

Applied a Tailwind v4 `mask` to the existing scroll container instead of a colored overlay:

```
mask-b-from-[calc(100%-2.5rem)] mask-b-to-100%
```

- Fades the actual content to transparent, so it's correct on any background (no hardcoded surface color).
- Single element — keeps the same `min-h-0 flex-1 overflow-y-auto` base the other scroll lists use.
- `pb-2` gives the last row breathing room under the fade.

## Why

TestFlight feedback (Moritz): the list looked non-scrollable where it met the submit button.

## Test

Open Report sighting, pick a line with many stations (e.g. U-Bahn) so the list overflows — the bottom rows fade out instead of cutting off hard.