### PR TITLE
fix: stop iOS WebView resizing on keyboard so it can't leave a black band

### DIFF
--- a/packages/frontend-next/capacitor.config.ts
+++ b/packages/frontend-next/capacitor.config.ts
@@ -1,10 +1,19 @@
 import type { CapacitorConfig } from '@capacitor/cli';
+import { KeyboardResize } from '@capacitor/keyboard';
 
 const config: CapacitorConfig = {
   appId: 'com.anonymous.Freifahren',
   appName: 'FreiFahren',
   webDir: 'dist',
   plugins: {
+    // The map is a full-bleed `position: fixed; inset: 0` layer and both text inputs (map search,
+    // report station search) sit at the top of the screen, so the keyboard can simply overlay the
+    // bottom — nothing needs to shrink. `None` stops iOS from resizing the WebView frame on focus,
+    // which on some devices/OS versions fails to restore after dismissal and leaves a black band
+    // where the keyboard was (reported on iPhone 16 Pro / iOS 27).
+    Keyboard: {
+      resize: KeyboardResize.None,
+    },
     // #2b2b2b matches the app-icon tile so the centered mark blends into the splash background.
     SplashScreen: {
       backgroundColor: '#2b2b2b',


### PR DESCRIPTION
## What

Sets the Capacitor keyboard to `KeyboardResize.None` so iOS no longer resizes the WebView frame when the keyboard opens.

## Why

TestFlight report (Moritz, iPhone 16 Pro / iOS 27): "Layout broken nach screenshot" — a black band fills the bottom ~third of the screen after the keyboard had been open.

Root cause: `@capacitor/keyboard` was installed without a `resize` config, so it defaulted to `KeyboardResize.Native`, which physically shrinks the WebView frame when the keyboard appears. On some devices/OS versions the frame fails to restore after dismissal, leaving the `position: fixed; inset: 0` map pinned to the shortened frame — the freed keyboard area renders black. The band height (~34% of screen) matches the iPhone 16 Pro keyboard height.

## How

The map is a full-bleed `fixed inset-0` layer and both text inputs (map search, report station search) sit at the top of the screen, so the keyboard can simply overlay the bottom — nothing needs to shrink. `None` removes the resize-then-fail-to-restore path entirely.