### PR TITLE
feat: reveal FreiFahren mark in the notch on screenshots

### DIFF
--- a/packages/frontend-next/src/components/ScreenshotBranding.tsx
+++ b/packages/frontend-next/src/components/ScreenshotBranding.tsx
@@ -1,0 +1,23 @@
+/**
+ * Brand mark tucked into the notch zone of Face-ID iPhones. The notch is a physical cutout, so the
+ * mark is hidden in normal use but captured in screenshots (a full-rectangle framebuffer) — branding
+ * with no screenshot detection. Native-only; aimed at the notch fleet (iPhone 13/14/mini/16e, etc.).
+ */
+export function ScreenshotBranding() {
+  if (!__CAPACITOR__) return null;
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-x-0 top-0 z-50 flex items-center justify-center"
+      style={{ height: 'env(safe-area-inset-top)' }}
+    >
+      <div className="flex items-center gap-1">
+        <img src="/pwa-192x192.png" alt="" className="size-4 rounded-[5px]" />
+        <span className="text-[11px] leading-none font-semibold tracking-tight text-white">
+          FreiFahren
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend-next/src/routes/__root.tsx
+++ b/packages/frontend-next/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import { ContributeCard } from '@/components/contribute/ContributeCard';
 import { FeedbackCard } from '@/components/feedback/FeedbackCard';
 import { LegalDisclaimer } from '@/components/LegalDisclaimer';
 import { PersistentMapView } from '@/components/map/PersistentMapView';
+import { ScreenshotBranding } from '@/components/ScreenshotBranding';
 import { GeolocationProvider } from '@/contexts/GeolocationProvider';
 
 export const Route = createRootRoute({
@@ -19,6 +20,7 @@ export const Route = createRootRoute({
       <ContributeCard />
       <FeedbackCard />
       <ConsentBanner />
+      <ScreenshotBranding />
     </GeolocationProvider>
   ),
 });


### PR DESCRIPTION
## What

Adds the FreiFahren app-icon mark + wordmark tucked into the notch zone on Face-ID iPhones.
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-06-24 at 15 06 13" src="https://github.com/user-attachments/assets/8c5fdd52-b89d-4588-92d8-3c08c9f209d1" />


## How it works

The notch is a physical cutout — no panel pixels behind it — so the mark is **invisible in normal use**, but a screenshot captures the full rectangular framebuffer and **reveals it**. So screenshots/shared images carry FreiFahren branding, with **no screenshot-detection plumbing** (iOS only reports screenshots after capture anyway, so it could never be added reactively).

- Pure web/CSS: a `pointer-events-none` element pinned to the top safe area, centered in the cutout between the status-bar ears.
- Native-only (`__CAPACITOR__`); there's no notch on the web.
- Targets the notch fleet (iPhone 13/14/mini/16e, etc.). On Dynamic Island devices the island floats lower so the mark can peek out — acceptable.

## Test

Verified on the iPhone 16e simulator (notched): the mark renders centered at the very top, between the clock and battery, exactly where a real screenshot reveals it.