### PR TITLE
feat: track screenshot_taken analytics event on iOS

### DIFF
--- a/packages/frontend-next/ios/App/App/AppDelegate.swift
+++ b/packages/frontend-next/ios/App/App/AppDelegate.swift
@@ -7,8 +7,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        // Forward iOS's screenshot notification to the web layer as a `screenshotTaken` window event
+        // (handled in native.ts). iOS fires this after the capture, which is fine for analytics.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(userDidTakeScreenshot),
+            name: UIApplication.userDidTakeScreenshotNotification,
+            object: nil
+        )
         return true
+    }
+
+    @objc private func userDidTakeScreenshot() {
+        let bridgeVC = window?.rootViewController as? CAPBridgeViewController
+        bridgeVC?.bridge?.triggerWindowJSEvent(eventName: "screenshotTaken")
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -22,6 +22,7 @@ type AnalyticsEvents = {
     lineId: string | null;
     directionId: string | null;
   };
+  screenshot_taken: Record<string, never>;
   risk_layer_toggled: { to: SuperProperties['map_layer'] };
   contribute_modal_opened: { source: ContributeSource };
   contribute_method_viewed: { method: 'stripe' | 'bank_transfer' };

--- a/packages/frontend-next/src/lib/native.ts
+++ b/packages/frontend-next/src/lib/native.ts
@@ -1,6 +1,7 @@
 import { Capacitor } from '@capacitor/core';
 
 import { queryClient } from '@/api/queryClient';
+import { track } from '@/lib/analytics';
 
 /**
  * Native-only platform setup for the Capacitor (iOS/Android) builds; a no-op on web. Plugins are
@@ -48,4 +49,8 @@ export async function initNativePlatform(): Promise<void> {
   } catch {
     /* ignore */
   }
+
+  // AppDelegate bridges iOS's userDidTakeScreenshot notification to this window event. The current
+  // route rides along automatically as posthog-js's `$pathname`.
+  window.addEventListener('screenshotTaken', () => track('screenshot_taken', {}));
 }


### PR DESCRIPTION
## What

Tracks a `screenshot_taken` PostHog event when a user screenshots the iOS app.

## How

- `AppDelegate.swift` observes `UIApplication.userDidTakeScreenshotNotification` and forwards it to the web layer via Capacitor's bridge (`triggerWindowJSEvent`).
- `native.ts` listens for that `screenshotTaken` window event and calls `track('screenshot_taken', {})`.
- `analytics.ts` adds the event to the typed event map.

No custom properties: the route is captured automatically by posthog-js as `$pathname` (verified), so `screenshot_taken` is already filterable/breakable by route. Device/OS/app-version come free too.

iOS-only — there's no reliable screenshot hook on web or Android. Pairs with the notch-branding feature (#683): this measures how often that mark gets exposed.

## Test

Verified end-to-end against the Web App PostHog project from the iPhone 16e simulator: `screenshot_taken` arrived with `$pathname=/` and `is_native=true`. Note the real screenshot gesture can't be triggered in the simulator (Apple limitation), so the native notification firing itself is best confirmed on a real device / TestFlight; the bridge → JS → PostHog chain is verified.