### PR TITLE
fix: allow the ff-platform header through CORS so the Capacitor app can report

### DIFF
--- a/packages/hono-backend/src/index.ts
+++ b/packages/hono-backend/src/index.ts
@@ -45,7 +45,7 @@ export const createApp = (dbConnection: DbConnection = db) => {
         '*',
         cors({
             origin: getCorsOrigins(),
-            allowHeaders: ['Accept', 'Content-Type', 'If-Modified-Since', 'If-None-Match'],
+            allowHeaders: ['Accept', 'Content-Type', 'If-Modified-Since', 'If-None-Match', 'ff-platform'],
             allowMethods: ['GET', 'POST', 'OPTIONS'],
             exposeHeaders: ['ETag', 'Last-Modified'],
         })


### PR DESCRIPTION
## Problem

Reporting from the Capacitor (iOS) app stopped working after a Cloudflare rule was added that gates `POST /v0/reports` — admitting requests either by a `*.freifahren.org` `Origin` or by the presence of the `ff-platform` header (the Telegram bot is whitelisted separately).

The web app passes on its `Origin` alone. The Capacitor WebView's origin is `capacitor://localhost`, which is **not** a freifahren.org domain, so the native app can only satisfy the rule via the `ff-platform: web` header (introduced in #680).

But `ff-platform` is a non-safelisted custom header, so the WebView issues a CORS **preflight** `OPTIONS` before the POST. The backend's `allowHeaders` did not include `ff-platform`, so the preflight response disallowed it and the WebView **dropped the POST before it ever reached Cloudflare** — meaning the request never carried the one header the rule needs to let it through.

Verified against the live API: a POST with `ff-platform` passes the CF rule (reaches origin), without it returns 403; and the live preflight's `Access-Control-Allow-Headers` was missing `ff-platform`.

## Fix

Add `ff-platform` to the backend CORS `allowHeaders`. The preflight then permits the header, the WebView sends the POST carrying it, and the CF rule lets it through.

## Notes

- This also cleans up the web path, which sends `ff-platform` cross-origin too (it only worked because its `Origin` already satisfied the rule, while the header itself was being dropped by CORS).
- Android Capacitor (origin `http://localhost`) is still not in the backend `CORS_ORIGINS` and would need adding there if/when Android ships — out of scope here.