### PR TITLE
fix: catch the service worker registration rejection so it stops flooding Sentry

### DIFF
--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -20,6 +20,19 @@ initErrorMonitoring();
 
 void initNativePlatform();
 
+// Register the PWA service worker ourselves rather than via vite-plugin-pwa's injected
+// registerSW.js, whose generated call has no .catch — so any registration rejection (bots,
+// crawlers, locked-down WebViews) bubbles up as an unhandled rejection and floods Sentry
+// (WEB-APP-1). The .catch here keeps that failure quiet; the SW is optional, so there's nothing
+// to do on failure. Gated on __CAPACITOR__ because the native build drops the PWA plugin and
+// ships no sw.js (FRE-649). registerType: 'autoUpdate' still applies — it lives in the generated
+// sw.js, not the registration snippet.
+if (!__CAPACITOR__ && 'serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    void navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {});
+  });
+}
+
 // Vite's documented recovery for a failed lazy import: a deploy purges the old chunks, so reload to
 // fetch the fresh shell. Skip when offline — a reload can't fetch a new chunk and the SW already
 // serves the precached shell, so it'd only wipe UI state. The timestamp bounds repeated reloads.

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -81,7 +81,11 @@ export default defineConfig({
         // navigation, with no prompt UI (AGENTS.md: keep registration/update UI minimal). skipWaiting
         // + clientsClaim are implied by autoUpdate, so no rider gets stuck on a stale shell.
         registerType: 'autoUpdate',
-        injectRegister: 'auto',
+        // Register the SW ourselves in main.tsx instead of letting the plugin inject registerSW.js.
+        // That generated snippet calls navigator.serviceWorker.register() with no .catch, so a
+        // rejection (common in bots/crawlers and locked-down WebViews) surfaces as an unhandled
+        // rejection and floods Sentry (WEB-APP-1). Our own registration swallows the rejection.
+        injectRegister: false,
         // Icons are generated into public/ from packages/app's app-icon.png (matches the native icon).
         manifest: {
           name: 'FreiFahren',


### PR DESCRIPTION
## What

Take over PWA service worker registration in `main.tsx` and attach a `.catch`, instead of relying on vite-plugin-pwa's auto-injected `registerSW.js`.

## Why

vite-plugin-pwa's generated `registerSW.js` calls `navigator.serviceWorker.register('/sw.js')` with **no `.catch`**. When registration rejects — common for bots/crawlers and locked-down WebViews — it surfaces as an unhandled promise rejection and gets reported to Sentry (`WEB-APP-1`: `Error: Rejected`, 103 occurrences, 0 real users impacted, escalating).

This switches `injectRegister` to `false` and registers the SW ourselves with the same `load`-event timing as the generated snippet, plus a `.catch` that quietly swallows the failure (the SW is optional, so there's nothing to do on failure).

## Notes

- `registerType: 'autoUpdate'` is unaffected — that behavior lives in the generated `sw.js`, not the registration script.
- Gated on `__CAPACITOR__` since the native build drops the PWA plugin and ships no `sw.js` (FRE-649).
- Verified: build still emits `dist/sw.js`, `dist/index.html` no longer references `registerSW.js`, and the bundle now contains `register('/sw.js',{scope:'/'}).catch(...)`.

Fixes WEB-APP-1