### PR TITLE
feat: port telegram bot to a typescript cloudflare worker

### DIFF
--- a/.github/workflows/telegram-worker-ci.yml
+++ b/.github/workflows/telegram-worker-ci.yml
@@ -1,0 +1,35 @@
+name: telegram-worker CI
+
+on:
+    pull_request:
+        branches: [main]
+        paths:
+            - 'packages/telegram-worker/**'
+            - '.github/workflows/telegram-worker-ci.yml'
+
+jobs:
+    check:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        defaults:
+            run:
+                working-directory: packages/telegram-worker
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Set up Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install dependencies
+              run: bun install --frozen-lockfile
+
+            - name: Typecheck
+              run: bun run typecheck
+
+            - name: Test
+              run: bun run test

--- a/.github/workflows/telegram-worker-deploy.yml
+++ b/.github/workflows/telegram-worker-deploy.yml
@@ -1,0 +1,54 @@
+name: telegram-worker Deploy
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - 'packages/telegram-worker/**'
+            - '.github/workflows/telegram-worker-deploy.yml'
+    workflow_dispatch: {}
+
+# Newest commit wins; never run two deploys at once.
+concurrency:
+    group: deploy-telegram-worker
+    cancel-in-progress: true
+
+jobs:
+    deploy:
+        # Gated on one-time setup being done. Set the `TELEGRAM_WORKER_ENABLED` repo variable
+        # (to any non-empty value) only after: the `telegram-updates` + `telegram-updates-dlq`
+        # queues exist, the secrets are set (`wrangler secret put MISTRAL_API_KEY` etc.), and
+        # TELEGRAM_REPORT_CHAT_ID is filled in. Until then this job is skipped, so merging never
+        # deploys against an unconfigured Worker.
+        if: ${{ vars.TELEGRAM_WORKER_ENABLED != '' }}
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        defaults:
+            run:
+                working-directory: packages/telegram-worker
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Set up Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install dependencies
+              run: bun install --frozen-lockfile
+
+            # --- Safety gates: nothing below this point deploys unless all pass ---
+            - name: Typecheck
+              run: bun run typecheck
+
+            - name: Test
+              run: bun run test
+
+            - name: Deploy to Cloudflare Workers
+              run: bunx wrangler@latest deploy
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/telegram-worker-deploy.yml
+++ b/.github/workflows/telegram-worker-deploy.yml
@@ -15,12 +15,9 @@ concurrency:
 
 jobs:
     deploy:
-        # Gated on one-time setup being done. Set the `TELEGRAM_WORKER_ENABLED` repo variable
-        # (to any non-empty value) only after: the `telegram-updates` + `telegram-updates-dlq`
-        # queues exist, the secrets are set (`wrangler secret put MISTRAL_API_KEY` etc.), and
-        # TELEGRAM_REPORT_CHAT_ID is filled in. Until then this job is skipped, so merging never
-        # deploys against an unconfigured Worker.
-        if: ${{ vars.TELEGRAM_WORKER_ENABLED != '' }}
+        # One-time setup before the first deploy: set the Worker secrets
+        # (`wrangler secret put MISTRAL_API_KEY` etc.) and fill TELEGRAM_REPORT_CHAT_ID in
+        # wrangler.jsonc.
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/packages/telegram-worker/.dev.vars.example
+++ b/packages/telegram-worker/.dev.vars.example
@@ -1,0 +1,7 @@
+# Secrets for `wrangler dev` (copy to .dev.vars). In production set these with
+# `wrangler secret put <NAME>` — do NOT put secrets in wrangler.jsonc.
+MISTRAL_API_KEY=
+TELEGRAM_BOT_TOKEN=
+REPORT_PASSWORD=password
+# The secret_token you pass to Telegram setWebhook; the worker checks it on every webhook.
+TELEGRAM_WEBHOOK_SECRET=

--- a/packages/telegram-worker/.gitignore
+++ b/packages/telegram-worker/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.wrangler/
+.dev.vars
+.dev.vars.*
+!.dev.vars.example

--- a/packages/telegram-worker/README.md
+++ b/packages/telegram-worker/README.md
@@ -1,0 +1,103 @@
+# telegram-worker
+
+TypeScript Cloudflare Worker that replaces the Python `packages/telegram_bot`. It ingests
+Telegram inspector-sighting messages, extracts a station/line/direction with Mistral, and
+submits a report to the backend — and forwards app reports back into the Telegram chat.
+
+It is a behavior-for-behavior port of the Python package; the extraction logic (spam filter,
+line detection, name normalization, two-tier fuzzy station matching) is reproduced verbatim.
+
+## Architecture
+
+```
+Telegram ──POST /telegram/webhook──▶ verify secret · filter (chat/text/command) · waitUntil(pipeline) → 200
+pipeline ──▶ isSpam → getTransitIndex (fetch) → detectLine → Mistral → resolve → POST /v0/reports
+POST /report ──▶ verify REPORT_PASSWORD → validate → Telegram sendMessage (deep link)
+```
+
+- **Background processing, no retry.** The webhook returns `200` instantly and runs the
+  pipeline in the background via `ctx.waitUntil` — so Telegram never re-delivers (no
+  duplicates). There's no queue: a failed run (e.g. a Mistral timeout) is dropped. The Mistral
+  call has a 20s timeout so a hung request can't linger. Error tracking is a TODO
+  ([FreiFahren#689](https://github.com/FreiFahren/FreiFahren/issues/689)).
+- **Transit data fetched per message.** `getTransitIndex` fetches `/v0/transit/{stations,lines}`
+  and builds the in-memory index on each run. There's no KV/cron — caching is meant to be done
+  at the edge with a Cloudflare cache rule on `/v0/transit/*` (see Caching below).
+- **City-agnostic.** All Berlin/German specifics live in `src/config.ts` only.
+
+## Layout
+
+| File | Role |
+| --- | --- |
+| `src/index.ts` | Router: `fetch` (webhook + `/report`) |
+| `src/webhook.ts` | Verify secret, filter (`acceptUpdate`), dispatch via `waitUntil` |
+| `src/pipeline.ts` | extract → resolve → submit (was `handle_text`) |
+| `src/extractor.ts` | line detection, prompt, Mistral call, normalize, fuzzy pick, resolve |
+| `src/transit.ts` | `getTransitIndex` (fetch backend) + `buildIndex` |
+| `src/reporting.ts` | `POST /v0/reports` |
+| `src/forwarding.ts` | `POST /report` handler |
+| `src/spam.ts` | `isSpam` |
+| `src/observability.ts` | `reportError` — the single error-reporting seam |
+| `src/config.ts` | **All** city/language specifics + env parsing |
+| `src/types.ts` | zod schemas + bindings |
+
+## Develop
+
+```sh
+bun install
+cp .dev.vars.example .dev.vars   # fill in secrets
+bun run typecheck
+bun run test                     # vitest + @cloudflare/vitest-pool-workers
+bun run dev
+```
+
+## Bindings / config (`wrangler.jsonc`)
+
+- **Vars**: `BACKEND_URL`, `PUBLIC_APP_URL`, `CITY_NAME`, `MISTRAL_MODEL`, `TELEGRAM_REPORT_CHAT_ID`.
+- **Secrets** (`wrangler secret put`): `MISTRAL_API_KEY`, `TELEGRAM_BOT_TOKEN`, `REPORT_PASSWORD`,
+  `TELEGRAM_WEBHOOK_SECRET`.
+
+## Monitoring (TODO)
+
+There's no retry/DLQ, so a failed pipeline run drops the message. Error tracking + alerting on
+error rates is not wired yet — tracked in
+[FreiFahren#689](https://github.com/FreiFahren/FreiFahren/issues/689). `reportError`
+(`src/observability.ts`) is the single seam to implement it: today it only logs to the live
+tail; point it at the chosen sink there.
+
+## Caching
+
+`getTransitIndex` fetches the transit endpoints on every message — there's no KV cache or
+cron. Cache it at the edge with a **Cloudflare cache rule** on `api.freifahren.org` scoped to
+`/v0/transit/*` (set an Edge TTL, e.g. 1h). Caveat: those endpoints echo the request `Origin`
+into `Access-Control-Allow-Origin` and send `Vary: Origin`, which Cloudflare's standard cache
+ignores — so either add `Origin` to the cache key or serve `Access-Control-Allow-Origin: *`
+for `/v0/transit/*` first, otherwise a cached response can break CORS for browser consumers.
+The Worker's own fetch sends no `Origin`, so it isn't affected by that itself.
+
+## Deploy & migrate off the Python bot
+
+1. Create the queues, fill `wrangler.jsonc` (`TELEGRAM_REPORT_CHAT_ID`), set secrets, then `bun run deploy`.
+2. Register the webhook (this also primes the secret the worker checks):
+   ```sh
+   curl "https://api.telegram.org/bot<TOKEN>/setWebhook" \
+     -d "url=https://<worker-host>/telegram/webhook" \
+     -d "secret_token=<TELEGRAM_WEBHOOK_SECRET>"
+   ```
+3. Repoint the Hono backend's report-forwarding target to `https://<worker-host>/report`
+   (keeps the `X-Password` header).
+4. **Stop the Python long-poller** — Telegram allows webhook *or* polling, not both.
+5. Verify: a real inspector message produces a report; a forwarded app report appears in chat.
+6. Remove `packages/telegram_bot` once parity is confirmed.
+
+## Behavior parity with the Python bot
+
+- Only processes messages from `TELEGRAM_REPORT_CHAT_ID`; ignores everything else.
+- Reads text **or** photo caption; ignores `/commands`.
+- Spam filter: short/long/question-mark/URL/emoji rules (`test/spam.test.ts`).
+- Line detection incl. circular-line alias (`Ring`/`Ringbahn`/`S-Ring`).
+- `normalizeName`: prefix strip + umlaut fold + abbreviation expansion + NFKD.
+- `pickStation`: two-tier scoring + on-line preference (off-line only if gap > 0.1) +
+  generic-word rejection (`test/resolution.test.ts`).
+- Report payload `{ stationId, lineId?, directionId?, source: "telegram" }`.
+- `/report` forwarding: auth, message text, deep link with utm params (`test/forwarding.test.ts`).

--- a/packages/telegram-worker/README.md
+++ b/packages/telegram-worker/README.md
@@ -1,103 +1,27 @@
 # telegram-worker
 
-TypeScript Cloudflare Worker that replaces the Python `packages/telegram_bot`. It ingests
-Telegram inspector-sighting messages, extracts a station/line/direction with Mistral, and
-submits a report to the backend — and forwards app reports back into the Telegram chat.
-
-It is a behavior-for-behavior port of the Python package; the extraction logic (spam filter,
-line detection, name normalization, two-tier fuzzy station matching) is reproduced verbatim.
-
-## Architecture
-
-```
-Telegram ──POST /telegram/webhook──▶ verify secret · filter (chat/text/command) · waitUntil(pipeline) → 200
-pipeline ──▶ isSpam → getTransitIndex (fetch) → detectLine → Mistral → resolve → POST /v0/reports
-POST /report ──▶ verify REPORT_PASSWORD → validate → Telegram sendMessage (deep link)
-```
-
-- **Background processing, no retry.** The webhook returns `200` instantly and runs the
-  pipeline in the background via `ctx.waitUntil` — so Telegram never re-delivers (no
-  duplicates). There's no queue: a failed run (e.g. a Mistral timeout) is dropped. The Mistral
-  call has a 20s timeout so a hung request can't linger. Error tracking is a TODO
-  ([FreiFahren#689](https://github.com/FreiFahren/FreiFahren/issues/689)).
-- **Transit data fetched per message.** `getTransitIndex` fetches `/v0/transit/{stations,lines}`
-  and builds the in-memory index on each run. There's no KV/cron — caching is meant to be done
-  at the edge with a Cloudflare cache rule on `/v0/transit/*` (see Caching below).
-- **City-agnostic.** All Berlin/German specifics live in `src/config.ts` only.
-
-## Layout
-
-| File | Role |
-| --- | --- |
-| `src/index.ts` | Router: `fetch` (webhook + `/report`) |
-| `src/webhook.ts` | Verify secret, filter (`acceptUpdate`), dispatch via `waitUntil` |
-| `src/pipeline.ts` | extract → resolve → submit (was `handle_text`) |
-| `src/extractor.ts` | line detection, prompt, Mistral call, normalize, fuzzy pick, resolve |
-| `src/transit.ts` | `getTransitIndex` (fetch backend) + `buildIndex` |
-| `src/reporting.ts` | `POST /v0/reports` |
-| `src/forwarding.ts` | `POST /report` handler |
-| `src/spam.ts` | `isSpam` |
-| `src/observability.ts` | `reportError` — the single error-reporting seam |
-| `src/config.ts` | **All** city/language specifics + env parsing |
-| `src/types.ts` | zod schemas + bindings |
+TypeScript Cloudflare Worker for the FreiFahren Telegram bot. Telegram POSTs
+inspector-sighting messages to `/telegram/webhook`; the worker extracts a station/line/direction
+with Mistral and submits a report to the backend. App reports POSTed to `/report` are forwarded
+back into the Telegram chat. All Berlin/German specifics live in `src/config.ts`.
 
 ## Develop
 
 ```sh
 bun install
 cp .dev.vars.example .dev.vars   # fill in secrets
-bun run typecheck
-bun run test                     # vitest + @cloudflare/vitest-pool-workers
-bun run dev
+bun run test                     # vitest — no live services needed
+bun run dev                      # http://localhost:8787
 ```
 
-## Bindings / config (`wrangler.jsonc`)
+## Deploy
 
-- **Vars**: `BACKEND_URL`, `PUBLIC_APP_URL`, `CITY_NAME`, `MISTRAL_MODEL`, `TELEGRAM_REPORT_CHAT_ID`.
-- **Secrets** (`wrangler secret put`): `MISTRAL_API_KEY`, `TELEGRAM_BOT_TOKEN`, `REPORT_PASSWORD`,
-  `TELEGRAM_WEBHOOK_SECRET`.
+Set secrets (`MISTRAL_API_KEY`, `TELEGRAM_BOT_TOKEN`, `REPORT_PASSWORD`, `TELEGRAM_WEBHOOK_SECRET`)
+with `wrangler secret put <NAME>`, fill `TELEGRAM_REPORT_CHAT_ID` in `wrangler.jsonc`, then
+`bun run deploy`. Register the webhook:
 
-## Monitoring (TODO)
-
-There's no retry/DLQ, so a failed pipeline run drops the message. Error tracking + alerting on
-error rates is not wired yet — tracked in
-[FreiFahren#689](https://github.com/FreiFahren/FreiFahren/issues/689). `reportError`
-(`src/observability.ts`) is the single seam to implement it: today it only logs to the live
-tail; point it at the chosen sink there.
-
-## Caching
-
-`getTransitIndex` fetches the transit endpoints on every message — there's no KV cache or
-cron. Cache it at the edge with a **Cloudflare cache rule** on `api.freifahren.org` scoped to
-`/v0/transit/*` (set an Edge TTL, e.g. 1h). Caveat: those endpoints echo the request `Origin`
-into `Access-Control-Allow-Origin` and send `Vary: Origin`, which Cloudflare's standard cache
-ignores — so either add `Origin` to the cache key or serve `Access-Control-Allow-Origin: *`
-for `/v0/transit/*` first, otherwise a cached response can break CORS for browser consumers.
-The Worker's own fetch sends no `Origin`, so it isn't affected by that itself.
-
-## Deploy & migrate off the Python bot
-
-1. Create the queues, fill `wrangler.jsonc` (`TELEGRAM_REPORT_CHAT_ID`), set secrets, then `bun run deploy`.
-2. Register the webhook (this also primes the secret the worker checks):
-   ```sh
-   curl "https://api.telegram.org/bot<TOKEN>/setWebhook" \
-     -d "url=https://<worker-host>/telegram/webhook" \
-     -d "secret_token=<TELEGRAM_WEBHOOK_SECRET>"
-   ```
-3. Repoint the Hono backend's report-forwarding target to `https://<worker-host>/report`
-   (keeps the `X-Password` header).
-4. **Stop the Python long-poller** — Telegram allows webhook *or* polling, not both.
-5. Verify: a real inspector message produces a report; a forwarded app report appears in chat.
-6. Remove `packages/telegram_bot` once parity is confirmed.
-
-## Behavior parity with the Python bot
-
-- Only processes messages from `TELEGRAM_REPORT_CHAT_ID`; ignores everything else.
-- Reads text **or** photo caption; ignores `/commands`.
-- Spam filter: short/long/question-mark/URL/emoji rules (`test/spam.test.ts`).
-- Line detection incl. circular-line alias (`Ring`/`Ringbahn`/`S-Ring`).
-- `normalizeName`: prefix strip + umlaut fold + abbreviation expansion + NFKD.
-- `pickStation`: two-tier scoring + on-line preference (off-line only if gap > 0.1) +
-  generic-word rejection (`test/resolution.test.ts`).
-- Report payload `{ stationId, lineId?, directionId?, source: "telegram" }`.
-- `/report` forwarding: auth, message text, deep link with utm params (`test/forwarding.test.ts`).
+```sh
+curl "https://api.telegram.org/bot<TOKEN>/setWebhook" \
+  -d "url=https://<worker-host>/telegram/webhook" \
+  -d "secret_token=<TELEGRAM_WEBHOOK_SECRET>"
+```

--- a/packages/telegram-worker/README.md
+++ b/packages/telegram-worker/README.md
@@ -14,6 +14,19 @@ bun run test                     # vitest — no live services needed
 bun run dev                      # http://localhost:8787
 ```
 
+## Evals
+
+`evals/run.ts` runs the extraction pipeline over a labeled dataset and reports per-field
+accuracy / precision / recall / F1. Drop the dataset in at `evals/messages.json` (gitignored;
+rows of `{ id, text, naive_labels: { stationId, directionId, lineName } }`), then:
+
+```sh
+bun run eval                       # full dataset
+bun run eval --smoke --n 200       # seeded random sample
+```
+
+Reads `MISTRAL_API_KEY` / `BACKEND_URL` / `MISTRAL_MODEL` from the env or `.dev.vars`.
+
 ## Deploy
 
 Set secrets (`MISTRAL_API_KEY`, `TELEGRAM_BOT_TOKEN`, `REPORT_PASSWORD`, `TELEGRAM_WEBHOOK_SECRET`)

--- a/packages/telegram-worker/bun.lock
+++ b/packages/telegram-worker/bun.lock
@@ -1,0 +1,516 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "telegram-worker",
+      "dependencies": {
+        "zod": "^3.25.0",
+      },
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.9.0",
+        "@cloudflare/workers-types": "^4.20251001.0",
+        "typescript": "~6.0.2",
+        "vitest": "~3.2.0",
+        "wrangler": "^4.103.0",
+      },
+    },
+  },
+  "packages": {
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/vitest-pool-workers": ["@cloudflare/vitest-pool-workers@0.9.14", "", { "dependencies": { "birpc": "0.2.14", "cjs-module-lexer": "^1.2.3", "devalue": "^5.3.2", "miniflare": "4.20251011.0", "semver": "^7.7.1", "wrangler": "4.44.0", "zod": "^3.22.3" }, "peerDependencies": { "@vitest/runner": "2.0.x - 3.2.x", "@vitest/snapshot": "2.0.x - 3.2.x", "vitest": "2.0.x - 3.2.x" } }, "sha512-1D/1KFa32EymaYDojWcrmUyMbHJwewn/mZSxsAqXdybvKMrHVaoaqGpLoH9bgWSfbrGs4af4RrmIXMINOqc4Lw=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260625.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-naCfBv0WnnTQIQPTniqMoUlklOIFjrAcSn1X+IAOhY8aFLF/xGYtFjs1eEE8sFib3ZuChGGpU23FFORVczqr0A=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260625.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jmH6zjp6Wrux46+qtFwDwrj+vd7s5bdwEqeGvdnwE0a4IEeAhKs0L42HQOyID+g5lkrHq9m55+AbhtmRAm63Pw=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260625.1", "", { "os": "linux", "cpu": "x64" }, "sha512-MiQkpA/dX8d83Zp64pzHUKfd6ca4cvwxnNobSP6CnXvfESvnNI9pfa+nfwnParla36sPmnYntNkjR7NjRuDeKQ=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260625.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-LxxW7Qv60Xvv37+w6gUSDpYZziyqMy+cZWd9IvSA5ehVgKAxmzEaYPMiSZlxk32nbIWL9u/tfjXYCOKJ4Lo+XQ=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260625.1", "", { "os": "win32", "cpu": "x64" }, "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260625.1", "", {}, "sha512-asH0RhPHiNu/IUSssyiOJYAcGqysy0DJpO9fihC6KATaayD9CE1E9bgNQozTLUraxrCT2qkM4CBOIcV0M5NPJw=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.2", "", { "os": "android", "cpu": "arm" }, "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.2", "", { "os": "android", "cpu": "arm64" }, "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.2", "", { "os": "linux", "cpu": "arm" }, "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.2", "", { "os": "linux", "cpu": "arm" }, "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.2", "", { "os": "linux", "cpu": "x64" }, "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.2", "", { "os": "none", "cpu": "arm64" }, "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.6", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.6", "@vitest/utils": "3.2.6", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.6", "", { "dependencies": { "@vitest/spy": "3.2.6", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.6", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.6", "", { "dependencies": { "@vitest/utils": "3.2.6", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.6", "", { "dependencies": { "@vitest/pretty-format": "3.2.6", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.6", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.6", "", { "dependencies": { "@vitest/pretty-format": "3.2.6", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg=="],
+
+    "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
+
+    "acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "birpc": ["birpc@0.2.14", "", {}, "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
+
+    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
+
+    "exsolve": ["exsolve@1.1.0", "", {}, "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
+
+    "is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
+
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
+    "miniflare": ["miniflare@4.20251011.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "sharp": "^0.33.5", "stoppable": "1.1.0", "undici": "7.14.0", "workerd": "1.20251011.0", "ws": "8.18.0", "youch": "4.1.0-beta.10", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-DlZ7vR5q/RE9eLsxsrXzfSZIF2f6O5k0YsFrSKhWUtdefyGtJt4sSpR6V+Af/waaZ6+zIFy9lsknHBCm49sEYA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "rollup": ["rollup@4.62.2", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.2", "@rollup/rollup-android-arm64": "4.62.2", "@rollup/rollup-darwin-arm64": "4.62.2", "@rollup/rollup-darwin-x64": "4.62.2", "@rollup/rollup-freebsd-arm64": "4.62.2", "@rollup/rollup-freebsd-x64": "4.62.2", "@rollup/rollup-linux-arm-gnueabihf": "4.62.2", "@rollup/rollup-linux-arm-musleabihf": "4.62.2", "@rollup/rollup-linux-arm64-gnu": "4.62.2", "@rollup/rollup-linux-arm64-musl": "4.62.2", "@rollup/rollup-linux-loong64-gnu": "4.62.2", "@rollup/rollup-linux-loong64-musl": "4.62.2", "@rollup/rollup-linux-ppc64-gnu": "4.62.2", "@rollup/rollup-linux-ppc64-musl": "4.62.2", "@rollup/rollup-linux-riscv64-gnu": "4.62.2", "@rollup/rollup-linux-riscv64-musl": "4.62.2", "@rollup/rollup-linux-s390x-gnu": "4.62.2", "@rollup/rollup-linux-x64-gnu": "4.62.2", "@rollup/rollup-linux-x64-musl": "4.62.2", "@rollup/rollup-openbsd-x64": "4.62.2", "@rollup/rollup-openharmony-arm64": "4.62.2", "@rollup/rollup-win32-arm64-msvc": "4.62.2", "@rollup/rollup-win32-ia32-msvc": "4.62.2", "@rollup/rollup-win32-x64-gnu": "4.62.2", "@rollup/rollup-win32-x64-msvc": "4.62.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "stoppable": ["stoppable@1.1.0", "", {}, "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
+
+    "undici": ["undici@7.14.0", "", {}, "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
+
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.6", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.6", "@vitest/mocker": "3.2.6", "@vitest/pretty-format": "^3.2.6", "@vitest/runner": "3.2.6", "@vitest/snapshot": "3.2.6", "@vitest/spy": "3.2.6", "@vitest/utils": "3.2.6", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.6", "@vitest/ui": "3.2.6", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "workerd": ["workerd@1.20260625.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260625.1", "@cloudflare/workerd-darwin-arm64": "1.20260625.1", "@cloudflare/workerd-linux-64": "1.20260625.1", "@cloudflare/workerd-linux-arm64": "1.20260625.1", "@cloudflare/workerd-windows-64": "1.20260625.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA=="],
+
+    "wrangler": ["wrangler@4.105.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260625.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260625.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260625.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g=="],
+
+    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler": ["wrangler@4.44.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.7.8", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20251011.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.21", "workerd": "1.20251011.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20251011.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-BLOUigckcWZ0r4rm7b5PuaTpb9KP9as0XeCRSJ8kqcNgXcKoUD3Ij8FlPvN25KybLnFnetaO0ZdfRYUPWle4qw=="],
+
+    "miniflare/workerd": ["workerd@1.20251011.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20251011.0", "@cloudflare/workerd-darwin-arm64": "1.20251011.0", "@cloudflare/workerd-linux-64": "1.20251011.0", "@cloudflare/workerd-linux-arm64": "1.20251011.0", "@cloudflare/workerd-windows-64": "1.20251011.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-Dq35TLPEJAw7BuYQMkN3p9rge34zWMU2Gnd4DSJFeVqld4+DAO2aPG7+We2dNIAyM97S8Y9BmHulbQ00E0HC7Q=="],
+
+    "miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
+
+    "wrangler/miniflare": ["miniflare@4.20260625.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260625.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-3kKXwRUObJsnBYPBgR0NiNZYKF/yv8GFyha1cx2EeAEraxNODgRVcyeRo+F1ok1tg5Mg7iUpOWSkknQTHuFhwA=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.0", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.7.8", "", { "peerDependencies": { "unenv": "2.0.0-rc.21", "workerd": "^1.20250927.0" }, "optionalPeers": ["workerd"] }, "sha512-Ky929MfHh+qPhwCapYrRPwPVHtA2Ioex/DbGZyskGyNRDe9Ru3WThYZivyNVaPy5ergQSgMs9OKrM9Ajtz9F6w=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/unenv": ["unenv@2.0.0-rc.21", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.7", "ohash": "^2.0.11", "pathe": "^2.0.3", "ufo": "^1.6.1" } }, "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd": ["workerd@1.20251011.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20251011.0", "@cloudflare/workerd-darwin-arm64": "1.20251011.0", "@cloudflare/workerd-linux-64": "1.20251011.0", "@cloudflare/workerd-linux-arm64": "1.20251011.0", "@cloudflare/workerd-windows-64": "1.20251011.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-Dq35TLPEJAw7BuYQMkN3p9rge34zWMU2Gnd4DSJFeVqld4+DAO2aPG7+We2dNIAyM97S8Y9BmHulbQ00E0HC7Q=="],
+
+    "miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20251011.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-0DirVP+Z82RtZLlK2B+VhLOkk+ShBqDYO/jhcRw4oVlp0TOvk3cOVZChrt3+y3NV8Y/PYgTEywzLKFSziK4wCg=="],
+
+    "miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20251011.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1WuFBGwZd15p4xssGN/48OE2oqokIuc51YvHvyNivyV8IYnAs3G9bJNGWth1X7iMDPe4g44pZrKhRnISS2+5dA=="],
+
+    "miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20251011.0", "", { "os": "linux", "cpu": "x64" }, "sha512-BccMiBzFlWZyFghIw2szanmYJrJGBGHomw2y/GV6pYXChFzMGZkeCEMfmCyJj29xczZXxcZmUVJxNy4eJxO8QA=="],
+
+    "miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20251011.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-79o/216lsbAbKEVDZYXR24ivEIE2ysDL9jvo0rDTkViLWju9dAp3CpyetglpJatbSi3uWBPKZBEOqN68zIjVsQ=="],
+
+    "miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20251011.0", "", { "os": "win32", "cpu": "x64" }, "sha512-RIXUQRchFdqEvaUqn1cXZXSKjpqMaSaVAkI5jNZ8XzAw/bw2bcdOVUtakrflgxDprltjFb0PTNtuss1FKtH9Jg=="],
+
+    "wrangler/miniflare/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "wrangler/miniflare/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "wrangler/miniflare/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.4", "", { "os": "android", "cpu": "arm" }, "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.4", "", { "os": "android", "cpu": "arm64" }, "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.4", "", { "os": "android", "cpu": "x64" }, "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.4", "", { "os": "linux", "cpu": "arm" }, "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.4", "", { "os": "linux", "cpu": "none" }, "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.4", "", { "os": "linux", "cpu": "none" }, "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.4", "", { "os": "linux", "cpu": "none" }, "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.4", "", { "os": "linux", "cpu": "x64" }, "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.4", "", { "os": "none", "cpu": "arm64" }, "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.4", "", { "os": "none", "cpu": "x64" }, "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.4", "", { "os": "win32", "cpu": "x64" }, "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20251011.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-0DirVP+Z82RtZLlK2B+VhLOkk+ShBqDYO/jhcRw4oVlp0TOvk3cOVZChrt3+y3NV8Y/PYgTEywzLKFSziK4wCg=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20251011.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1WuFBGwZd15p4xssGN/48OE2oqokIuc51YvHvyNivyV8IYnAs3G9bJNGWth1X7iMDPe4g44pZrKhRnISS2+5dA=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20251011.0", "", { "os": "linux", "cpu": "x64" }, "sha512-BccMiBzFlWZyFghIw2szanmYJrJGBGHomw2y/GV6pYXChFzMGZkeCEMfmCyJj29xczZXxcZmUVJxNy4eJxO8QA=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20251011.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-79o/216lsbAbKEVDZYXR24ivEIE2ysDL9jvo0rDTkViLWju9dAp3CpyetglpJatbSi3uWBPKZBEOqN68zIjVsQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20251011.0", "", { "os": "win32", "cpu": "x64" }, "sha512-RIXUQRchFdqEvaUqn1cXZXSKjpqMaSaVAkI5jNZ8XzAw/bw2bcdOVUtakrflgxDprltjFb0PTNtuss1FKtH9Jg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "wrangler/miniflare/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+  }
+}

--- a/packages/telegram-worker/evals/run.ts
+++ b/packages/telegram-worker/evals/run.ts
@@ -1,0 +1,379 @@
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { getTransitIndex } from '../src/transit'
+import {
+    buildLinePattern,
+    buildSystemPrompt,
+    detectLineName,
+    extractWithMistral,
+    resolveExtraction,
+    type ExtractionResult,
+} from '../src/extractor'
+import type { TransitIndex } from '../src/types'
+
+const EVAL_DIR = dirname(fileURLToPath(import.meta.url))
+const DATA_PATH = join(EVAL_DIR, 'messages.json')
+const REPORT_PATH = join(EVAL_DIR, 'eval_report.md')
+const RESULTS_PATH = join(EVAL_DIR, 'eval_results.json')
+
+type Labels = { stationId: string | null; directionId: string | null; lineName: string | null }
+interface Row {
+    id: string
+    text: string
+    naive_labels: Labels
+}
+
+interface RowOutcome {
+    rowId: string
+    text: string
+    expected: Labels
+    actual: Labels
+    correctStation: boolean
+    correctDirection: boolean
+    correctLine: boolean
+    error: string | null
+}
+
+const fullyCorrect = (o: RowOutcome): boolean => o.correctStation && o.correctDirection && o.correctLine
+
+// ---------------------------------------------------------------------------
+// Line scoring (port of expected_line_tokens / line_correct)
+// ---------------------------------------------------------------------------
+
+const LINE_TOKEN_RE = /^([A-Za-z]+)(\d+)$/
+
+/**
+ * Tokenize the label's lineName so compound labels like "U1 U3" or "S41 42" both match. A
+ * bare-digit token (the "42" in "S41 42") inherits the letter prefix from the most recent
+ * letter-bearing token. Returns null when the label has no line (so the bot must also be null).
+ */
+function expectedLineTokens(lineLabel: string | null): Set<string> | null {
+    if (lineLabel === null) {
+        return null
+    }
+    const tokens = new Set<string>()
+    let lastPrefix: string | null = null
+    for (const raw of lineLabel.split(/\s+/).filter(Boolean)) {
+        const m = LINE_TOKEN_RE.exec(raw)
+        if (m) {
+            lastPrefix = m[1]
+            tokens.add(raw)
+        } else if (/^\d+$/.test(raw) && lastPrefix !== null) {
+            tokens.add(`${lastPrefix}${raw}`)
+        } else {
+            tokens.add(raw)
+        }
+    }
+    return tokens
+}
+
+/** Bot is correct if it picks ANY token from a compound label, or both are null. */
+function lineCorrect(expected: string | null, actual: string | null): boolean {
+    const tokens = expectedLineTokens(expected)
+    if (tokens === null) {
+        return actual === null
+    }
+    return actual !== null && tokens.has(actual)
+}
+
+// ---------------------------------------------------------------------------
+// Metrics (port of field_metrics) — null treated as a negative prediction.
+// ---------------------------------------------------------------------------
+
+interface FieldMetrics {
+    accuracy: number
+    correct: number
+    total: number
+    tp: number
+    fp: number
+    fn: number
+    tn: number
+    precision: number
+    recall: number
+    f1: number
+}
+
+function fieldMetrics(
+    outcomes: RowOutcome[],
+    field: keyof Labels,
+    correctnessAttr: 'correctStation' | 'correctDirection' | 'correctLine'
+): FieldMetrics {
+    let tp = 0
+    let fp = 0
+    let fn = 0
+    let tn = 0
+    for (const o of outcomes) {
+        const exp = o.expected[field]
+        const act = o.actual[field]
+        if (exp !== null && act !== null) {
+            if (o[correctnessAttr]) {
+                tp += 1
+            } else {
+                fp += 1 // picked something, but the wrong one (also counts as a miss)
+                fn += 1
+            }
+        } else if (exp === null && act !== null) {
+            fp += 1
+        } else if (exp !== null && act === null) {
+            fn += 1
+        } else {
+            tn += 1
+        }
+    }
+    const total = outcomes.length
+    const correct = outcomes.filter((o) => o[correctnessAttr]).length
+    const precision = tp + fp ? tp / (tp + fp) : 0
+    const recall = tp + fn ? tp / (tp + fn) : 0
+    const f1 = precision + recall ? (2 * precision * recall) / (precision + recall) : 0
+    return { accuracy: total ? correct / total : 0, correct, total, tp, fp, fn, tn, precision, recall, f1 }
+}
+
+// ---------------------------------------------------------------------------
+// Report (port of build_report)
+// ---------------------------------------------------------------------------
+
+const pct = (x: number): string => `${(x * 100).toFixed(1)}%`
+
+function buildReport(opts: {
+    outcomes: RowOutcome[]
+    durationS: number
+    smoke: boolean
+    datasetSize: number
+    parallel: number
+    model: string
+}): string {
+    const { outcomes, durationS, smoke, datasetSize, parallel, model } = opts
+    const n = outcomes.length
+    const station = fieldMetrics(outcomes, 'stationId', 'correctStation')
+    const direction = fieldMetrics(outcomes, 'directionId', 'correctDirection')
+    const line = fieldMetrics(outcomes, 'lineName', 'correctLine')
+    const fully = outcomes.filter(fullyCorrect).length
+    const errors = outcomes.filter((o) => o.error !== null).length
+
+    const fieldRow = (name: string, m: FieldMetrics): string =>
+        `| ${name} | ${pct(m.accuracy)} | ${m.correct}/${m.total} | ${pct(m.precision)} | ` +
+        `${pct(m.recall)} | ${pct(m.f1)} | ${m.tp} | ${m.fp} | ${m.fn} | ${m.tn} |`
+
+    const throughput = durationS > 0 && n > 0 ? `${(n / durationS).toFixed(1)} msg/s` : 'n/a'
+    const lines: string[] = [
+        '# Telegram bot extractor — eval report',
+        '',
+        `**Mode:** ${smoke ? 'SMOKE' : 'FULL'} (${n} rows of ${datasetSize})  `,
+        `**Model:** \`${model}\`  `,
+        `**Parallelism:** ${parallel}  `,
+        `**Wall time:** ${durationS.toFixed(1)}s (${throughput})  `,
+        `**LLM/network errors:** ${errors}`,
+        '',
+    ]
+    if (n === 0) {
+        lines.push('_No rows evaluated._', '', 'See `eval_results.json` for the full per-row breakdown.')
+        return lines.join('\n') + '\n'
+    }
+    lines.push(
+        '## Headline',
+        '',
+        `- **Fully correct rows** (all three fields match): ${fully}/${n} = **${pct(fully / n)}**`,
+        `- Station accuracy: **${pct(station.accuracy)}**`,
+        `- Direction accuracy: **${pct(direction.accuracy)}**`,
+        `- Line accuracy: **${pct(line.accuracy)}**`,
+        '',
+        '## Per-field metrics',
+        '',
+        'Null is treated as a negative prediction. *Precision* = "when the bot says X, how often ' +
+            'is X right?". *Recall* = "when the label has a value, how often does the bot extract ' +
+            'it correctly?".',
+        '',
+        '| Field | Accuracy | Correct | Precision | Recall | F1 | TP | FP | FN | TN |',
+        '|---|---|---|---|---|---|---|---|---|---|',
+        fieldRow('stationId', station),
+        fieldRow('directionId', direction),
+        fieldRow('lineName', line),
+        '',
+        'See `eval_results.json` for the full per-row breakdown.'
+    )
+    return lines.join('\n') + '\n'
+}
+
+// ---------------------------------------------------------------------------
+// Runtime plumbing
+// ---------------------------------------------------------------------------
+
+/** Load .dev.vars (KEY=VALUE, # comments) into process.env without overriding what's set. */
+function loadDevVars(): void {
+    const path = join(EVAL_DIR, '..', '.dev.vars')
+    if (!existsSync(path)) {
+        return
+    }
+    for (const raw of readFileSync(path, 'utf8').split('\n')) {
+        const lineStr = raw.trim()
+        if (!lineStr || lineStr.startsWith('#')) {
+            continue
+        }
+        const eq = lineStr.indexOf('=')
+        if (eq === -1) {
+            continue
+        }
+        const key = lineStr.slice(0, eq).trim()
+        if (!(key in process.env)) {
+            process.env[key] = lineStr.slice(eq + 1).trim()
+        }
+    }
+}
+
+/** Deterministic PRNG (mulberry32) so --smoke is repeatable across runs of this harness.
+ *  Note: the sample won't match the Python harness's `random.sample` row-for-row. */
+function mulberry32(seed: number): () => number {
+    let a = seed >>> 0
+    return () => {
+        a |= 0
+        a = (a + 0x6d2b79f5) | 0
+        let t = Math.imul(a ^ (a >>> 15), 1 | a)
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+}
+
+function sample<T>(items: T[], n: number, seed: number): T[] {
+    const rng = mulberry32(seed)
+    const copy = [...items]
+    for (let i = copy.length - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1))
+        ;[copy[i], copy[j]] = [copy[j], copy[i]]
+    }
+    return copy.slice(0, Math.min(n, copy.length))
+}
+
+/** Run async tasks with a bounded concurrency, preserving input order in the output. */
+async function mapPool<T, R>(items: T[], limit: number, fn: (item: T, i: number) => Promise<R>): Promise<R[]> {
+    const results = new Array<R>(items.length)
+    let next = 0
+    const worker = async (): Promise<void> => {
+        for (;;) {
+            const i = next++
+            if (i >= items.length) {
+                return
+            }
+            results[i] = await fn(items[i], i)
+        }
+    }
+    await Promise.all(Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, worker))
+    return results
+}
+
+const NULL_RESULT: ExtractionResult = { stationId: null, lineName: null, directionId: null }
+
+async function runOne(
+    row: Row,
+    index: TransitIndex,
+    linePattern: RegExp,
+    systemPrompt: string,
+    apiKey: string,
+    model: string
+): Promise<RowOutcome> {
+    let result: ExtractionResult = NULL_RESULT
+    let error: string | null = null
+    try {
+        const detectedLine = detectLineName(row.text, index.lineNames, linePattern, index.circularLineNames)
+        const parsed = await extractWithMistral(row.text, systemPrompt, apiKey, model)
+        result = parsed === null ? NULL_RESULT : resolveExtraction(index, parsed, detectedLine)
+    } catch (exc) {
+        error = exc instanceof Error ? `${exc.name}: ${exc.message}` : String(exc)
+    }
+
+    const expected = row.naive_labels
+    return {
+        rowId: row.id,
+        text: row.text,
+        expected: {
+            stationId: expected.stationId ?? null,
+            directionId: expected.directionId ?? null,
+            lineName: expected.lineName ?? null,
+        },
+        actual: { stationId: result.stationId, directionId: result.directionId, lineName: result.lineName },
+        correctStation: result.stationId === (expected.stationId ?? null),
+        correctDirection: result.directionId === (expected.directionId ?? null),
+        correctLine: lineCorrect(expected.lineName ?? null, result.lineName),
+        error,
+    }
+}
+
+function parseArgs(argv: string[]): { smoke: boolean; n: number; parallel: number; seed: number } {
+    const opts = { smoke: false, n: 200, parallel: 1, seed: 42 }
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i]
+        if (a === '--smoke') opts.smoke = true
+        else if (a === '--n') opts.n = Number(argv[++i])
+        else if (a === '--parallel') opts.parallel = Number(argv[++i])
+        else if (a === '--seed') opts.seed = Number(argv[++i])
+    }
+    return opts
+}
+
+async function main(): Promise<void> {
+    const args = parseArgs(process.argv.slice(2))
+    loadDevVars()
+
+    const apiKey = process.env.MISTRAL_API_KEY
+    if (!apiKey) {
+        throw new Error('MISTRAL_API_KEY is not set (env or .dev.vars)')
+    }
+    const backendUrl = (process.env.BACKEND_URL || 'https://api.freifahren.org').replace(/\/+$/, '')
+    const model = process.env.MISTRAL_MODEL || 'mistral-small-latest'
+    const cityName = process.env.CITY_NAME || 'Berlin'
+
+    if (!existsSync(DATA_PATH)) {
+        throw new Error(
+            `Dataset not found: ${DATA_PATH}\n` +
+                'It is gitignored — drop in messages.json (rows of ' +
+                '{ id, text, naive_labels: { stationId, directionId, lineName } }).'
+        )
+    }
+    const dataset = JSON.parse(readFileSync(DATA_PATH, 'utf8')) as Row[]
+    const datasetSize = dataset.length
+    const rows = args.smoke ? sample(dataset, args.n, args.seed) : dataset
+
+    const index = await getTransitIndex(backendUrl)
+    const linePattern = buildLinePattern(index.lineNames)
+    const systemPrompt = buildSystemPrompt(index, cityName)
+
+    console.log(`running ${rows.length} rows with parallel=${args.parallel} model=${model}...`)
+    const start = performance.now()
+    const outcomes = await mapPool(rows, args.parallel, (row) =>
+        runOne(row, index, linePattern, systemPrompt, apiKey, model)
+    )
+    const durationS = (performance.now() - start) / 1000
+
+    const report = buildReport({ outcomes, durationS, smoke: args.smoke, datasetSize, parallel: args.parallel, model })
+    writeFileSync(REPORT_PATH, report)
+    writeFileSync(
+        RESULTS_PATH,
+        JSON.stringify(
+            outcomes.map((o) => ({
+                id: o.rowId,
+                text: o.text,
+                expected: o.expected,
+                actual: o.actual,
+                correct: {
+                    stationId: o.correctStation,
+                    directionId: o.correctDirection,
+                    lineName: o.correctLine,
+                    all: fullyCorrect(o),
+                },
+                error: o.error,
+            })),
+            null,
+            2
+        )
+    )
+
+    // Echo the headline so a smoke run is useful without opening the file.
+    process.stdout.write('\n' + report.split('## Per-field metrics')[0])
+    console.log(`done in ${durationS.toFixed(1)}s — report at ${resolve(REPORT_PATH)}`)
+}
+
+main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/telegram-worker/package.json
+++ b/packages/telegram-worker/package.json
@@ -7,7 +7,8 @@
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "eval": "bun run evals/run.ts"
   },
   "dependencies": {
     "zod": "^3.25.0"

--- a/packages/telegram-worker/package.json
+++ b/packages/telegram-worker/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "telegram-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.9.0",
+    "@cloudflare/workers-types": "^4.20251001.0",
+    "typescript": "~6.0.2",
+    "vitest": "~3.2.0",
+    "wrangler": "^4.103.0"
+  }
+}

--- a/packages/telegram-worker/src/config.ts
+++ b/packages/telegram-worker/src/config.ts
@@ -1,0 +1,164 @@
+import type { Env } from './types'
+
+// =============================================================================
+// City / language profile
+//
+// THIS IS THE ONLY PLACE with Berlin/German specifics. Extraction logic in
+// extractor.ts reads from here and never hardcodes city specifics. To port the
+// bot to another city, swap the constants below (and the CITY_NAME var).
+// =============================================================================
+
+/** Free-text reminder of the local circular-line name. Empty = no circular line. */
+export const CIRCULAR_LINE_ALIAS = 'Ringbahn'
+
+/** Regex recognizing user shorthand for the circular line. Empty = no circular line. */
+export const CIRCULAR_LINE_PATTERN = String.raw`(?<![A-Za-z])(?:s[-\s]?)?ring(?:bahn)?`
+
+/**
+ * Language-specific letter folding for normalization.
+ *
+ * Collapse umlauts to their base letter rather than the digraph form: when users
+ * type on ASCII keyboards they almost always write "u"/"o"/"a" (sudkreuz, mockern,
+ * bulow), not the "ue"/"oe"/"ae" expansion. Mapping to the base letter makes user
+ * input line up with normalized station names. ß stays "ss" — the universally
+ * typed substitute.
+ */
+export const LANGUAGE_LETTER_MAP: Record<string, string> = {
+    ä: 'a',
+    ö: 'o',
+    ü: 'u',
+    ß: 'ss',
+    Ä: 'a',
+    Ö: 'o',
+    Ü: 'u',
+}
+
+/**
+ * (pattern, replacement) pairs applied during normalization so user-typed
+ * abbreviations match canonical names. German: "str."/"straße" -> "strasse", etc.
+ * Patterns run after lowercasing and letter folding, so they target lowercase.
+ */
+export const LANGUAGE_ABBREVIATIONS: [RegExp, string][] = [
+    [/straße/g, 'strasse'],
+    [/str\.?(?=\s|$|\/|,|\)|-)/g, 'strasse'],
+    [/str$/g, 'strasse'],
+    [/\bbhf\.?\b/g, 'bahnhof'],
+    [/\bhbf\.?\b/g, 'hauptbahnhof'],
+    [/\bpl\.?\b/g, 'platz'],
+]
+
+/** Prefixes users write before a station name that aren't part of it ("S Alexanderplatz"). */
+export const STATION_NAME_PREFIX_PATTERN = /^(?:bahnhof\s+|bhf\s+|s\s+|u\s+|s-bahn\s+|u-bahn\s+)+/i
+
+/** Words the LLM might emit as a stationName that really refer to platforms/vehicles. */
+export const GENERIC_NON_STATION_WORDS: ReadonlySet<string> = new Set([
+    'bahnsteig',
+    'bahnsteige',
+    'bahnhof',
+    'gleis',
+    'gleise',
+    'zug',
+    'zuege',
+    'ubahn',
+    'sbahn',
+    'tram',
+    'strassenbahn',
+    'haltestelle',
+    'platform',
+    'bus',
+    'station',
+    'stop',
+])
+
+/** Inspector-report vocabulary the prompt highlights to the model. */
+export const INSPECTOR_KEYWORDS =
+    'Kontrolleur, BVG-Kontrolle, BOS, BW, Blauwesten, Zivilkontrolle, blaue Westen'
+
+/**
+ * Few-shot examples appended to the prompt. Tuned to teach disambiguation the model
+ * gets wrong: slang names, direction-vs-station, all-clear messages, the implicit-
+ * direction case. Kept in the local language since the chat is mixed German/English.
+ * Empty string disables few-shot.
+ */
+export const PROMPT_EXAMPLES = `Message: "U2 alex hab in dem bahnstation gesehen"
+{"stationName": "Alex", "directionName": null}
+
+Message: "3x kotti u3 am Gleis"
+{"stationName": "Kottbusser Tor", "directionName": null}
+
+Message: "gorli u1/u3 3 Männer"
+{"stationName": "Görlitzer Bahnhof", "directionName": null}
+
+Message: "U7 Rathaus Spandau Richt Rudow Höhe sbhf Neukölln 4 Mann BOS"
+{"stationName": "Neukölln", "directionName": "Rudow"}
+
+Message: "u 8 wittenau in blauen westen höhe osloer"
+{"stationName": "osloer", "directionName": "wittenau"}
+
+Message: "Gesundbrunnen clean on u8"
+{"stationName": "Gesundbrunnen", "directionName": null}
+
+Message: "M29 bus moritzplatz"
+{"stationName": "Moritzplatz", "directionName": null}
+
+Message: "3 Bos Jacken M29 Anhalter Bahnhof Richtung Hermannplatz"
+{"stationName": "Anhalter Bahnhof", "directionName": "Hermannplatz"}
+
+Message: "S3 nach ostbahnof"
+{"stationName": null, "directionName": "Ostbahnhof"}
+
+Message: "To Rathaus SPANDAU"
+{"stationName": null, "directionName": "Rathaus Spandau"}
+
+Message: "U7 Rathaus Neukölln 3x BOS just got off the train"
+{"stationName": "Rathaus Neukölln", "directionName": null}
+
+Message: "U6 Kaiserin Augusta 2x bos"
+{"stationName": "Kaiserin-Augusta-Straße", "directionName": null}
+
+Message: "Zoo Richtung Steglitz"
+{"stationName": "Zoo", "directionName": "Steglitz"}
+
+Message: "Hi, kann mir wer ein Ticket verkaufen?"
+{"stationName": null, "directionName": null}
+`
+
+// =============================================================================
+// Runtime config (from env bindings) — non-city-specific.
+// =============================================================================
+
+export interface RuntimeConfig {
+    backendUrl: string
+    publicAppUrl: string
+    cityName: string
+    mistralModel: string
+    telegramReportChatId: string
+    mistralApiKey: string
+    telegramBotToken: string
+    reportPassword: string
+    telegramWebhookSecret: string
+}
+
+function required(env: Env, name: keyof Env): string {
+    const value = env[name]
+    if (typeof value !== 'string' || value === '') {
+        throw new Error(`Missing required env var: ${name}`)
+    }
+    return value
+}
+
+const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, '')
+
+export function readConfig(env: Env): RuntimeConfig {
+    return {
+        backendUrl: stripTrailingSlash(required(env, 'BACKEND_URL')),
+        publicAppUrl: stripTrailingSlash(env.PUBLIC_APP_URL || 'https://app.freifahren.org'),
+        cityName: env.CITY_NAME || 'Berlin',
+        mistralModel: env.MISTRAL_MODEL || 'mistral-small-latest',
+        telegramReportChatId: required(env, 'TELEGRAM_REPORT_CHAT_ID'),
+        mistralApiKey: required(env, 'MISTRAL_API_KEY'),
+        telegramBotToken: required(env, 'TELEGRAM_BOT_TOKEN'),
+        reportPassword: required(env, 'REPORT_PASSWORD'),
+        telegramWebhookSecret: required(env, 'TELEGRAM_WEBHOOK_SECRET'),
+    }
+}

--- a/packages/telegram-worker/src/extractor.ts
+++ b/packages/telegram-worker/src/extractor.ts
@@ -37,8 +37,7 @@ export function normalizeName(name: string): string {
     return n
 }
 
-// Faithful port of CPython's difflib.SequenceMatcher.ratio() (no custom junk; autojunk
-// kicks in at len>=200 as upstream). Station names are short, but we keep parity exact.
+// Implements difflib.SequenceMatcher.ratio() (no custom junk; autojunk kicks in at len>=200).
 
 function buildB2J(b: string): Map<string, number[]> {
     const b2j = new Map<string, number[]>()
@@ -184,7 +183,7 @@ function candidates(
     if (scored.length === 0) {
         return []
     }
-    // Stable sort by score descending (matches Python's list.sort stability).
+    // Stable sort by score descending.
     scored.sort((x, y) => y[1] - x[1])
 
     const results: [string, number][] = []

--- a/packages/telegram-worker/src/extractor.ts
+++ b/packages/telegram-worker/src/extractor.ts
@@ -1,0 +1,419 @@
+import * as config from './config'
+import { StationNameExtraction, type TransitIndex } from './types'
+import { stationLineNames } from './transit'
+
+export interface ExtractionResult {
+    stationId: string | null
+    lineName: string | null
+    directionId: string | null
+}
+
+export function isEmpty(result: ExtractionResult): boolean {
+    return result.stationId === null && result.lineName === null && result.directionId === null
+}
+
+export function extractionToLog(result: ExtractionResult): string {
+    return JSON.stringify({
+        stationId: result.stationId,
+        lineName: result.lineName,
+        directionId: result.directionId,
+    })
+}
+
+function translateLetters(s: string): string {
+    return s.replace(/[äöüßÄÖÜ]/g, (c) => config.LANGUAGE_LETTER_MAP[c] ?? c)
+}
+
+export function normalizeName(name: string): string {
+    let n = name.trim().toLowerCase()
+    n = n.replace(config.STATION_NAME_PREFIX_PATTERN, '')
+    n = translateLetters(n)
+    // Strip any diacritics that survived the letter map.
+    n = n.normalize('NFKD').replace(/\p{M}/gu, '')
+    for (const [pattern, repl] of config.LANGUAGE_ABBREVIATIONS) {
+        n = n.replace(pattern, repl)
+    }
+    n = n.replace(/[^a-z0-9]+/g, '')
+    return n
+}
+
+// Faithful port of CPython's difflib.SequenceMatcher.ratio() (no custom junk; autojunk
+// kicks in at len>=200 as upstream). Station names are short, but we keep parity exact.
+
+function buildB2J(b: string): Map<string, number[]> {
+    const b2j = new Map<string, number[]>()
+    for (let i = 0; i < b.length; i++) {
+        const arr = b2j.get(b[i])
+        if (arr) arr.push(i)
+        else b2j.set(b[i], [i])
+    }
+    const n = b.length
+    if (n >= 200) {
+        const ntest = Math.floor(n / 100) + 1
+        for (const [elt, idxs] of [...b2j]) {
+            if (idxs.length > ntest) b2j.delete(elt)
+        }
+    }
+    return b2j
+}
+
+function findLongestMatch(
+    a: string,
+    b: string,
+    b2j: Map<string, number[]>,
+    alo: number,
+    ahi: number,
+    blo: number,
+    bhi: number,
+): [number, number, number] {
+    let besti = alo
+    let bestj = blo
+    let bestsize = 0
+    let j2len = new Map<number, number>()
+    for (let i = alo; i < ahi; i++) {
+        const newj2len = new Map<number, number>()
+        const js = b2j.get(a[i])
+        if (js) {
+            for (const j of js) {
+                if (j < blo) continue
+                if (j >= bhi) break
+                const k = (j2len.get(j - 1) ?? 0) + 1
+                newj2len.set(j, k)
+                if (k > bestsize) {
+                    besti = i - k + 1
+                    bestj = j - k + 1
+                    bestsize = k
+                }
+            }
+        }
+        j2len = newj2len
+    }
+    while (besti > alo && bestj > blo && a[besti - 1] === b[bestj - 1]) {
+        besti--
+        bestj--
+        bestsize++
+    }
+    while (besti + bestsize < ahi && bestj + bestsize < bhi && a[besti + bestsize] === b[bestj + bestsize]) {
+        bestsize++
+    }
+    return [besti, bestj, bestsize]
+}
+
+function matchingChars(a: string, b: string): number {
+    const b2j = buildB2J(b)
+    let total = 0
+    const queue: [number, number, number, number][] = [[0, a.length, 0, b.length]]
+    while (queue.length) {
+        const [alo, ahi, blo, bhi] = queue.pop()!
+        const [i, j, k] = findLongestMatch(a, b, b2j, alo, ahi, blo, bhi)
+        if (k > 0) {
+            total += k
+            if (alo < i && blo < j) queue.push([alo, i, blo, j])
+            if (i + k < ahi && j + k < bhi) queue.push([i + k, ahi, j + k, bhi])
+        }
+    }
+    return total
+}
+
+function ratio(a: string, b: string): number {
+    const total = a.length + b.length
+    return total ? (2.0 * matchingChars(a, b)) / total : 1.0
+}
+
+/** Hybrid score: prefix and substring win first, otherwise difflib ratio. */
+function similarity(queryNorm: string, candidateNorm: string): number {
+    if (!queryNorm || !candidateNorm) {
+        return 0.0
+    }
+    if (queryNorm === candidateNorm) {
+        return 1.0
+    }
+    if (candidateNorm.startsWith(queryNorm) || queryNorm.startsWith(candidateNorm)) {
+        return 0.95
+    }
+    if (candidateNorm.includes(queryNorm) || queryNorm.includes(candidateNorm)) {
+        // Reward containment but cap below prefix; longer overlap relative to candidate scores higher.
+        return 0.85 + 0.05 * (queryNorm.length / Math.max(candidateNorm.length, 1))
+    }
+    return ratio(queryNorm, candidateNorm)
+}
+
+/**
+ * Score candidate station ids for a free-text query against the index.
+ * Two-tier: full-query scoring first, per-word fallback only if no strong match.
+ */
+function candidates(
+    index: TransitIndex,
+    query: string,
+    lineName: string | null,
+    minScore = 0.6,
+): [string, number][] {
+    const full = normalizeName(query)
+    if (!full) {
+        return []
+    }
+
+    const scored: [string, number][] = []
+    for (const candNorm of Object.keys(index.byNorm)) {
+        const sc = similarity(full, candNorm)
+        if (sc >= minScore) {
+            scored.push([candNorm, sc])
+        }
+    }
+
+    // Tier 2: only if Tier 1 found no strong match, fall back to per-word scoring.
+    // Keeps "Rathaus Tiergarten" matchable as "Tiergarten" without letting common
+    // tail words ("Markt", "Platz", "Str") hijack longer queries.
+    const best = scored.reduce((m, [, sc]) => Math.max(m, sc), 0)
+    if (scored.length === 0 || best < 0.75) {
+        const wordQueries = query
+            .split(/[\s\-/,]+/)
+            .filter((p) => p.trim() && p.trim().length > 4)
+            .map((p) => normalizeName(p))
+            .filter((w) => w && w !== full)
+        for (const candNorm of Object.keys(index.byNorm)) {
+            for (const w of wordQueries) {
+                const sc = similarity(w, candNorm) * 0.9 // slight penalty so full-query wins ties
+                if (sc >= minScore) {
+                    scored.push([candNorm, sc])
+                }
+            }
+        }
+    }
+
+    if (scored.length === 0) {
+        return []
+    }
+    // Stable sort by score descending (matches Python's list.sort stability).
+    scored.sort((x, y) => y[1] - x[1])
+
+    const results: [string, number][] = []
+    for (const [norm, sc] of scored) {
+        for (const stationId of index.byNorm[norm]) {
+            if (lineName !== null && !stationLineNames(index, stationId).includes(lineName)) {
+                continue
+            }
+            results.push([stationId, sc])
+        }
+    }
+    return results
+}
+
+/**
+ * Return [stationId, stationIsOnLine] or null.
+ *
+ * The bool tells callers whether the picked station is on `lineName`. When the user
+ * types a station that isn't on the line they mentioned (e.g. "u6 turmstr" —
+ * Turmstraße is on U9), we trust the station and drop the line rather than pick a
+ * wrong same-line station with a worse fuzzy score.
+ */
+export function pickStation(
+    index: TransitIndex,
+    query: string | null,
+    lineName: string | null,
+    allowOffLine = true,
+): [string, boolean] | null {
+    if (!query) {
+        return null
+    }
+    if (config.GENERIC_NON_STATION_WORDS.has(normalizeName(query))) {
+        return null
+    }
+    const onLine = lineName !== null ? candidates(index, query, lineName) : []
+    let offLine: [string, number][] = []
+    if (allowOffLine && (onLine.length === 0 || (lineName !== null && onLine[0][1] < 0.92))) {
+        // Only compare against an unfiltered search when the line-filtered match isn't
+        // already near-exact, else we'd risk swapping in a slightly higher off-line station.
+        offLine = candidates(index, query, null)
+    }
+
+    if (onLine.length === 0 && offLine.length === 0) {
+        return null
+    }
+    if (onLine.length === 0) {
+        return [offLine[0][0], false]
+    }
+    if (offLine.length === 0) {
+        return [onLine[0][0], true]
+    }
+    // If off-line tops on-line by a clear margin, prefer it and drop the line.
+    if (offLine[0][1] >= onLine[0][1] + 0.1) {
+        return [offLine[0][0], false]
+    }
+    return [onLine[0][0], true]
+}
+
+/**
+ * Pick a direction station id, preferring stations on the user's line for
+ * disambiguation. Backend handles terminus snapping and same-as-station clearing.
+ */
+export function pickDirection(
+    index: TransitIndex,
+    query: string | null,
+    lineName: string | null,
+): string | null {
+    if (!query) {
+        return null
+    }
+    const picked = pickStation(index, query, lineName, lineName === null)
+    return picked !== null ? picked[0] : null
+}
+
+/**
+ * Resolution stage: raw extracted strings + detected line in, station/direction ids out.
+ * Kept separate from the LLM so its fuzzy-match edge cases are testable without one.
+ */
+export function resolveExtraction(
+    index: TransitIndex,
+    parsed: StationNameExtraction,
+    detectedLine: string | null,
+): ExtractionResult {
+    const picked = pickStation(index, parsed.stationName, detectedLine)
+    const stationId = picked !== null ? picked[0] : null
+    const stationOnLine = picked !== null ? picked[1] : false
+
+    let lineName = detectedLine
+    if (lineName !== null && stationId !== null && !stationOnLine) {
+        lineName = null
+    }
+
+    return {
+        stationId,
+        lineName,
+        directionId: pickDirection(index, parsed.directionName, lineName),
+    }
+}
+
+const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const CIRCULAR_LINE_REGEX = config.CIRCULAR_LINE_PATTERN
+    ? new RegExp(config.CIRCULAR_LINE_PATTERN, 'i')
+    : null
+
+export function buildLinePattern(lineNames: string[]): RegExp {
+    const alternatives: string[] = []
+    for (const lineName of [...lineNames].sort((a, b) => b.length - a.length)) {
+        if (/^\d+$/.test(lineName)) {
+            continue
+        }
+        // Match common chat variants like "U6", "u 6", "M 10" while avoiding words like "Uhr".
+        const parts = /^([A-Za-z]+)(\d+)$/.exec(lineName)
+        alternatives.push(
+            parts ? `${escapeRegex(parts[1])}\\s*${escapeRegex(parts[2])}` : escapeRegex(lineName),
+        )
+    }
+    return new RegExp(`(?<![A-Za-z0-9])(${alternatives.join('|')})(?![A-Za-z0-9])`, 'gi')
+}
+
+export function detectLineName(
+    message: string,
+    lineNames: string[],
+    linePattern: RegExp,
+    circularLineNames: string[] = [],
+): string | null {
+    const normalizedLines = new Map<string, string>()
+    for (const lineName of lineNames) {
+        normalizedLines.set(lineName.replace(/\s+/g, '').toUpperCase(), lineName)
+    }
+    for (const match of message.matchAll(linePattern)) {
+        const normalizedMatch = match[1].replace(/\s+/g, '').toUpperCase()
+        const hit = normalizedLines.get(normalizedMatch)
+        if (hit !== undefined) {
+            return hit
+        }
+    }
+    if (circularLineNames.length > 0 && CIRCULAR_LINE_REGEX !== null && CIRCULAR_LINE_REGEX.test(message)) {
+        return circularLineNames[0]
+    }
+    return null
+}
+
+export function buildSystemPrompt(index: TransitIndex, cityName: string): string {
+    const tracked = [...index.lineNames].sort().join(', ')
+    const examples = config.PROMPT_EXAMPLES.trim()
+    return (
+        `This is a ${cityName} public-transit chat where users report ticket-inspector ` +
+        `sightings (${config.INSPECTOR_KEYWORDS}, etc.). Almost every message is a sighting report.\n` +
+        '\n' +
+        'Respond with ONLY a JSON object — no prose, no markdown — exactly matching this shape:\n' +
+        '{"stationName": <string or null>, "directionName": <string or null>}\n' +
+        '\n' +
+        'Rules:\n' +
+        '- Extract from sighting reports. Messages with just a station name, just a line, or vague ' +
+        'phrasing like "waiting at X", "got out at X", "now at X", "chilling at X", or "X clean" ' +
+        'are reports. Typos, slang, and language mixing are normal.\n' +
+        '- For clear non-reports (spam/ads, questions, ticket sales, social chitchat with no ' +
+        'location, off-topic banter), set both fields to null.\n' +
+        '- stationName: the station the user is currently at. Copy it as written, including typos. ' +
+        'If the user gives a CURRENT station and a DIRECTION ("U7 Rathaus Spandau Richtung Rudow ' +
+        'höhe Neukölln" / "u8 wittenau höhe osloer"), the CURRENT station is the one near a word ' +
+        'like "höhe", "at", "now", "gerade", "jetzt", or simply the LATER one in the sentence. ' +
+        "A line's terminus mentioned without \"Richtung\" but at the start of the message is often " +
+        'still the direction. Set null if only a line and/or a direction phrase appear, with no ' +
+        'current station.\n' +
+        '- directionName: the destination after words like "Richtung", "nach", "to", "towards", ' +
+        '"->", "bis", "Ri.", or a line\'s well-known terminus mentioned alongside another ' +
+        'station ("U7 Rudow ... Neukölln" -> direction Rudow, station Neukölln). NEVER repeat ' +
+        'the current station here. Null if no direction is given.\n' +
+        `- We track these lines: ${tracked}. Sightings on OTHER lines (local buses M19/M29/M41, ` +
+        'X-lines, three-digit lines, etc.) are still reports if a station name is mentioned — ' +
+        'extract the station (bus stops are named after the nearby U/S station).\n' +
+        '- Never return generic words as a stationName (platform, station, vehicle types). If ' +
+        'only generic words appear, set stationName=null.\n' +
+        (examples ? `\nExamples:\n${examples}\n` : '')
+    )
+}
+
+const MISTRAL_ENDPOINT = 'https://api.mistral.ai/v1/chat/completions'
+// Bound a hung request so it can't keep the waitUntil task alive indefinitely; a timeout
+// surfaces as a thrown error the caller reports.
+const MISTRAL_TIMEOUT_MS = 20_000
+
+/**
+ * Call Mistral and parse the JSON response. Throws on API failure (network, timeout, 429,
+ * 5xx); the caller reports it and the message is dropped (no retry). Returns null on an
+ * unparseable/malformed response (a non-report we simply drop).
+ */
+export async function extractWithMistral(
+    message: string,
+    systemPrompt: string,
+    apiKey: string,
+    model: string,
+): Promise<StationNameExtraction | null> {
+    const response = await fetch(MISTRAL_ENDPOINT, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+        },
+        body: JSON.stringify({
+            model,
+            messages: [
+                { role: 'system', content: systemPrompt },
+                { role: 'user', content: message },
+            ],
+            response_format: { type: 'json_object' },
+            temperature: 0.0,
+        }),
+        signal: AbortSignal.timeout(MISTRAL_TIMEOUT_MS),
+    })
+
+    if (!response.ok) {
+        throw new Error(`Mistral API error: ${response.status} ${await response.text()}`)
+    }
+
+    const data = (await response.json()) as {
+        choices?: { message?: { content?: unknown } }[]
+    }
+    const raw = data.choices?.[0]?.message?.content
+    if (typeof raw !== 'string') {
+        return null
+    }
+
+    try {
+        return StationNameExtraction.parse(JSON.parse(raw))
+    } catch {
+        return null
+    }
+}

--- a/packages/telegram-worker/src/forwarding.ts
+++ b/packages/telegram-worker/src/forwarding.ts
@@ -4,7 +4,7 @@ import { getTransitIndex } from './transit'
 import { readConfig } from './config'
 import { reportError } from './observability'
 
-/** Mirrors Python's `html.escape(s, quote=True)`. */
+/** HTML-escape for Telegram markup, quotes included. */
 function escapeHtml(s: string): string {
     return s
         .replace(/&/g, '&amp;')

--- a/packages/telegram-worker/src/forwarding.ts
+++ b/packages/telegram-worker/src/forwarding.ts
@@ -1,0 +1,174 @@
+import type { Env, ForwardedReport, TransitIndex } from './types'
+import { lineNameForId, stationLineNames } from './transit'
+import { getTransitIndex } from './transit'
+import { readConfig } from './config'
+import { reportError } from './observability'
+
+/** Mirrors Python's `html.escape(s, quote=True)`. */
+function escapeHtml(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#x27;')
+}
+
+class BadRequestError extends Error {}
+
+export function validateForwardedReport(payload: unknown): ForwardedReport {
+    if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+        throw new BadRequestError('JSON body must be an object')
+    }
+    const body = payload as Record<string, unknown>
+    const { lineId, stationId, directionId } = body
+
+    if (lineId !== null && lineId !== undefined && typeof lineId !== 'string') {
+        throw new BadRequestError('lineId must be a string or null')
+    }
+    if (typeof stationId !== 'string' || stationId === '') {
+        throw new BadRequestError('stationId must be a non-empty string')
+    }
+    if (directionId !== null && directionId !== undefined && typeof directionId !== 'string') {
+        throw new BadRequestError('directionId must be a string or null')
+    }
+
+    const allowed = new Set(['lineId', 'stationId', 'directionId'])
+    const keys = Object.keys(body)
+    if (keys.length !== allowed.size || !keys.every((k) => allowed.has(k))) {
+        throw new BadRequestError('body must contain exactly lineId, stationId, and directionId')
+    }
+
+    return {
+        lineId: (lineId as string | null | undefined) ?? null,
+        stationId,
+        directionId: (directionId as string | null | undefined) ?? null,
+    }
+}
+
+export function validateTransitReferences(index: TransitIndex, report: ForwardedReport): void {
+    if (!(report.stationId in index.stations)) {
+        throw new BadRequestError(`unknown stationId: ${report.stationId}`)
+    }
+    if (report.directionId !== null && !(report.directionId in index.stations)) {
+        throw new BadRequestError(`unknown directionId: ${report.directionId}`)
+    }
+
+    const lineName = report.lineId !== null ? lineNameForId(index, report.lineId) : null
+    if (report.lineId !== null && lineName === null) {
+        throw new BadRequestError(`unknown lineId: ${report.lineId}`)
+    }
+    if (lineName !== null && !stationLineNames(index, report.stationId).includes(lineName)) {
+        throw new BadRequestError(`stationId ${report.stationId} is not served by lineId ${report.lineId}`)
+    }
+    if (
+        lineName !== null &&
+        report.directionId !== null &&
+        !stationLineNames(index, report.directionId).includes(lineName)
+    ) {
+        throw new BadRequestError(
+            `directionId ${report.directionId} is not served by lineId ${report.lineId}`,
+        )
+    }
+}
+
+export function formatForwardedReport(
+    index: TransitIndex,
+    report: ForwardedReport,
+    publicAppUrl: string,
+): string {
+    const station = index.stations[report.stationId]
+    const direction = report.directionId !== null ? index.stations[report.directionId] : null
+    const lineName = report.lineId !== null ? lineNameForId(index, report.lineId) : null
+    // utm_source lets the app attribute arrivals from this link in analytics (PostHog
+    // captures utm_* automatically). The app redirects /station/<id> to the live report
+    // view when one is fresh.
+    const stationUrl = `${publicAppUrl}/station/${report.stationId}?utm_source=telegram&utm_medium=bot`
+
+    const lines = [`<b>Station:</b> ${escapeHtml(station.name)}`]
+    if (lineName !== null) {
+        lines.push(`<b>Line:</b> ${escapeHtml(lineName)}`)
+    }
+    if (direction !== null) {
+        lines.push(`<b>Direction:</b> ${escapeHtml(direction.name)}`)
+    }
+    lines.push('')
+    lines.push(`Mehr Informationen auf <a href="${escapeHtml(stationUrl)}">${publicAppUrl}</a>`)
+    return lines.join('\n')
+}
+
+async function sendTelegramMessage(
+    botToken: string,
+    chatId: string,
+    text: string,
+): Promise<void> {
+    const response = await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            chat_id: chatId,
+            text,
+            parse_mode: 'HTML',
+            link_preview_options: {
+                is_disabled: false,
+                prefer_large_media: false,
+                show_above_text: false,
+            },
+        }),
+    })
+    if (!response.ok) {
+        throw new Error(`Telegram sendMessage failed: ${response.status} ${await response.text()}`)
+    }
+}
+
+const json = (body: unknown, status = 200): Response =>
+    new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    })
+
+export async function handleReportForward(request: Request, env: Env): Promise<Response> {
+    const cfg = readConfig(env)
+
+    if (request.headers.get('X-Password') !== cfg.reportPassword) {
+        return json({ error: 'unauthorized' }, 401)
+    }
+
+    // Validate the body shape before fetching transit data so a malformed request
+    // doesn't hit the backend.
+    let report: ForwardedReport
+    try {
+        report = validateForwardedReport(await request.json())
+    } catch (err) {
+        const detail = err instanceof Error ? err.message : 'invalid request'
+        return json({ error: 'bad_request', detail }, 400)
+    }
+
+    let index: TransitIndex
+    try {
+        index = await getTransitIndex(cfg.backendUrl)
+    } catch (err) {
+        reportError('Failed to load transit data', err)
+        return json({ error: 'transit_unavailable' }, 502)
+    }
+
+    try {
+        validateTransitReferences(index, report)
+    } catch (err) {
+        const detail = err instanceof Error ? err.message : 'invalid request'
+        return json({ error: 'bad_request', detail }, 400)
+    }
+
+    try {
+        await sendTelegramMessage(
+            cfg.telegramBotToken,
+            cfg.telegramReportChatId,
+            formatForwardedReport(index, report, cfg.publicAppUrl),
+        )
+    } catch (err) {
+        reportError('Failed to forward app report to Telegram', err)
+        return json({ error: 'telegram_send_failed' }, 502)
+    }
+
+    return json({ status: 'success' })
+}

--- a/packages/telegram-worker/src/index.ts
+++ b/packages/telegram-worker/src/index.ts
@@ -1,0 +1,21 @@
+import type { Env } from './types'
+import { handleWebhook } from './webhook'
+import { handleReportForward } from './forwarding'
+
+export default {
+    async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+        const url = new URL(request.url)
+
+        if (request.method === 'POST' && url.pathname === '/telegram/webhook') {
+            return handleWebhook(request, env, ctx)
+        }
+        if (request.method === 'POST' && url.pathname === '/report') {
+            return handleReportForward(request, env)
+        }
+        if (request.method === 'GET' && url.pathname === '/health') {
+            return new Response('ok', { status: 200 })
+        }
+
+        return new Response('not found', { status: 404 })
+    },
+} satisfies ExportedHandler<Env>

--- a/packages/telegram-worker/src/observability.ts
+++ b/packages/telegram-worker/src/observability.ts
@@ -1,0 +1,11 @@
+// Single seam for error reporting. With no queue/retry, a failed pipeline run drops the
+// message — for now we only log to the live tail.
+//
+// TODO(#689): wire real error tracking + alerting on error rates.
+// https://github.com/FreiFahren/FreiFahren/issues/689
+export function reportError(message: string, err: unknown, extra?: Record<string, unknown>): void {
+    console.error(message, {
+        error: err instanceof Error ? (err.stack ?? err.message) : String(err),
+        ...extra,
+    })
+}

--- a/packages/telegram-worker/src/pipeline.ts
+++ b/packages/telegram-worker/src/pipeline.ts
@@ -1,0 +1,47 @@
+import type { Env } from './types'
+import { readConfig } from './config'
+import { isSpam } from './spam'
+import { getTransitIndex } from './transit'
+import {
+    buildLinePattern,
+    buildSystemPrompt,
+    detectLineName,
+    extractWithMistral,
+    extractionToLog,
+    resolveExtraction,
+} from './extractor'
+import { postReport, reportIdentifiers } from './reporting'
+
+/**
+ * The extract -> resolve -> submit chain (was Python's handle_text). Throws on failure
+ * (Mistral or backend) for the caller to report; returns normally when there's nothing to
+ * submit (spam, no extraction, no station). Runs in the background via waitUntil — no retry.
+ */
+export async function processMessage(text: string, env: Env): Promise<void> {
+    if (isSpam(text)) {
+        console.info('Skipped as spam:', text.slice(0, 80))
+        return
+    }
+
+    const cfg = readConfig(env)
+    const index = await getTransitIndex(cfg.backendUrl)
+
+    const linePattern = buildLinePattern(index.lineNames)
+    const detectedLine = detectLineName(text, index.lineNames, linePattern, index.circularLineNames)
+
+    const systemPrompt = buildSystemPrompt(index, cfg.cityName)
+    const parsed = await extractWithMistral(text, systemPrompt, cfg.mistralApiKey, cfg.mistralModel)
+    if (parsed === null) {
+        console.info('No extraction produced (LLM error or unparseable)')
+        return
+    }
+
+    const result = resolveExtraction(index, parsed, detectedLine)
+    const ids = reportIdentifiers(index, result)
+    if (ids === null) {
+        return
+    }
+
+    console.info('Submitting report:', extractionToLog(result))
+    await postReport(cfg.backendUrl, cfg.reportPassword, ids)
+}

--- a/packages/telegram-worker/src/pipeline.ts
+++ b/packages/telegram-worker/src/pipeline.ts
@@ -13,7 +13,7 @@ import {
 import { postReport, reportIdentifiers } from './reporting'
 
 /**
- * The extract -> resolve -> submit chain (was Python's handle_text). Throws on failure
+ * The extract -> resolve -> submit chain. Throws on failure
  * (Mistral or backend) for the caller to report; returns normally when there's nothing to
  * submit (spam, no extraction, no station). Runs in the background via waitUntil — no retry.
  */

--- a/packages/telegram-worker/src/reporting.ts
+++ b/packages/telegram-worker/src/reporting.ts
@@ -1,0 +1,65 @@
+import type { TransitIndex } from './types'
+import { type ExtractionResult, extractionToLog, isEmpty } from './extractor'
+import { resolveLineVariant } from './transit'
+
+export interface ReportPayload {
+    stationId: string
+    source: 'telegram'
+    lineId?: string
+    directionId?: string
+}
+
+export interface ReportIdentifiers {
+    stationId: string
+    lineId: string | null
+    directionId: string | null
+}
+
+export function buildReportPayload(ids: ReportIdentifiers): ReportPayload {
+    const payload: ReportPayload = { stationId: ids.stationId, source: 'telegram' }
+    if (ids.lineId !== null) {
+        payload.lineId = ids.lineId
+    }
+    if (ids.directionId !== null) {
+        payload.directionId = ids.directionId
+    }
+    return payload
+}
+
+export function reportIdentifiers(
+    index: TransitIndex,
+    extraction: ExtractionResult,
+): ReportIdentifiers | null {
+    if (isEmpty(extraction)) {
+        console.info('LLM returned no inspector report for this message')
+        return null
+    }
+    if (extraction.stationId === null) {
+        // Backend requires at least one identifier and our pipeline keys off the station.
+        console.info('Extraction lacked stationId; skipping', extractionToLog(extraction))
+        return null
+    }
+
+    const lineId =
+        extraction.lineName !== null
+            ? resolveLineVariant(index, extraction.lineName, extraction.stationId)
+            : null
+
+    return { stationId: extraction.stationId, lineId, directionId: extraction.directionId }
+}
+
+// Throws on a non-success response; the caller reports it (no retry).
+export async function postReport(
+    backendUrl: string,
+    reportPassword: string,
+    ids: ReportIdentifiers,
+): Promise<void> {
+    const response = await fetch(`${backendUrl}/v0/reports`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Password': reportPassword },
+        body: JSON.stringify(buildReportPayload(ids)),
+    })
+    if (!response.ok) {
+        throw new Error(`POST /v0/reports returned ${response.status}: ${await response.text()}`)
+    }
+}

--- a/packages/telegram-worker/src/spam.ts
+++ b/packages/telegram-worker/src/spam.ts
@@ -2,7 +2,7 @@ export const MINIMUM_MESSAGE_LENGTH = 3
 export const MAXIMUM_MESSAGE_LENGTH = 250
 export const MAX_EMOJIS = 5
 
-// Matches the Python classifier's emoji range (Emoticons block, U+1F600–U+1F64F).
+// Emoji range: Emoticons block, U+1F600–U+1F64F.
 const EMOJI_PATTERN = /[\u{1f600}-\u{1f64f}]/gu
 
 export function isSpam(text: string): boolean {

--- a/packages/telegram-worker/src/spam.ts
+++ b/packages/telegram-worker/src/spam.ts
@@ -1,0 +1,23 @@
+export const MINIMUM_MESSAGE_LENGTH = 3
+export const MAXIMUM_MESSAGE_LENGTH = 250
+export const MAX_EMOJIS = 5
+
+// Matches the Python classifier's emoji range (Emoticons block, U+1F600–U+1F64F).
+const EMOJI_PATTERN = /[\u{1f600}-\u{1f64f}]/gu
+
+export function isSpam(text: string): boolean {
+    if (text.length < MINIMUM_MESSAGE_LENGTH) {
+        return true
+    }
+    if (text.includes('?')) {
+        return true
+    }
+    if (text.length > MAXIMUM_MESSAGE_LENGTH) {
+        return true
+    }
+    if (text.includes('http')) {
+        return true
+    }
+    const emojis = text.match(EMOJI_PATTERN)
+    return (emojis?.length ?? 0) > MAX_EMOJIS
+}

--- a/packages/telegram-worker/src/transit.ts
+++ b/packages/telegram-worker/src/transit.ts
@@ -1,0 +1,102 @@
+import type { IndexVariant, TransitIndex } from './types'
+import { normalizeName } from './extractor'
+
+interface RawStation {
+    name: string
+    lines?: string[]
+}
+
+interface RawLine {
+    id: string
+    name: string
+    isCircular?: boolean
+    stations?: string[]
+}
+
+// Lines-per-station are derived from the variants (not the /stations `lines` field) so we
+// index PUBLIC line names ("S85") rather than variant names ("S85-a") the /stations endpoint
+// sometimes returns.
+export function buildIndex(rawStations: Record<string, RawStation>, rawLines: RawLine[]): TransitIndex {
+    const variants: IndexVariant[] = rawLines.map((line) => ({
+        id: line.id,
+        name: line.name,
+        stations: line.stations ?? [],
+    }))
+
+    const linesByStation: Record<string, string[]> = {}
+    for (const variant of variants) {
+        for (const stationId of variant.stations) {
+            const set = (linesByStation[stationId] ??= [])
+            if (!set.includes(variant.name)) {
+                set.push(variant.name)
+            }
+        }
+    }
+
+    const stations: TransitIndex['stations'] = {}
+    const byNorm: Record<string, string[]> = {}
+    for (const [stationId, props] of Object.entries(rawStations)) {
+        stations[stationId] = { id: stationId, name: props.name }
+        const norm = normalizeName(props.name)
+        ;(byNorm[norm] ??= []).push(stationId)
+        linesByStation[stationId] ??= []
+    }
+
+    const lineNames = [...new Set(variants.map((v) => v.name))].sort()
+    const circularLineNames = [
+        ...new Set(rawLines.filter((l) => l.isCircular).map((l) => l.name)),
+    ].sort()
+
+    return { stations, byNorm, linesByStation, lineNames, circularLineNames, variants }
+}
+
+// Fetched fresh from the backend on every call. Response caching is handled at the
+// Cloudflare edge (a cache rule on /v0/transit/*), not here.
+export async function getTransitIndex(backendUrl: string): Promise<TransitIndex> {
+    const [stationsResp, linesResp] = await Promise.all([
+        fetch(`${backendUrl}/v0/transit/stations`),
+        fetch(`${backendUrl}/v0/transit/lines`),
+    ])
+    if (!stationsResp.ok) {
+        throw new Error(`GET /v0/transit/stations failed: ${stationsResp.status}`)
+    }
+    if (!linesResp.ok) {
+        throw new Error(`GET /v0/transit/lines failed: ${linesResp.status}`)
+    }
+    const rawStations = (await stationsResp.json()) as Record<string, RawStation>
+    const rawLines = (await linesResp.json()) as RawLine[]
+    return buildIndex(rawStations, rawLines)
+}
+
+export function stationLineNames(index: TransitIndex, stationId: string): string[] {
+    return index.linesByStation[stationId] ?? []
+}
+
+export function lineNameForId(index: TransitIndex, lineId: string): string | null {
+    for (const variant of index.variants) {
+        if (variant.id === lineId) {
+            return variant.name
+        }
+    }
+    return null
+}
+
+// Mirrors the frontend's longest-variant fallback: of the variants whose name matches (and
+// which contain the station, if given), return the id of the one with the most stations.
+export function resolveLineVariant(
+    index: TransitIndex,
+    lineName: string,
+    stationId: string | null,
+): string | null {
+    let candidates = index.variants.filter((v) => v.name === lineName)
+    if (candidates.length === 0) {
+        return null
+    }
+    if (stationId !== null) {
+        const withStation = candidates.filter((v) => v.stations.includes(stationId))
+        if (withStation.length > 0) {
+            candidates = withStation
+        }
+    }
+    return candidates.reduce((best, v) => (v.stations.length > best.stations.length ? v : best)).id
+}

--- a/packages/telegram-worker/src/types.ts
+++ b/packages/telegram-worker/src/types.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod'
+
+export interface Env {
+    // Vars (wrangler.jsonc)
+    BACKEND_URL: string
+    PUBLIC_APP_URL: string
+    CITY_NAME: string
+    MISTRAL_MODEL: string
+    TELEGRAM_REPORT_CHAT_ID: string
+
+    // Secrets (wrangler secret put)
+    MISTRAL_API_KEY: string
+    TELEGRAM_BOT_TOKEN: string
+    REPORT_PASSWORD: string
+    TELEGRAM_WEBHOOK_SECRET: string
+}
+
+// Telegram update — only the fields we read.
+
+const TelegramChat = z.object({
+    id: z.number(),
+    type: z.string().optional(),
+    title: z.string().nullish(),
+    username: z.string().nullish(),
+})
+
+const TelegramMessageEntity = z.object({
+    type: z.string(),
+    offset: z.number(),
+    length: z.number(),
+})
+
+const TelegramMessage = z.object({
+    text: z.string().nullish(),
+    caption: z.string().nullish(),
+    chat: TelegramChat.nullish(),
+    entities: z.array(TelegramMessageEntity).nullish(),
+    caption_entities: z.array(TelegramMessageEntity).nullish(),
+})
+
+export const TelegramUpdate = z.object({
+    update_id: z.number().optional(),
+    message: TelegramMessage.nullish(),
+    edited_message: TelegramMessage.nullish(),
+    channel_post: TelegramMessage.nullish(),
+    edited_channel_post: TelegramMessage.nullish(),
+})
+
+export type TelegramUpdate = z.infer<typeof TelegramUpdate>
+export type TelegramMessage = z.infer<typeof TelegramMessage>
+
+export const StationNameExtraction = z.object({
+    stationName: z.string().nullish().transform((v) => v ?? null),
+    directionName: z.string().nullish().transform((v) => v ?? null),
+})
+
+export type StationNameExtraction = z.infer<typeof StationNameExtraction>
+
+export interface IndexStation {
+    id: string
+    name: string
+}
+
+export interface IndexVariant {
+    id: string
+    name: string
+    stations: string[]
+}
+
+// Built per message from the backend's transit endpoints (see getTransitIndex).
+export interface TransitIndex {
+    stations: Record<string, IndexStation>
+    byNorm: Record<string, string[]>
+    // Derived from the variants, not the /stations `lines` field — see buildIndex.
+    linesByStation: Record<string, string[]>
+    lineNames: string[]
+    circularLineNames: string[]
+    variants: IndexVariant[]
+}
+
+export interface ForwardedReport {
+    lineId: string | null
+    stationId: string
+    directionId: string | null
+}

--- a/packages/telegram-worker/src/webhook.ts
+++ b/packages/telegram-worker/src/webhook.ts
@@ -1,0 +1,77 @@
+import type { Env, TelegramMessage } from './types'
+import { TelegramUpdate } from './types'
+import { processMessage } from './pipeline'
+import { reportError } from './observability'
+
+export const WEBHOOK_SECRET_HEADER = 'X-Telegram-Bot-Api-Secret-Token'
+
+function effectiveMessage(update: TelegramUpdate): TelegramMessage | null {
+    return update.message ?? update.edited_message ?? update.channel_post ?? update.edited_channel_post ?? null
+}
+
+function messageReportText(message: TelegramMessage): string | null {
+    const text = message.text ?? message.caption ?? null
+    return text || null
+}
+
+function isCommand(message: TelegramMessage): boolean {
+    const entities = message.entities ?? message.caption_entities ?? []
+    if (entities.some((e) => e.type === 'bot_command' && e.offset === 0)) {
+        return true
+    }
+    const text = message.text ?? message.caption ?? ''
+    return text.startsWith('/')
+}
+
+// Filter to the allowed chat (text/caption, non-command). Returns the text to process, or
+// null to ignore. Pure, so the filtering rules are testable without the pipeline.
+export function acceptUpdate(update: TelegramUpdate, allowedChatId: string): string | null {
+    const message = effectiveMessage(update)
+    if (message === null) {
+        return null
+    }
+    const chat = message.chat
+    if (!chat || String(chat.id) !== allowedChatId) {
+        return null
+    }
+    if (isCommand(message)) {
+        return null
+    }
+    return messageReportText(message)
+}
+
+type Processor = (text: string, env: Env) => Promise<void>
+
+/**
+ * Verify the Telegram secret, filter, then process in the background via waitUntil so we
+ * return 200 instantly and Telegram never re-delivers. There's no retry: a failed pipeline
+ * run (e.g. a Mistral timeout) is reported and the message is dropped — we monitor error
+ * rates instead. Only a bad secret yields a 401; everything else acks with 200.
+ */
+export async function handleWebhook(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext,
+    process: Processor = processMessage,
+): Promise<Response> {
+    if (request.headers.get(WEBHOOK_SECRET_HEADER) !== env.TELEGRAM_WEBHOOK_SECRET) {
+        return new Response('unauthorized', { status: 401 })
+    }
+
+    let update: TelegramUpdate
+    try {
+        update = TelegramUpdate.parse(await request.json())
+    } catch {
+        return new Response('ok', { status: 200 })
+    }
+
+    const text = acceptUpdate(update, env.TELEGRAM_REPORT_CHAT_ID)
+    if (text) {
+        ctx.waitUntil(
+            process(text, env).catch((err) =>
+                reportError('telegram pipeline failed', err, { text: text.slice(0, 80) }),
+            ),
+        )
+    }
+    return new Response('ok', { status: 200 })
+}

--- a/packages/telegram-worker/test/env.d.ts
+++ b/packages/telegram-worker/test/env.d.ts
@@ -1,0 +1,5 @@
+import type { Env } from '../src/types'
+
+declare module 'cloudflare:test' {
+    interface ProvidedEnv extends Env {}
+}

--- a/packages/telegram-worker/test/fixtures.ts
+++ b/packages/telegram-worker/test/fixtures.ts
@@ -1,0 +1,60 @@
+import { buildIndex } from '../src/transit'
+import type { TransitIndex } from '../src/types'
+
+export const ALLOWED_CHAT_ID = '-1001'
+export const PUBLIC_APP_URL = 'https://app.example.test'
+export const BACKEND_URL = 'https://backend.test'
+
+/**
+ * Synthetic transit payloads mirroring tests/test_resolution.py's _make_transit(),
+ * shaped exactly as the backend's /v0/transit/{stations,lines} responses.
+ */
+export function rawTransit() {
+    const rawStations = {
+        'S-suedkreuz': { name: 'Südkreuz', lines: ['S41', 'S42'] },
+        'U-turmstrasse': { name: 'Turmstraße', lines: ['U9'] },
+        'U-leinestrasse': { name: 'Leinestraße', lines: ['U8'] },
+        'U-rudow': { name: 'Rudow', lines: ['U7'] },
+        'U-rathaus-neukoelln': { name: 'Rathaus Neukölln', lines: ['U7'] },
+        'U-hermannplatz': { name: 'Hermannplatz', lines: ['U7', 'U8'] },
+    }
+    const rawLines = [
+        { id: 'S41-v', name: 'S41', isCircular: true, stations: ['S-suedkreuz'] },
+        { id: 'S42-v', name: 'S42', isCircular: true, stations: ['S-suedkreuz'] },
+        { id: 'U9-v', name: 'U9', isCircular: false, stations: ['U-turmstrasse'] },
+        { id: 'U8-v', name: 'U8', isCircular: false, stations: ['U-leinestrasse', 'U-hermannplatz'] },
+        {
+            id: 'U7-v',
+            name: 'U7',
+            isCircular: false,
+            stations: ['U-rudow', 'U-rathaus-neukoelln', 'U-hermannplatz'],
+        },
+    ]
+    return { rawStations, rawLines }
+}
+
+export function makeIndex(): TransitIndex {
+    const { rawStations, rawLines } = rawTransit()
+    return buildIndex(rawStations, rawLines)
+}
+
+export interface PickedStation {
+    stationId: string
+    lineId: string
+    lineName: string
+    directionId: string
+}
+
+/** First variant with >=2 stations: first station is the location, last the direction. */
+export function pickStationFixture(index: TransitIndex): PickedStation {
+    const variant = index.variants.find((v) => v.stations.length >= 2)
+    if (!variant) {
+        throw new Error('No line variant with >=2 stations in fixture')
+    }
+    return {
+        stationId: variant.stations[0],
+        lineId: variant.id,
+        lineName: variant.name,
+        directionId: variant.stations[variant.stations.length - 1],
+    }
+}

--- a/packages/telegram-worker/test/forwarding.test.ts
+++ b/packages/telegram-worker/test/forwarding.test.ts
@@ -1,0 +1,143 @@
+import { env, fetchMock } from 'cloudflare:test'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { handleReportForward } from '../src/forwarding'
+import type { Env } from '../src/types'
+import { makeIndex, pickStationFixture, rawTransit } from './fixtures'
+
+const testEnv = env as unknown as Env
+const index = makeIndex()
+const picked = pickStationFixture(index)
+
+function interceptTransit() {
+    const { rawStations, rawLines } = rawTransit()
+    fetchMock
+        .get('https://backend.test')
+        .intercept({ path: '/v0/transit/stations', method: 'GET' })
+        .reply(200, JSON.stringify(rawStations), { headers: { 'content-type': 'application/json' } })
+    fetchMock
+        .get('https://backend.test')
+        .intercept({ path: '/v0/transit/lines', method: 'GET' })
+        .reply(200, JSON.stringify(rawLines), { headers: { 'content-type': 'application/json' } })
+}
+
+function interceptTelegram(statusCode: number, capture?: { body?: Record<string, unknown> }) {
+    fetchMock
+        .get('https://api.telegram.org')
+        .intercept({ path: /\/bot.*\/sendMessage/, method: 'POST' })
+        .reply((opts) => {
+            if (capture) capture.body = JSON.parse(opts.body as string)
+            return { statusCode, data: statusCode === 200 ? '{"ok":true}' : '{"ok":false}' }
+        })
+}
+
+function reportRequest(body: unknown, password: string | null = 'password'): Request {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (password !== null) headers['X-Password'] = password
+    return new Request('https://worker.test/report', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+    })
+}
+
+beforeEach(() => {
+    fetchMock.activate()
+    fetchMock.disableNetConnect()
+})
+
+afterEach(() => {
+    fetchMock.assertNoPendingInterceptors()
+})
+
+describe('handleReportForward', () => {
+    it('sends a Telegram message for a valid request', async () => {
+        interceptTransit()
+        const capture: { body?: Record<string, unknown> } = {}
+        interceptTelegram(200, capture)
+
+        const res = await handleReportForward(
+            reportRequest({
+                stationId: picked.stationId,
+                lineId: picked.lineId,
+                directionId: picked.directionId,
+            }),
+            testEnv,
+        )
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ status: 'success' })
+
+        const text = capture.body!.text as string
+        expect(text).toContain(index.stations[picked.stationId].name)
+        expect(text).toContain(picked.lineName)
+        expect(text).toContain(index.stations[picked.directionId].name)
+        expect(text).toContain(`/station/${picked.stationId}?utm_source=telegram`)
+        expect(text).toContain('utm_medium=bot')
+    })
+
+    it('rejects a request with no password (401)', async () => {
+        const res = await handleReportForward(
+            reportRequest({ stationId: picked.stationId, lineId: picked.lineId, directionId: picked.directionId }, null),
+            testEnv,
+        )
+        expect(res.status).toBe(401)
+    })
+
+    it('rejects a wrong password (401)', async () => {
+        const res = await handleReportForward(
+            reportRequest(
+                { stationId: picked.stationId, lineId: picked.lineId, directionId: picked.directionId },
+                'totally-wrong',
+            ),
+            testEnv,
+        )
+        expect(res.status).toBe(401)
+    })
+
+    it.each([
+        ['missing_station', { lineId: null, directionId: null }],
+        ['empty_station_id', { lineId: null, stationId: '', directionId: null }],
+        ['extra_key', { lineId: null, stationId: 'x', directionId: null, extra: 1 }],
+        ['wrong_type_line', { lineId: 123, stationId: 'x', directionId: null }],
+        ['wrong_type_direction', { lineId: null, stationId: 'x', directionId: 5 }],
+    ])('returns 400 for schema violation: %s', async (_label, body) => {
+        // Schema is validated before any transit fetch, so no interceptor is needed.
+        const res = await handleReportForward(reportRequest(body), testEnv)
+        expect(res.status).toBe(400)
+    })
+
+    it('returns 400 for an unknown stationId', async () => {
+        interceptTransit()
+        const res = await handleReportForward(
+            reportRequest({ lineId: null, stationId: 'DOES_NOT_EXIST', directionId: null }),
+            testEnv,
+        )
+        expect(res.status).toBe(400)
+        expect(((await res.json()) as { error: string }).error).toBe('bad_request')
+    })
+
+    it('returns 400 when the line does not serve the station', async () => {
+        interceptTransit()
+        const badLine = index.variants.find((v) => !v.stations.includes(picked.stationId))
+        expect(badLine).toBeDefined()
+        const res = await handleReportForward(
+            reportRequest({ lineId: badLine!.id, stationId: picked.stationId, directionId: null }),
+            testEnv,
+        )
+        expect(res.status).toBe(400)
+    })
+
+    it('returns 502 when the Telegram send fails', async () => {
+        interceptTransit()
+        interceptTelegram(500)
+        const res = await handleReportForward(
+            reportRequest({
+                stationId: picked.stationId,
+                lineId: picked.lineId,
+                directionId: picked.directionId,
+            }),
+            testEnv,
+        )
+        expect(res.status).toBe(502)
+    })
+})

--- a/packages/telegram-worker/test/pipeline.test.ts
+++ b/packages/telegram-worker/test/pipeline.test.ts
@@ -1,0 +1,83 @@
+import { env, fetchMock } from 'cloudflare:test'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { processMessage } from '../src/pipeline'
+import type { Env } from '../src/types'
+import { rawTransit } from './fixtures'
+
+const testEnv = env as unknown as Env
+
+function interceptTransit() {
+    const { rawStations, rawLines } = rawTransit()
+    fetchMock
+        .get('https://backend.test')
+        .intercept({ path: '/v0/transit/stations', method: 'GET' })
+        .reply(200, JSON.stringify(rawStations), { headers: { 'content-type': 'application/json' } })
+    fetchMock
+        .get('https://backend.test')
+        .intercept({ path: '/v0/transit/lines', method: 'GET' })
+        .reply(200, JSON.stringify(rawLines), { headers: { 'content-type': 'application/json' } })
+}
+
+function interceptMistral(stationName: string | null, directionName: string | null) {
+    const body = JSON.stringify({
+        choices: [{ message: { content: JSON.stringify({ stationName, directionName }) } }],
+    })
+    fetchMock
+        .get('https://api.mistral.ai')
+        .intercept({ path: '/v1/chat/completions', method: 'POST' })
+        .reply(200, body, { headers: { 'content-type': 'application/json' } })
+}
+
+function interceptBackendReport(capture: { body?: Record<string, unknown> }) {
+    fetchMock
+        .get('https://backend.test')
+        .intercept({ path: '/v0/reports', method: 'POST' })
+        .reply((opts) => {
+            capture.body = JSON.parse(opts.body as string)
+            return { statusCode: 200, data: '{}' }
+        })
+}
+
+beforeEach(() => {
+    fetchMock.activate()
+    fetchMock.disableNetConnect()
+})
+
+afterEach(() => {
+    fetchMock.assertNoPendingInterceptors()
+})
+
+describe('processMessage', () => {
+    it('submits a full report (station + line + direction resolution)', async () => {
+        interceptTransit()
+        interceptMistral('Rudow', null)
+        const capture: { body?: Record<string, unknown> } = {}
+        interceptBackendReport(capture)
+
+        await processMessage('U7 Rudow 2x BOS', testEnv)
+
+        expect(capture.body).toEqual({ stationId: 'U-rudow', source: 'telegram', lineId: 'U7-v' })
+    })
+
+    it('drops spam before fetching transit, Mistral, or the backend', async () => {
+        // No interceptors registered: any outbound fetch would throw on disableNetConnect.
+        await processMessage('ok', testEnv)
+    })
+
+    it('does not submit when the extraction is empty', async () => {
+        interceptTransit()
+        interceptMistral(null, null)
+        await processMessage('this is fine', testEnv)
+    })
+
+    it('submits station-only with no lineId/directionId', async () => {
+        interceptTransit()
+        interceptMistral('Rudow', null)
+        const capture: { body?: Record<string, unknown> } = {}
+        interceptBackendReport(capture)
+
+        await processMessage('Rudow 2x bos', testEnv)
+
+        expect(capture.body).toEqual({ stationId: 'U-rudow', source: 'telegram' })
+    })
+})

--- a/packages/telegram-worker/test/resolution.test.ts
+++ b/packages/telegram-worker/test/resolution.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+    normalizeName,
+    pickDirection,
+    pickStation,
+    resolveExtraction,
+} from '../src/extractor'
+import { makeIndex } from './fixtures'
+
+const index = makeIndex()
+
+describe('normalizeName', () => {
+    it.each([
+        ['Südkreuz', 'sudkreuz'],
+        ['sudkreuz', 'sudkreuz'],
+        ['  Südkreuz  ', 'sudkreuz'],
+        ['S Südkreuz', 'sudkreuz'],
+        ['U Turmstraße', 'turmstrasse'],
+        ['Leinestr.', 'leinestrasse'],
+        ['Leinestr', 'leinestrasse'],
+    ])('normalizes %s -> %s', (raw, expected) => {
+        expect(normalizeName(raw)).toBe(expected)
+    })
+})
+
+describe('pickStation', () => {
+    it('resolves a diacritic typo off-line', () => {
+        expect(pickStation(index, 'sudkreuz', null)).toEqual(['S-suedkreuz', false])
+    })
+
+    it('flags an on-line match', () => {
+        expect(pickStation(index, 'Rudow', 'U7')).toEqual(['U-rudow', true])
+    })
+
+    it('drops the line when the station is off it', () => {
+        // 'u6 turmstr' — Turmstraße is on U9, so trust the station and drop the wrong line.
+        expect(pickStation(index, 'turmstr', 'U6')).toEqual(['U-turmstrasse', false])
+    })
+
+    it('rejects a generic non-station word', () => {
+        expect(pickStation(index, 'Bahnhof', null)).toBeNull()
+    })
+
+    it('returns null for an empty query', () => {
+        expect(pickStation(index, null, null)).toBeNull()
+        expect(pickStation(index, '', null)).toBeNull()
+    })
+})
+
+describe('pickDirection', () => {
+    it('restricts to the line', () => {
+        expect(pickDirection(index, 'Rudow', 'U7')).toBe('U-rudow')
+    })
+
+    it('returns null for a missing query', () => {
+        expect(pickDirection(index, null, 'U7')).toBeNull()
+    })
+})
+
+describe('resolveExtraction', () => {
+    it('resolves station and direction', () => {
+        const result = resolveExtraction(
+            index,
+            { stationName: 'Rathaus Neukölln', directionName: 'Rudow' },
+            'U7',
+        )
+        expect(result.stationId).toBe('U-rathaus-neukoelln')
+        expect(result.lineName).toBe('U7')
+        expect(result.directionId).toBe('U-rudow')
+    })
+
+    it('drops the line for an off-line station', () => {
+        const result = resolveExtraction(index, { stationName: 'Turmstraße', directionName: null }, 'U6')
+        expect(result.stationId).toBe('U-turmstrasse')
+        expect(result.lineName).toBeNull()
+    })
+
+    it('is empty when nothing matches', () => {
+        const result = resolveExtraction(index, { stationName: null, directionName: null }, null)
+        expect(result.stationId).toBeNull()
+        expect(result.lineName).toBeNull()
+        expect(result.directionId).toBeNull()
+    })
+})

--- a/packages/telegram-worker/test/spam.test.ts
+++ b/packages/telegram-worker/test/spam.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_EMOJIS, MAXIMUM_MESSAGE_LENGTH, MINIMUM_MESSAGE_LENGTH, isSpam } from '../src/spam'
+
+describe('isSpam — ham', () => {
+    it.each([
+        ['typical_report', 'U2 alex 2x BOS'],
+        ['short_but_valid', 'a'.repeat(MINIMUM_MESSAGE_LENGTH)],
+        ['long_but_valid', 'a'.repeat(MAXIMUM_MESSAGE_LENGTH)],
+        ['emoji_at_threshold', 'report ' + '😀'.repeat(MAX_EMOJIS)],
+    ])('does not flag %s', (_label, text) => {
+        expect(isSpam(text)).toBe(false)
+    })
+})
+
+describe('isSpam — spam', () => {
+    it.each([
+        ['empty', ''],
+        ['one_char', 'a'],
+        ['below_minimum', 'a'.repeat(MINIMUM_MESSAGE_LENGTH - 1)],
+        ['above_maximum', 'a'.repeat(MAXIMUM_MESSAGE_LENGTH + 1)],
+        ['contains_question_mark', 'kontrolleur?'],
+        ['contains_http', 'see http://example.com'],
+        ['contains_https', 'see https://example.com'],
+        ['too_many_emojis', '😀'.repeat(MAX_EMOJIS + 1)],
+    ])('flags %s', (_label, text) => {
+        expect(isSpam(text)).toBe(true)
+    })
+})

--- a/packages/telegram-worker/test/webhook.test.ts
+++ b/packages/telegram-worker/test/webhook.test.ts
@@ -1,0 +1,115 @@
+import { env } from 'cloudflare:test'
+import { describe, expect, it, vi } from 'vitest'
+import { WEBHOOK_SECRET_HEADER, acceptUpdate, handleWebhook } from '../src/webhook'
+import { TelegramUpdate } from '../src/types'
+import type { Env } from '../src/types'
+import { ALLOWED_CHAT_ID } from './fixtures'
+
+function makeUpdate(opts: {
+    text?: string
+    caption?: string
+    chatId?: number | string
+    hasPhoto?: boolean
+    entities?: { type: string; offset: number; length: number }[]
+}): TelegramUpdate {
+    const message: Record<string, unknown> = {
+        message_id: 100,
+        date: 1_716_220_800,
+        chat: { id: Number(opts.chatId ?? ALLOWED_CHAT_ID), type: 'supergroup', title: 'tests' },
+        from: { id: 42, is_bot: false, first_name: 'Tester' },
+    }
+    if (opts.text !== undefined) message.text = opts.text
+    if (opts.caption !== undefined) message.caption = opts.caption
+    if (opts.entities) message.entities = opts.entities
+    if (opts.hasPhoto) message.photo = [{ file_id: 'p1', file_unique_id: 'pu1', width: 100, height: 100 }]
+    return TelegramUpdate.parse({ update_id: 1, message })
+}
+
+describe('acceptUpdate (filtering)', () => {
+    it('accepts a text message from the allowed chat', () => {
+        expect(acceptUpdate(makeUpdate({ text: 'U2 alex 2x BOS' }), ALLOWED_CHAT_ID)).toBe('U2 alex 2x BOS')
+    })
+
+    it('accepts a photo caption', () => {
+        expect(acceptUpdate(makeUpdate({ caption: 'U2 alex 2x BOS', hasPhoto: true }), ALLOWED_CHAT_ID)).toBe(
+            'U2 alex 2x BOS',
+        )
+    })
+
+    it('ignores a sticker with no text or caption', () => {
+        expect(acceptUpdate(makeUpdate({}), ALLOWED_CHAT_ID)).toBeNull()
+    })
+
+    it('ignores a message from an unallowed chat', () => {
+        expect(acceptUpdate(makeUpdate({ text: 'U2 alex 2x BOS', chatId: -9999 }), ALLOWED_CHAT_ID)).toBeNull()
+    })
+
+    it('ignores bot commands', () => {
+        const update = makeUpdate({ text: '/start', entities: [{ type: 'bot_command', offset: 0, length: 6 }] })
+        expect(acceptUpdate(update, ALLOWED_CHAT_ID)).toBeNull()
+    })
+})
+
+function webhookRequest(body: unknown, secret = 'webhook-secret'): Request {
+    return new Request('https://worker.test/telegram/webhook', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', [WEBHOOK_SECRET_HEADER]: secret },
+        body: JSON.stringify(body),
+    })
+}
+
+function fakeCtx() {
+    const promises: Promise<unknown>[] = []
+    return {
+        ctx: { waitUntil: (p: Promise<unknown>) => void promises.push(p) } as unknown as ExecutionContext,
+        promises,
+    }
+}
+
+describe('handleWebhook', () => {
+    it('rejects a wrong secret token with 401 and does not process', async () => {
+        const process = vi.fn(async () => {})
+        const { ctx, promises } = fakeCtx()
+        const res = await handleWebhook(webhookRequest(makeUpdate({ text: 'U2 alex' }), 'wrong'), env as unknown as Env, ctx, process)
+        expect(res.status).toBe(401)
+        expect(process).not.toHaveBeenCalled()
+        expect(promises).toHaveLength(0)
+    })
+
+    it('returns 200 and processes an accepted message in the background', async () => {
+        const process = vi.fn(async () => {})
+        const { ctx, promises } = fakeCtx()
+        const res = await handleWebhook(webhookRequest(makeUpdate({ text: 'U2 alex 2x BOS' })), env as unknown as Env, ctx, process)
+        expect(res.status).toBe(200)
+        expect(process).toHaveBeenCalledExactlyOnceWith('U2 alex 2x BOS', expect.anything())
+        expect(promises).toHaveLength(1)
+        await Promise.all(promises)
+    })
+
+    it('returns 200 without processing a filtered message', async () => {
+        const process = vi.fn(async () => {})
+        const { ctx, promises } = fakeCtx()
+        const res = await handleWebhook(
+            webhookRequest(makeUpdate({ text: 'U2 alex', chatId: -9999 })),
+            env as unknown as Env,
+            ctx,
+            process,
+        )
+        expect(res.status).toBe(200)
+        expect(process).not.toHaveBeenCalled()
+        expect(promises).toHaveLength(0)
+    })
+
+    it('acks malformed JSON with 200 and does not process', async () => {
+        const process = vi.fn(async () => {})
+        const { ctx } = fakeCtx()
+        const badReq = new Request('https://worker.test/telegram/webhook', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', [WEBHOOK_SECRET_HEADER]: 'webhook-secret' },
+            body: 'not json',
+        })
+        const res = await handleWebhook(badReq, env as unknown as Env, ctx, process)
+        expect(res.status).toBe(200)
+        expect(process).not.toHaveBeenCalled()
+    })
+})

--- a/packages/telegram-worker/tsconfig.json
+++ b/packages/telegram-worker/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src", "test"]
+}

--- a/packages/telegram-worker/vitest.config.ts
+++ b/packages/telegram-worker/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config'
+
+export default defineWorkersConfig({
+    test: {
+        poolOptions: {
+            workers: {
+                miniflare: {
+                    compatibilityDate: '2025-10-11',
+                    bindings: {
+                        BACKEND_URL: 'https://backend.test',
+                        PUBLIC_APP_URL: 'https://app.example.test',
+                        CITY_NAME: 'Berlin',
+                        MISTRAL_MODEL: 'mistral-small-latest',
+                        TELEGRAM_REPORT_CHAT_ID: '-1001',
+                        MISTRAL_API_KEY: 'test-mistral-key',
+                        TELEGRAM_BOT_TOKEN: '1:fake',
+                        REPORT_PASSWORD: 'password',
+                        TELEGRAM_WEBHOOK_SECRET: 'webhook-secret',
+                    },
+                },
+            },
+        },
+    },
+})

--- a/packages/telegram-worker/wrangler.jsonc
+++ b/packages/telegram-worker/wrangler.jsonc
@@ -10,7 +10,7 @@
         "CITY_NAME": "Berlin",
         "MISTRAL_MODEL": "mistral-small-latest",
         // Group chat the bot listens to and forwards app reports into. Negative for groups.
-        "TELEGRAM_REPORT_CHAT_ID": ""
+        "TELEGRAM_REPORT_CHAT_ID": "-5176241055"
     }
     // Messages are processed in the background (ctx.waitUntil) with no queue/retry; failed
     // runs are dropped (error tracking is TODO, FreiFahren/FreiFahren#689). Transit data is

--- a/packages/telegram-worker/wrangler.jsonc
+++ b/packages/telegram-worker/wrangler.jsonc
@@ -1,0 +1,20 @@
+{
+    "$schema": "node_modules/wrangler/config-schema.json",
+    "name": "telegram-worker",
+    "main": "src/index.ts",
+    "compatibility_date": "2025-10-11",
+    "vars": {
+        // Backend that serves /v0/transit/* and accepts POST /v0/reports.
+        "BACKEND_URL": "https://api.freifahren.org",
+        "PUBLIC_APP_URL": "https://app.freifahren.org",
+        "CITY_NAME": "Berlin",
+        "MISTRAL_MODEL": "mistral-small-latest",
+        // Group chat the bot listens to and forwards app reports into. Negative for groups.
+        "TELEGRAM_REPORT_CHAT_ID": ""
+    }
+    // Messages are processed in the background (ctx.waitUntil) with no queue/retry; failed
+    // runs are dropped (error tracking is TODO, FreiFahren/FreiFahren#689). Transit data is
+    // fetched per message from BACKEND_URL; cache it with a Cloudflare cache rule on
+    // /v0/transit/*. Secrets (set via `wrangler secret put`): MISTRAL_API_KEY,
+    // TELEGRAM_BOT_TOKEN, REPORT_PASSWORD, TELEGRAM_WEBHOOK_SECRET.
+}


### PR DESCRIPTION
## What

Replaces the Python `packages/telegram_bot` with a behavior-for-behavior TypeScript Cloudflare Worker (`packages/telegram-worker`). The extraction logic — spam filter, line detection, name normalization, and the two-tier fuzzy station matching (including a faithful port of CPython's `difflib` ratio) — is reproduced from the Python package so extraction quality doesn't regress.

## How it works

* **Webhook** verifies the Telegram secret header, filters to the allowed chat (text/caption, non-command), then processes in the background via `ctx.waitUntil` — returns `200` instantly so Telegram never re-delivers (no duplicates).
* **No queue/retry.** A failed run is dropped; the Mistral call has a 20s timeout so a hung request can't linger. Error tracking is deferred to FreiFahren/FreiFahren#689.
* **Transit data** is fetched per message from the backend and built into an in-memory index. Edge caching is intended via a Cloudflare cache rule on `/v0/transit/*` (documented in the README, including the per-origin CORS caveat).
* `POST /report` keeps `X-Password` auth and forwards app reports into the chat with the deep link + utm params.
* **City-agnostic:** all Berlin/German specifics live only in `config.ts`.

## Tests

Ported the four Python suites to Vitest (`@cloudflare/vitest-pool-workers`): spam, resolution, inbound (webhook filter + pipeline), and forwarding — 53 tests. `bun run typecheck` + `bun run test` are green.

## CI/CD

* `telegram-worker-ci.yml` — typecheck + test on PRs.
* `telegram-worker-deploy.yml` — deploy to Cloudflare on push to `main`, **gated behind the** `TELEGRAM_WORKER_ENABLED` **repo variable** so merging never deploys against an unconfigured Worker.

## Follow-ups before this goes live (see README)

* Set secrets (`MISTRAL_API_KEY`, `TELEGRAM_BOT_TOKEN`, `REPORT_PASSWORD`, `TELEGRAM_WEBHOOK_SECRET`) and `TELEGRAM_REPORT_CHAT_ID`, then set `TELEGRAM_WORKER_ENABLED`.
* `setWebhook` to the worker, repoint the backend's report-forwarding URL, stop the Python poller.
* Add the `/v0/transit/*` cache rule.
* Wire error tracking (FreiFahren/FreiFahren#689).
* Remove `packages/telegram_bot` once parity is confirmed.