### PR TITLE
feat: make report form selection states clearer and consistent

### DIFF
--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -82,7 +82,8 @@ function LinePicker() {
           selectLine(isSelected ? null : line.name);
         }}
         className={cn(
-          'shrink-0 rounded-sm transition-opacity outline-none focus-visible:ring-2 focus-visible:ring-white/50',
+          'shrink-0 rounded-sm outline-none transition-all focus-visible:ring-2 focus-visible:ring-white/50',
+          isSelected && 'ring-2 ring-white',
           lineName && !isSelected && 'opacity-40',
         )}
       >
@@ -127,7 +128,7 @@ function LinePicker() {
       {stationId ? (
         <div className="flex flex-wrap gap-2">{chips}</div>
       ) : (
-        <div className="-mx-4 overflow-x-auto px-4 pb-1">
+        <div className="-mx-4 overflow-x-auto px-4 py-1.5">
           <div className="flex w-max gap-2">{chips}</div>
         </div>
       )}
@@ -196,7 +197,7 @@ function StationPicker() {
       </div>
 
       {stationId ? (
-        <div className="bg-muted flex items-center rounded-md px-3 py-2.5 text-sm font-semibold">
+        <div className="bg-muted flex items-center rounded-md px-3 py-2.5 text-sm ring-2 ring-white">
           {visibleStations[0]?.name}
         </div>
       ) : (
@@ -266,8 +267,9 @@ function DirectionPicker() {
                   selectDirection(isSelected ? null : station.id);
                 }}
                 className={cn(
-                  'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm outline-none',
-                  isSelected && 'bg-muted font-semibold',
+                  'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm outline-none transition-opacity',
+                  isSelected && 'bg-muted ring-2 ring-white',
+                  directionStationId && !isSelected && 'opacity-40',
                 )}
               >
                 <ChevronRight className="text-muted-foreground size-5 shrink-0" />

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -82,7 +82,7 @@ function LinePicker() {
           selectLine(isSelected ? null : line.name);
         }}
         className={cn(
-          'shrink-0 rounded-sm outline-none transition-all focus-visible:ring-2 focus-visible:ring-white/50',
+          'shrink-0 rounded-sm transition-all outline-none focus-visible:ring-2 focus-visible:ring-white/50',
           isSelected && 'ring-2 ring-white',
           lineName && !isSelected && 'opacity-40',
         )}
@@ -267,7 +267,7 @@ function DirectionPicker() {
                   selectDirection(isSelected ? null : station.id);
                 }}
                 className={cn(
-                  'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm outline-none transition-opacity',
+                  'hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm transition-opacity outline-none',
                   isSelected && 'bg-muted ring-2 ring-white',
                   directionStationId && !isSelected && 'opacity-40',
                 )}


### PR DESCRIPTION
## What

Gives the **line**, **station**, and **direction** pickers in the report form one consistent selected-state treatment:

- Selected item gets a solid white ring (`ring-2 ring-white`).
- The other options fade to `opacity-40`.
- Removed the bold-only highlight so all three pickers speak the same selection language.

## Why

Previously the selected line was only signalled by dimming the *other* chips, with no affirmative cue on the selected one — it wasn't obvious a line had been picked. The station and direction pickers used a different idiom (`bg-muted` / bold), so the three steps didn't read consistently. A shared white-ring + fade treatment makes the active choice unambiguous at every step.

## Notes

- The line chip row gained a little vertical padding so the ring isn't clipped by the horizontal scroller.