### PR TITLE
feat: add Sentry observability to the telegram-worker

### DIFF
--- a/packages/telegram-worker/bun.lock
+++ b/packages/telegram-worker/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "telegram-worker",
       "dependencies": {
+        "@sentry/cloudflare": "^10.62.0",
         "zod": "^3.25.0",
       },
       "devDependencies": {
@@ -147,6 +148,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
@@ -202,6 +205,10 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA=="],
+
+    "@sentry/cloudflare": ["@sentry/cloudflare@10.62.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@sentry/core": "10.62.0" }, "peerDependencies": { "@cloudflare/workers-types": "^4.x" }, "optionalPeers": ["@cloudflare/workers-types"] }, "sha512-oHDpXXiO3XpBO2cHiTRQpSrtQOQrsU9JsO3TZ6ukdd24IUE6Tkc3l7hWdwzKqId3nTWP1Ef0Fr+offsrEGJ6UA=="],
+
+    "@sentry/core": ["@sentry/core@10.62.0", "", {}, "sha512-tV69fMg2sS5DUFmQSnS7Jd5qJAp0izxwcsvBVz2ieTM9VMRi99IfOSYW9UYr3p1yfuksk41kefN5PEbeedUE+A=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 

--- a/packages/telegram-worker/package.json
+++ b/packages/telegram-worker/package.json
@@ -11,6 +11,7 @@
     "eval": "bun run evals/run.ts"
   },
   "dependencies": {
+    "@sentry/cloudflare": "^10.62.0",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/telegram-worker/src/forwarding.ts
+++ b/packages/telegram-worker/src/forwarding.ts
@@ -131,6 +131,7 @@ export async function handleReportForward(request: Request, env: Env): Promise<R
     const cfg = readConfig(env)
 
     if (request.headers.get('X-Password') !== cfg.reportPassword) {
+        console.warn('Report forward rejected: bad password')
         return json({ error: 'unauthorized' }, 401)
     }
 
@@ -170,5 +171,6 @@ export async function handleReportForward(request: Request, env: Env): Promise<R
         return json({ error: 'telegram_send_failed' }, 502)
     }
 
+    console.info('Forwarded app report to Telegram', { stationId: report.stationId })
     return json({ status: 'success' })
 }

--- a/packages/telegram-worker/src/index.ts
+++ b/packages/telegram-worker/src/index.ts
@@ -1,21 +1,33 @@
+import { withSentry, consoleLoggingIntegration } from '@sentry/cloudflare'
 import type { Env } from './types'
 import { handleWebhook } from './webhook'
 import { handleReportForward } from './forwarding'
 
-export default {
-    async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-        const url = new URL(request.url)
+// withSentry wraps the handler: unhandled errors in fetch are captured automatically,
+// console.* is forwarded to Sentry Logs, and Sentry.captureException works inside
+// ctx.waitUntil (the SDK binds the client via AsyncLocalStorage).
+export default withSentry(
+    (env: Env) => ({
+        dsn: env.SENTRY_DSN,
+        enableLogs: true,
+        integrations: [consoleLoggingIntegration({ levels: ['info', 'warn', 'error'] })],
+        tracesSampleRate: 1.0,
+    }),
+    {
+        async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+            const url = new URL(request.url)
 
-        if (request.method === 'POST' && url.pathname === '/telegram/webhook') {
-            return handleWebhook(request, env, ctx)
-        }
-        if (request.method === 'POST' && url.pathname === '/report') {
-            return handleReportForward(request, env)
-        }
-        if (request.method === 'GET' && url.pathname === '/health') {
-            return new Response('ok', { status: 200 })
-        }
+            if (request.method === 'POST' && url.pathname === '/telegram/webhook') {
+                return handleWebhook(request, env, ctx)
+            }
+            if (request.method === 'POST' && url.pathname === '/report') {
+                return handleReportForward(request, env)
+            }
+            if (request.method === 'GET' && url.pathname === '/health') {
+                return new Response('ok', { status: 200 })
+            }
 
-        return new Response('not found', { status: 404 })
-    },
-} satisfies ExportedHandler<Env>
+            return new Response('not found', { status: 404 })
+        },
+    } satisfies ExportedHandler<Env>,
+)

--- a/packages/telegram-worker/src/observability.ts
+++ b/packages/telegram-worker/src/observability.ts
@@ -1,9 +1,11 @@
+import { captureException } from '@sentry/cloudflare'
+
 // Single seam for error reporting. With no queue/retry, a failed pipeline run drops the
-// message — for now we only log to the live tail.
-//
-// TODO(#689): wire real error tracking + alerting on error rates.
-// https://github.com/FreiFahren/FreiFahren/issues/689
+// message, so we capture it as a Sentry issue (alert on the error rate) and also log to
+// the live tail. captureException works here even under ctx.waitUntil — withSentry binds
+// the client via AsyncLocalStorage.
 export function reportError(message: string, err: unknown, extra?: Record<string, unknown>): void {
+    captureException(err, { extra: { message, ...extra } })
     console.error(message, {
         error: err instanceof Error ? (err.stack ?? err.message) : String(err),
         ...extra,

--- a/packages/telegram-worker/src/types.ts
+++ b/packages/telegram-worker/src/types.ts
@@ -7,6 +7,7 @@ export interface Env {
     CITY_NAME: string
     MISTRAL_MODEL: string
     TELEGRAM_REPORT_CHAT_ID: string
+    SENTRY_DSN: string
 
     // Secrets (wrangler secret put)
     MISTRAL_API_KEY: string

--- a/packages/telegram-worker/src/webhook.ts
+++ b/packages/telegram-worker/src/webhook.ts
@@ -55,6 +55,7 @@ export async function handleWebhook(
     process: Processor = processMessage,
 ): Promise<Response> {
     if (request.headers.get(WEBHOOK_SECRET_HEADER) !== env.TELEGRAM_WEBHOOK_SECRET) {
+        console.warn('Webhook rejected: bad secret token')
         return new Response('unauthorized', { status: 401 })
     }
 
@@ -62,6 +63,7 @@ export async function handleWebhook(
     try {
         update = TelegramUpdate.parse(await request.json())
     } catch {
+        console.warn('Webhook ignored: unparseable update body')
         return new Response('ok', { status: 200 })
     }
 

--- a/packages/telegram-worker/wrangler.jsonc
+++ b/packages/telegram-worker/wrangler.jsonc
@@ -3,6 +3,8 @@
     "name": "telegram-worker",
     "main": "src/index.ts",
     "compatibility_date": "2025-10-11",
+    // @sentry/cloudflare needs the AsyncLocalStorage API.
+    "compatibility_flags": ["nodejs_compat"],
     "vars": {
         // Backend that serves /v0/transit/* and accepts POST /v0/reports.
         "BACKEND_URL": "https://api.freifahren.org",
@@ -11,10 +13,11 @@
         "MISTRAL_MODEL": "mistral-small-latest",
         // Group chat the bot listens to and forwards app reports into. Negative for groups.
         "TELEGRAM_REPORT_CHAT_ID": "-1001370021231",
+        "SENTRY_DSN": "https://9d9ac700f1213d4db367b557167a0594@o4508609338867712.ingest.de.sentry.io/4511633367564368",
     },
     // Messages are processed in the background (ctx.waitUntil) with no queue/retry; failed
-    // runs are dropped (error tracking is TODO, FreiFahren/FreiFahren#689). Transit data is
-    // fetched per message from BACKEND_URL; cache it with a Cloudflare cache rule on
-    // /v0/transit/*. Secrets (set via `wrangler secret put`): MISTRAL_API_KEY,
+    // runs are dropped but captured in Sentry (see src/observability.ts) — alert on the
+    // error rate there. Transit data is fetched per message from BACKEND_URL; cache it with
+    // a Cloudflare cache rule on /v0/transit/*. Secrets (set via `wrangler secret put`): MISTRAL_API_KEY,
     // TELEGRAM_BOT_TOKEN, REPORT_PASSWORD, TELEGRAM_WEBHOOK_SECRET.
 }


### PR DESCRIPTION
## What

Adds full observability (errors + logs + tracing) to the `telegram-worker` via a dedicated Sentry project (`telegram-worker` in the `freifahren-web` org, separate from `web-app`). Closes #689.

## Changes

- **`@sentry/cloudflare`** installed; `withSentry` wraps the worker handler in `index.ts`.
  - Unhandled errors in `fetch` are captured automatically.
  - `consoleLoggingIntegration` forwards `console.info/warn/error` to Sentry Logs (`enableLogs: true`).
  - `tracesSampleRate: 1.0` — outbound `fetch` spans (Mistral, backend, Telegram) show up as traces.
- **`observability.ts`** — `reportError` now calls `captureException`, so the three caught failure paths (pipeline run, transit load, Telegram forward) become Sentry **issues** to alert on. Still logs to the live tail.
- **`nodejs_compat`** flag + `SENTRY_DSN` var added to `wrangler.jsonc` (a DSN is not a secret, safe to commit).
- A few missing high-signal logs: auth rejections on the webhook (bad secret) and `/report` (bad password) endpoints, unparseable webhook bodies, and a success log on the report forward.


## Testing

`bun run typecheck` clean, all 53 tests pass.