### PR TITLE
feat: trace report submissions in the frontend Sentry

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/rea
 import type { TFunction } from 'i18next';
 import { useEffect, useState } from 'react';
 
+import { traceAction } from '@/lib/error-monitoring';
 import { requireEnv } from '@/lib/utils';
 
 import { fetchJson, type Line, useLines } from './transit';
@@ -226,21 +227,22 @@ export function useSubmitReport() {
   const { data: lines } = useLines();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: SubmitReportInput): Promise<SubmitReportResponse> => {
-      const lineId = resolveLineId(input, lines);
-      const response = await fetch(`${API_URL}/v0/reports`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'ff-platform': 'web' },
-        body: JSON.stringify({
-          stationId: input.stationId,
-          lineId,
-          directionId: input.directionStationId ?? null,
-          source: 'web_app',
-        }),
-      });
-      if (!response.ok) throw new Error(`Report submission failed: ${response.status}`);
-      return response.json();
-    },
+    mutationFn: (input: SubmitReportInput): Promise<SubmitReportResponse> =>
+      traceAction('Submit Report', async () => {
+        const lineId = resolveLineId(input, lines);
+        const response = await fetch(`${API_URL}/v0/reports`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'ff-platform': 'web' },
+          body: JSON.stringify({
+            stationId: input.stationId,
+            lineId,
+            directionId: input.directionStationId ?? null,
+            source: 'web_app',
+          }),
+        });
+        if (!response.ok) throw new Error(`Report submission failed: ${response.status}`);
+        return response.json();
+      }),
     // The backend commits the report and clears its reports/risk caches before
     // returning 200, so by the time we get here the new data is already live —
     // no wait/race-condition guard is needed. Refetch both so the map and risk

--- a/packages/frontend-next/src/lib/error-monitoring.ts
+++ b/packages/frontend-next/src/lib/error-monitoring.ts
@@ -31,11 +31,11 @@ export function initErrorMonitoring(): void {
     initialScope: { tags: { platform: Capacitor.getPlatform() } },
     // No IP address, cookies, or request payloads — see the file header.
     sendDefaultPii: false,
-    // Performance: capture page-load/navigation timing and Web Vitals (LCP, INP, CLS, ...) on a 10%
+    // Performance: capture page-load/navigation timing and Web Vitals (LCP, INP, CLS, ...) on a 50%
     // sample. These spans carry only in-app route + own-API URLs (no personal data); disclosed in
     // the privacy policy alongside error diagnostics.
     integrations: [SentryReact.browserTracingIntegration()],
-    tracesSampleRate: 0.1,
+    tracesSampler: (samplingContext) => (samplingContext.name === 'Submit Report' ? 1.0 : 0.5),
     // Same-origin only: never attach sentry-trace/baggage headers to the cross-origin API (its CORS
     // config doesn't allow them, and we don't do distributed tracing into the backend).
     tracePropagationTargets: ['localhost', /^\//],
@@ -52,4 +52,13 @@ export function initErrorMonitoring(): void {
   }
 
   SentryReact.init(options);
+}
+
+// Wrap a user action so the API calls inside it are recorded as a trace with timing. The
+// auto-instrumented fetch spans only attach to an active root span (pageload/navigation), which
+// has usually closed by the time the user triggers an action — so without this the request is
+// never captured. The action name doubles as the tracesSampler key (see init). When Sentry is
+// uninitialized (local dev / Do Not Track) startSpan still runs the callback, so this is a no-op.
+export function traceAction<T>(name: string, callback: () => Promise<T>): Promise<T> {
+  return SentryReact.startSpan({ name, op: 'ui.action.submit' }, callback);
 }


### PR DESCRIPTION
## What

Makes the report submission show up in the `web-app` Sentry project with its real latency. Today it's invisible — the auto-instrumented `fetch` span only attaches to an active pageload/navigation trace, which has long closed by the time a user clicks submit. So the slowest, most user-facing request (often 3s+, dominated by the backend's synchronous Telegram forward) has zero trace data.

## Changes

- **`lib/error-monitoring.ts`** — added a provider-agnostic `traceAction(name, cb)` wrapper around `Sentry.startSpan`, keeping the rule that the rest of the app never imports the SDK directly. No-op when Sentry is uninitialized (local dev / Do Not Track).
- **`api/reports.ts`** — wrapped the `useSubmitReport` mutation in `traceAction('Submit Report', …)`, so the submission is recorded as a root span with the `POST /v0/reports` fetch as a timed child.
- **Sampling** — replaced flat `tracesSampleRate: 0.1` with a `tracesSampler`: 50% of general traffic, but **always** trace `Submit Report` (low-volume; a flat sample would mostly miss it). We're at 124K/50M spans this cycle, so the bump is immaterial.

## Privacy

Checked against the privacy policy §12 ("Error Monitoring and Performance Diagnostics"): performance metrics are collected "on a sampled basis" and "reference only in-app screen paths and our own API endpoints, and no IP addresses." This change stays inside that — `/v0/reports` is our own endpoint, `sendDefaultPii: false` still excludes IPs, and Sentry's fetch instrumentation captures method/URL/status/timing only (no request body). No policy wording change needed.

## Testing

`tsc -b`, `eslint`, and `prettier --check` all clean on the changed files.

## Follow-up

To get the **backend** side of that 3s (where the time is actually spent), the hono-backend needs its own Sentry project + the fire-and-forget `notifyTelegram` refactor — tracked separately.