### PR TITLE
fix: stop logging Telegram message text to Sentry

### DIFF
--- a/packages/telegram-worker/src/pipeline.ts
+++ b/packages/telegram-worker/src/pipeline.ts
@@ -19,7 +19,9 @@ import { postReport, reportIdentifiers } from './reporting'
  */
 export async function processMessage(text: string, env: Env): Promise<void> {
     if (isSpam(text)) {
-        console.info('Skipped as spam:', text.slice(0, 80))
+        // Never log the message text — the privacy policy promises we don't store it, and logs are
+        // persisted in Sentry. Length is a non-identifying signal that's still useful for triage.
+        console.info('Skipped as spam', { length: text.length })
         return
     }
 

--- a/packages/telegram-worker/src/webhook.ts
+++ b/packages/telegram-worker/src/webhook.ts
@@ -70,8 +70,10 @@ export async function handleWebhook(
     const text = acceptUpdate(update, env.TELEGRAM_REPORT_CHAT_ID)
     if (text) {
         ctx.waitUntil(
+            // Pass the length, not the text: the privacy policy promises we don't store message
+            // content, and reportError persists to Sentry. Length still helps correlate failures.
             process(text, env).catch((err) =>
-                reportError('telegram pipeline failed', err, { text: text.slice(0, 80) }),
+                reportError('telegram pipeline failed', err, { length: text.length }),
             ),
         )
     }


### PR DESCRIPTION
## What

Removes raw Telegram message text from the worker's logs. Two sites passed the message content into logs:

- `pipeline.ts` — `Skipped as spam: <message text>`
- `webhook.ts` — pipeline-failure `reportError(..., { text: text.slice(0, 80) })`

Both now log `{ length }` instead of the text.

## Why

Until we enabled `enableLogs` (#698), these were ephemeral `wrangler tail` lines. Now they're persisted in **Sentry Logs for 30 days** — and the message text is user content. The privacy policy's Telegram-bot section states *"Messages are not stored… FreiFahren does not store the message texts."* Logging the raw text contradicts that. Message **length** is a non-identifying signal that still helps triage (e.g. very long messages correlating with timeouts).

The extracted station/line/direction logs (`extractionToLog`) are unaffected — the policy explicitly permits storing that derived data.

## Note

Message text already captured in Sentry Logs before this deploy will age out at the 30-day retention boundary; can be purged sooner from the Sentry project if needed.

## Testing

`tsc --noEmit` clean, all 53 tests pass.