### PR TITLE
fix: swallow PostHog load failures to stop unhandled rejections

### DIFF
--- a/packages/frontend-next/src/lib/posthog-client.ts
+++ b/packages/frontend-next/src/lib/posthog-client.ts
@@ -65,5 +65,12 @@ export function loadPostHog(): Promise<void> {
     for (const op of queue) op(posthog);
     queue.length = 0;
   });
+  // Analytics is non-critical: a content blocker or a stale chunk can make the dynamic import
+  // resolve empty (destructuring `default` then throws) or reject outright. Swallow it and disable
+  // capture so it doesn't surface as an unhandled rejection.
+  loadPromise = loadPromise.catch(() => {
+    disabled = true;
+    queue.length = 0;
+  });
   return loadPromise;
 }


### PR DESCRIPTION
## What

Add a `.catch` to the lazy PostHog load chain in `posthog-client.ts` so a failed SDK load disables analytics instead of throwing.

## Why

Two Sentry issues (`WEB-APP-D`, `WEB-APP-H`) are the same bug in different browsers:

- **WEB-APP-D** (Safari): `Cannot destructure property 'default' from null or undefined value`
- **WEB-APP-H** (Firefox): `(destructured parameter) is undefined`

Both originate at the same line — `import('posthog-js').then(({ default: posthog }) => …)`. On mobile browsers a content/ad blocker (or a stale chunk) can make the dynamic import resolve to an empty/nullish value, so destructuring `default` throws — or the import rejects outright. Neither the `.then` in `loadPostHog` nor the `void loadPostHog().then(...)` trigger in `main.tsx` had a `.catch`, so it surfaced as an **unhandled promise rejection** and was reported to Sentry.

Analytics is non-critical, so the load failure is now swallowed and capture is disabled (mirroring the existing no-API-key path).

## Fixes

`Fixes WEB-APP-D`
`Fixes WEB-APP-H`