### PR TITLE
fix: open the Postgres connection per request to satisfy the Workers I/O model

### DIFF
--- a/docs/adr/0006-api-on-cloudflare-worker-hyperdrive.md
+++ b/docs/adr/0006-api-on-cloudflare-worker-hyperdrive.md
@@ -39,9 +39,10 @@ db:purge-cache`. Postgres is kept for now; **D1 is a deliberate later step**.
 
 ## Consequences
 
-- The Worker is stateless: env/db/services are built per request from `c.env` (the db client is
-  memoized per isolate). No import-time env access, and no in-process caches — the 1-minute reports
-  cache was dropped.
+- The Worker is stateless: env/db/services are built per request from `c.env`. A fresh Postgres
+  connection is opened per request and closed after the response — Workers forbid reusing an I/O
+  object (a `postgres.js` client) across requests, and Hyperdrive pools the upstream connections.
+  No import-time env access, and no in-process caches — the 1-minute reports cache was dropped.
 - **Hyperdrive TLS constraint:** Hyperdrive's TLS stack (BoringSSL) will not negotiate Coolify's
   default ECDSA **P-521** Postgres certificate (`SSLV3_ALERT_HANDSHAKE_FAILURE`). The database must
   serve an **RSA** certificate. Coolify's "Regenerate SSL Certificates" button or a DB re-deploy

--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono'
+import { Context, Hono } from 'hono'
 
 import { createLogger, Logger, LogLevel } from './common/logger'
 import { createDb, DbConnection } from './db'
@@ -67,30 +67,29 @@ const resolveConnectionString = (env: Bindings): string => {
     return connectionString
 }
 
-const createServices = (db: DbConnection, config: AppConfig): Services => {
+const applyServices = (c: Context<Env>, db: DbConnection, config: AppConfig) => {
     const transitNetworkDataService = new TransitNetworkDataService(db)
     const reportsService = new ReportsService(db, transitNetworkDataService, {
         nodeEnv: config.nodeEnv,
         telegramWorkerUrl: config.telegramWorkerUrl,
         reportPassword: config.reportPassword,
     })
-    const riskService = new RiskService(reportsService, transitNetworkDataService)
 
-    return { transitNetworkDataService, reportsService, riskService }
+    c.set('config', config)
+    c.set('reportsService', reportsService)
+    c.set('riskService', new RiskService(reportsService, transitNetworkDataService))
+    c.set('transitNetworkDataService', transitNetworkDataService)
 }
 
-// Memoize the db client (the expensive part) per connection string. Services are built per
-// Request instead, so config like NODE_ENV stays current and no request state is shared.
-let cachedDb: { key: string; db: DbConnection } | null = null
+// Reused connection for non-Workers runtimes (tests, seed/CLI scripts), where there is no
+// cross-request I/O restriction — opening one per request would exhaust the connection pool.
+let nodeDb: { key: string; db: DbConnection } | null = null
 
-const getDb = (env: Bindings): DbConnection => {
-    const key = resolveConnectionString(env)
-    if (cachedDb && cachedDb.key === key) {
-        return cachedDb.db
+const getNodeDb = (key: string): DbConnection => {
+    if (!nodeDb || nodeDb.key !== key) {
+        nodeDb = { key, db: createDb(key).db }
     }
-    const db = createDb(key)
-    cachedDb = { key, db }
-    return db
+    return nodeDb.db
 }
 
 export const registerContext = (app: Hono<Env>) => {
@@ -99,13 +98,30 @@ export const registerContext = (app: Hono<Env>) => {
         c.set('logger', createLogger(c.env.LOG_LEVEL ?? 'info'))
 
         const config = resolveConfig(c.env)
-        const services = createServices(getDb(c.env), config)
+        const key = resolveConnectionString(c.env)
 
-        c.set('config', config)
-        c.set('reportsService', services.reportsService)
-        c.set('riskService', services.riskService)
-        c.set('transitNetworkDataService', services.transitNetworkDataService)
+        // The "no I/O across requests" limit is Workers-only. Off Workers (no execution context)
+        // reuse one connection; on Workers a postgres.js client is bound to the request that opened
+        // it, so build it per request and close it after the response (Hyperdrive pools upstream).
+        let executionCtx: { waitUntil: (promise: Promise<unknown>) => void } | undefined
+        try {
+            executionCtx = c.executionCtx
+        } catch {
+            executionCtx = undefined
+        }
 
-        await next()
+        if (executionCtx === undefined) {
+            applyServices(c, getNodeDb(key), config)
+            await next()
+            return
+        }
+
+        const { db, client } = createDb(key)
+        applyServices(c, db, config)
+        try {
+            await next()
+        } finally {
+            executionCtx.waitUntil(client.end({ timeout: 5 }))
+        }
     })
 }

--- a/packages/api-worker/src/db/index.ts
+++ b/packages/api-worker/src/db/index.ts
@@ -8,6 +8,10 @@ import { stations } from './schema/stations'
 
 // Hyperdrive pools in transaction mode, which has no named prepared statements — hence `prepare: false`.
 // Disabling `fetch_types` skips the first-use round-trip postgres.js makes to introspect column types.
+//
+// Returns the raw client alongside the Drizzle instance so the caller can close it. On Workers a
+// postgres.js client is an I/O object bound to the request that created it, so it must be built and
+// closed per request — Hyperdrive does the cross-request pooling upstream.
 export const createDb = (connectionString: string) => {
     const client = postgres(connectionString, {
         prepare: false,
@@ -16,13 +20,15 @@ export const createDb = (connectionString: string) => {
         connect_timeout: 10,
     })
 
-    return drizzle(client, {
+    const db = drizzle(client, {
         schema: { reports, stations, lines, lineStations, segments },
         casing: 'snake_case',
     })
+
+    return { db, client }
 }
 
-export type DbConnection = ReturnType<typeof createDb>
+export type DbConnection = ReturnType<typeof createDb>['db']
 
 export * from './schema/reports'
 export * from './schema/lines'

--- a/packages/api-worker/src/db/seed/index.ts
+++ b/packages/api-worker/src/db/seed/index.ts
@@ -8,7 +8,7 @@ import { seedBaseData } from './seed'
 const seed = async () => {
     logger.info('Starting seed...')
 
-    const db = createDb(process.env.DATABASE_URL!)
+    const { db } = createDb(process.env.DATABASE_URL!)
     await seedBaseData(db)
 
     logger.info('Seed completed successfully!')

--- a/packages/api-worker/tests/preload.ts
+++ b/packages/api-worker/tests/preload.ts
@@ -9,7 +9,7 @@ const [{ migrate }, { createDb }, { seedBaseData }] = await Promise.all([
     import('../src/db/seed/seed'),
 ])
 
-const db = createDb(process.env.DATABASE_URL!)
+const { db } = createDb(process.env.DATABASE_URL!)
 
 await migrate(db, { migrationsFolder: './drizzle' })
 

--- a/packages/api-worker/tests/test-db.ts
+++ b/packages/api-worker/tests/test-db.ts
@@ -1,6 +1,6 @@
 import { createDb } from '../src/db'
 
 // Db client for direct setup/teardown and assertions in tests.
-export const db = createDb(process.env.DATABASE_URL!)
+export const { db } = createDb(process.env.DATABASE_URL!)
 
 export * from '../src/db'


### PR DESCRIPTION
## The bug

After deploy, ~50% of requests to **every** DB-backed endpoint (`/v0/transit/*`, `/v0/reports`, `/v0/risk`) returned 500. Sentry logs show the cause:

> `Cannot perform I/O on behalf of a different request. I/O objects … created in the context of one request handler cannot be accessed from a different request's handler.`

`app-env.ts` memoized the `postgres.js` client **per isolate** (`cachedDb`) and reused it across requests. On Cloudflare Workers a connection is an I/O object bound to the request that opened it — the request that creates the client succeeds, every later request on that isolate reuses it and is killed. Hence the intermittent ~50% failure.

## The fix

Build the `postgres.js` client **per request** and close it after the response (`ctx.waitUntil(client.end())`, or inline when there's no execution context, e.g. tests). Hyperdrive already pools the upstream Postgres connections, so per-request driver clients are the intended pattern — the connection to the local Hyperdrive socket is cheap.

- `createDb` now returns `{ db, client }` so the caller can close the connection.
- `registerContext` opens/closes the connection per request; removed the `cachedDb` per-isolate memo.
- Seed/preload/test callers updated to destructure `{ db }`.
- ADR-0006 consequence corrected (per-request connection, not per-isolate memo).

## Verification

Locally: 89/89 tests pass, lint/prettier clean, worker bundles. This must merge to redeploy; after deploy I'll re-run the failure-rate check (was 11/20, 10/20, 10/20) to confirm it's 0 before cutover.