### PR TITLE
feat: route api.freifahren.org to the Worker

### DIFF
--- a/packages/api-worker/wrangler.jsonc
+++ b/packages/api-worker/wrangler.jsonc
@@ -5,6 +5,7 @@
     "compatibility_date": "2025-10-11",
     "compatibility_flags": ["nodejs_compat"],
     "workers_dev": true,
+    "routes": [{ "pattern": "api.freifahren.org/*", "zone_name": "freifahren.org" }],
     "hyperdrive": [
         {
             "binding": "HYPERDRIVE",


### PR DESCRIPTION
## Cutover

Adds the Workers route so **`api.freifahren.org` is served by `api-worker`** instead of the Coolify/Hetzner origin:

```jsonc
"routes": [{ "pattern": "api.freifahren.org/*", "zone_name": "freifahren.org" }],
```

`api.freifahren.org` is proxied, so the Workers route takes precedence over the origin. **Merging this redeploys and flips live production traffic.**

## Pre-cutover verification (against `api-worker.freifahren.workers.dev`)

- **0 / 100** failures (sequential) and **0 / 40** (concurrent) across `/v0/transit/*`, `/v0/reports`, `/v0/risk` — the per-request connection fix (#704) is confirmed.
- **Data parity with the current origin:** stations 639=639, lines 55=55, segments 1410=1410; risk matches.
- **Sentry:** no errors since the #704 deploy.

Not exercised pre-cutover: `POST /v0/reports` (write path) — config is wired (`REPORT_PASSWORD`, `TELEGRAM_WORKER_URL`); it'll first see real traffic after cutover.

## Rollback

Remove this route and redeploy, or delete the route in the Cloudflare dashboard for an instant revert — traffic falls back to the Hetzner origin (still running). `telegram-worker`'s `BACKEND_URL` and the frontend API URL are unchanged.