### PR TITLE
Track app version (native + web) in PostHog via app_version super property

### DIFF
--- a/packages/frontend-next/src/lib/posthog-client.ts
+++ b/packages/frontend-next/src/lib/posthog-client.ts
@@ -31,6 +31,23 @@ export function enqueuePostHog(op: PostHogOp): void {
   queue.push(op);
 }
 
+// Register the app/bundle version super properties. On native the store binary version comes from
+// the already-present @capacitor/app plugin (a pure bundle change, ships via Capgo OTA); web has
+// only the bundle build. Failures are non-critical and stay silent so analytics never breaks boot.
+async function registerVersion(posthog: PostHog): Promise<void> {
+  try {
+    if (Capacitor.isNativePlatform()) {
+      const { App } = await import('@capacitor/app');
+      const { version, build } = await App.getInfo();
+      posthog.register({ app_version: version, app_build: build, bundle_build: __BUILD_ID__ });
+    } else {
+      posthog.register({ app_version: __BUILD_ID__, bundle_build: __BUILD_ID__ });
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
 export function loadPostHog(): Promise<void> {
   if (loadPromise) return loadPromise;
 
@@ -64,6 +81,11 @@ export function loadPostHog(): Promise<void> {
     instance = posthog;
     for (const op of queue) op(posthog);
     queue.length = 0;
+    // Stamp the version so insights can break down adoption by app_version x platform. On native
+    // App.getInfo() reports the installed store binary (app_version/app_build, only changes on a
+    // store update), kept separate from the web bundle (bundle_build, moves with every deploy and
+    // Capgo OTA push). This trails posthog.register because it awaits a native plugin call.
+    void registerVersion(posthog);
   });
   // Analytics is non-critical: a content blocker or a stale chunk can make the dynamic import
   // resolve empty (destructuring `default` then throws) or reject outright. Swallow it and disable

--- a/packages/frontend-next/src/lib/posthog-client.ts
+++ b/packages/frontend-next/src/lib/posthog-client.ts
@@ -31,9 +31,7 @@ export function enqueuePostHog(op: PostHogOp): void {
   queue.push(op);
 }
 
-// Register the app/bundle version super properties. On native the store binary version comes from
-// the already-present @capacitor/app plugin (a pure bundle change, ships via Capgo OTA); web has
-// only the bundle build. Failures are non-critical and stay silent so analytics never breaks boot.
+// On native, app_version/app_build track the store binary; bundle_build tracks the OTA bundle.
 async function registerVersion(posthog: PostHog): Promise<void> {
   try {
     if (Capacitor.isNativePlatform()) {
@@ -81,10 +79,7 @@ export function loadPostHog(): Promise<void> {
     instance = posthog;
     for (const op of queue) op(posthog);
     queue.length = 0;
-    // Stamp the version so insights can break down adoption by app_version x platform. On native
-    // App.getInfo() reports the installed store binary (app_version/app_build, only changes on a
-    // store update), kept separate from the web bundle (bundle_build, moves with every deploy and
-    // Capgo OTA push). This trails posthog.register because it awaits a native plugin call.
+    // Trails the register above because it awaits a native plugin call.
     void registerVersion(posthog);
   });
   // Analytics is non-critical: a content blocker or a stale chunk can make the dynamic import


### PR DESCRIPTION
## Describe the issue:

We can't tell which app version users are on in PostHog. The app stamps `platform` (web/ios) and `is_native` super properties on every event, but no version property. The build id (`__BUILD_ID__`) only reaches Sentry (as `release`) and feedback-survey events.

There are two distinct "versions" we want to track:
- **Native binary version** — Capacitor/App Store version, only changes on a store update.
- **Web bundle build** — `__BUILD_ID__`, changes on every deploy and every Capgo OTA push.

Closes FRE-678 / #707

## Explain how you solved the issue:

Added a `registerVersion()` helper in `packages/frontend-next/src/lib/posthog-client.ts` that registers version super properties right after the existing `register({ platform, is_native })`:

- **Native**: dynamically imports `@capacitor/app` and calls `App.getInfo()`, registering `app_version` + `app_build` (the installed store binary) and `bundle_build` (`__BUILD_ID__`, the OTA bundle).
- **Web**: registers `app_version` and `bundle_build`, both set to `__BUILD_ID__`.

`App.getInfo()` returns the store binary version, not the OTA bundle — so `app_version`/`app_build` stay pinned to the installed binary while `bundle_build` moves with each deploy/OTA push. That's the desired separation, and any insight can now break down by `app_version` × `platform`.

## Additional notes or considerations:

- **Ships via Capgo OTA, no App Store review.** `@capacitor/app` is already compiled into the iOS binary (`ios/App/CapApp-SPM/Package.swift`) and already used at runtime (`native.ts` appStateChange listener). `App.getInfo()` is a new JS call against an already-present native plugin → pure bundle change. The dynamic `import('@capacitor/app')` matches the existing pattern in `native.ts`.
- Registration is non-critical: it runs after the queue flush (it awaits a native plugin call) and stays silent on failure so analytics never breaks boot.
- Typecheck (`tsc -b`), lint (`eslint`), and prettier all pass.

### Follow-up (out of scope for this PR)
- Build a "Version Adoption" PostHog dashboard once the property is flowing.
- Optional: set Sentry `dist: build` to align release health with native build numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnCpMv9yhheZX4HeBKsy1B

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnCpMv9yhheZX4HeBKsy1B)_