### PR TITLE
fix: fail the deploy when the transit cache purge errors

### DIFF
--- a/packages/api-worker/src/db/seed/purge-transit-cache.ts
+++ b/packages/api-worker/src/db/seed/purge-transit-cache.ts
@@ -23,8 +23,10 @@ export const purgeTransitCache = async () => {
 
     if (!response.ok) {
         const body = await response.text()
-        logger.warn({ status: response.status, body }, 'Cloudflare transit cache purge failed')
-        return
+        // Throw rather than warn-and-return: a swallowed failure (e.g. a 401 from a
+        // Token without Cache Purge rights) lets a stale transit response keep serving
+        // For its full 30-day TTL, which silently breaks the risk map after a reseed.
+        throw new Error(`Cloudflare transit cache purge failed (status ${response.status}): ${body}`)
     }
 
     logger.info({ tag: TRANSIT_CACHE_TAG }, 'Cloudflare transit cache purged')


### PR DESCRIPTION
## What

Make `purgeTransitCache()` throw on a non-OK response from the Cloudflare purge API, so a failed purge fails the deploy instead of being swallowed as a warning.

## Why — the risk map went out of sync with reports

After the API moved to a Worker + D1, the risk-coloured line segments on the map stopped matching where reports actually were.

Root cause, traced end to end:

1. `/v0/transit/segments` is cached in the Workers Cache API for 30 days (#708). The live entry was **~2.6 days stale** (`cf-cache-status: HIT`, `age: 226584`) and dated from the **Postgres-era worker**, before the current D1 database even existed.
2. The Postgres→D1 migration (#706) reseeded segments into a fresh D1 table, which handed out **new autoincrement segment IDs** (e.g. U5 went from IDs `285–309` to `1257–1281`; ID `292` now belongs to line `62`, `305` to `M2`).
3. `/v0/risk` computes live against the **new** D1 IDs. The frontend draws geometry from the **stale cached** segments (old IDs) and colours each by `risk[id]` — so line 62's risk gets painted onto U5's geometry. Hence "risk out of sync with reports". `/v0/risk` itself is uncached and correct.
4. The stale cache should have been cleared by the deploy's `db:purge-cache` step — but that step had been returning **`HTTP 401 {"code":10000,"message":"Authentication error"}`** on every run (the API token lacked the zone Cache Purge permission). `purgeTransitCache()` only `logger.warn`'d and returned, so the deploy stayed green while the cache rotted for its full TTL.

The token permission has been fixed separately. This change makes the same class of failure **loud**: a non-OK purge now throws, the `db:purge-cache` entrypoint exits non-zero, and the deploy fails — instead of silently serving stale transit data (and a broken risk map) for up to 30 days.

## Note

A one-time purge of the existing stale `/v0/transit/{segments,lines,stations}` entries is still needed to recover prod immediately; this PR only prevents recurrence.
