### PR TITLE
fix: make browsers revalidate transit responses instead of caching them for 30 days

### DIFF
--- a/packages/api-worker/src/modules/transit/transit-cache-middleware.ts
+++ b/packages/api-worker/src/modules/transit/transit-cache-middleware.ts
@@ -12,7 +12,16 @@ export const VERSIONED_TRANSIT_CACHEABLE_PATHS = [
 ] as const
 
 export const TRANSIT_CACHE_TAG = 'transit-network'
-export const TRANSIT_CACHE_CONTROL = 'public, max-age=2592000, stale-while-revalidate=86400'
+/*
+ * Split TTL: the edge (a shared cache, including the Workers Cache API entry
+ * below) keeps the response for 30 days via s-maxage, but browsers get
+ * max-age=0 + must-revalidate so they always revalidate with an If-None-Match.
+ * On a hit that revalidation is a cheap 304; after a reseed/purge the body's
+ * ETag changes and the browser gets the fresh segments immediately. A single
+ * long max-age would instead let every client serve stale geometry for up to
+ * 30 days after an id-changing reseed, which silently breaks the risk map.
+ */
+export const TRANSIT_CACHE_CONTROL = 'public, max-age=0, s-maxage=2592000, must-revalidate'
 
 export const transitCacheMiddleware: MiddlewareHandler<Env> = async (c, next) => {
     await next()

--- a/packages/api-worker/tests/generalAPI.test.ts
+++ b/packages/api-worker/tests/generalAPI.test.ts
@@ -102,7 +102,10 @@ describe('Transit cache headers', () => {
         const response = await app.request('/v0/transit/stations', undefined, testEnv())
 
         expect(response.status).toBe(200)
-        expect(response.headers.get('Cache-Control')).toContain('max-age=2592000')
+        // Edge keeps the response 30 days (s-maxage) while browsers revalidate (max-age=0).
+        expect(response.headers.get('Cache-Control')).toContain('s-maxage=2592000')
+        expect(response.headers.get('Cache-Control')).toContain('max-age=0')
+        expect(response.headers.get('Cache-Control')).toContain('must-revalidate')
         expect(response.headers.get('Vary')).toContain('Origin')
         expect(response.headers.get('Cache-Tag')).toBe('transit-network')
     })


### PR DESCRIPTION
## What

Split the transit responses' `Cache-Control` so the **edge** keeps the long TTL but **browsers revalidate**:

```
- public, max-age=2592000, stale-while-revalidate=86400
+ public, max-age=0, s-maxage=2592000, must-revalidate
```

`s-maxage` governs shared caches (the Workers Cache API entry → still 30 days); browsers ignore `s-maxage` and obey `max-age=0`, so they send a conditional `If-None-Match` on every load. The edge-cache middleware already answers those with a cheap `304` on a hit, and after a reseed the body's ETag changes so clients pull fresh geometry immediately. No frontend change needed — browser HTTP-cache revalidation is automatic.

## Why

Follow-up to the risk-map incident. The risk-coloured segments stopped matching reports because `/v0/transit/segments` was serving **stale geometry with the old segment ids** while `/v0/risk` computed against the new (reseeded) ids, so risk colours landed on the wrong lines.

The edge cache was purged, but the previous `Cache-Control: max-age=2592000` was also sent to **browsers**, which then cached the geometry on disk for 30 days. A server-side purge can't reach a browser's disk cache, so every existing client would keep rendering the broken map for up to a month after any id-changing reseed.

With this split, an edge purge now actually propagates to clients on their next load (they revalidate and get the fresh ETag/body), while the edge still serves the long-lived cached copy to keep origin/D1 load low.

`max-age=2592000` → `s-maxage=2592000` is the [documented Cloudflare pattern](https://developers.cloudflare.com/cache/concepts/cache-control/) for caching for different durations at the edge vs. in the browser.

## Note

This is forward-looking: clients that already cached the old 30-day response won't revalidate until it expires (or a hard reload). It prevents the next reseed from stranding clients for a month.

## Test

Updated `generalAPI.test.ts` to assert the split directives. `bun test` → 89 pass.
