### PR TITLE
fix: revalidate cached transit data on the client so reseeds propagate

### DIFF
--- a/packages/frontend-next/src/api/transit.ts
+++ b/packages/frontend-next/src/api/transit.ts
@@ -91,16 +91,29 @@ export function resolveStationLineNames(
   return names;
 }
 
-export async function fetchJson<T>(path: string): Promise<T> {
-  const response = await fetch(`${API_URL}${path}`);
+export async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_URL}${path}`, init);
   if (!response.ok) {
     throw new Error(`Request to ${path} failed: ${response.status}`);
   }
   return response.json();
 }
 
+/*
+ * Transit reference data is edge-cached for 30 days, so we must force the
+ * client (browser HTTP cache / native WebView cache) to revalidate rather than
+ * blindly serve its stored copy: an id-changing reseed otherwise leaves a
+ * client painting risk colours onto stale geometry until the cached entry
+ * expires. `no-cache` revalidates with an If-None-Match — a cheap 304 when
+ * unchanged, the fresh body (new ETag) right after a reseed.
+ */
+const REVALIDATE: RequestInit = { cache: 'no-cache' };
+
 export async function fetchStations(): Promise<Stations> {
-  const response = await fetchJson<Record<StationId, StationResponse>>('/v0/transit/stations');
+  const response = await fetchJson<Record<StationId, StationResponse>>(
+    '/v0/transit/stations',
+    REVALIDATE,
+  );
   const stations: Stations = {};
   for (const [id, station] of Object.entries(response)) stations[id] = { ...station, id };
   return stations;
@@ -113,12 +126,12 @@ export const stationsQueryOptions = () => ({
 
 export const linesQueryOptions = () => ({
   queryKey: ['transit', 'lines'] as const,
-  queryFn: () => fetchJson<Line[]>('/v0/transit/lines'),
+  queryFn: () => fetchJson<Line[]>('/v0/transit/lines', REVALIDATE),
 });
 
 export const segmentsQueryOptions = () => ({
   queryKey: ['transit', 'segments'] as const,
-  queryFn: () => fetchJson<Segments>('/v0/transit/segments'),
+  queryFn: () => fetchJson<Segments>('/v0/transit/segments', REVALIDATE),
 });
 
 export const useStations = () => useQuery(stationsQueryOptions());


### PR DESCRIPTION
## What

Fetch the transit reference data (`stations`, `lines`, `segments`) with `cache: 'no-cache'`, so the client revalidates instead of blindly serving its stored copy.

```ts
const REVALIDATE: RequestInit = { cache: 'no-cache' };
// ...
fetchJson<Segments>('/v0/transit/segments', REVALIDATE)
```

## Why

Final piece of the risk-map incident. The server now serves transit data with `max-age=0, s-maxage=…` (browsers revalidate, edge keeps 30 days) — but **clients that already cached the response under the previous `max-age=2592000` still consider it fresh for 30 days and never revalidate**. They keep painting risk colours onto stale, pre-reseed segment geometry.

This bites the Capacitor app especially: there's no `CapacitorHttp` plugin, so `fetch()` uses the native WebView HTTP cache (NSURLCache), which honors the old 30-day entry. Capgo ships the JS bundle, not the WebView cache or IndexedDB, so an OTA update can't flush it. A server purge can't reach a device's cache either.

`cache: 'no-cache'` forces an `If-None-Match` revalidation **even when the stored entry looks fresh**, so it bypasses the poisoned 30-day entry: a cheap `304` when unchanged, the fresh body (new ETag) right after a reseed. From then on it stays coherent with the server's `must-revalidate` header.

The React Query IndexedDB persistence layer self-heals separately — its `buster` is `__BUILD_ID__`, so this new build drops the old persisted cache on next load.

Net effect: existing web and Capacitor users self-recover on next open instead of waiting up to 30 days, and future reseeds propagate immediately.

## Scope

Only the three long-cached transit reference endpoints. `/v0/reports` and `/v0/risk` are already `no-store` / uncached and unaffected. `tsc -b` + `eslint` clean.
