### PR TITLE
perf: parallelize independent transit reads to cut consecutive D1 round-trips

### DIFF
--- a/packages/api-worker/src/modules/reports/reports-service.ts
+++ b/packages/api-worker/src/modules/reports/reports-service.ts
@@ -132,8 +132,20 @@ export class ReportsService {
         if (result.length < predictedReportsThreshold) {
             const numberOfReportsToFetch = predictedReportsThreshold - result.length
             const reportedStationIds = new Set(result.map((r) => r.stationId as StationId))
-            const allowedStationIds = await this.resolveAllowedStationIds(stationId, reportedStationIds)
-            const historicReports = await this.predictReports(numberOfReportsToFetch, from, to, allowedStationIds)
+            // The allowed-station lookup may read the full station list and the historic
+            // Candidate fetch reads recent reports; the two are independent, so issue
+            // Them concurrently rather than as back-to-back D1 round-trips.
+            const [allowedStationIds, candidateRows] = await Promise.all([
+                this.resolveAllowedStationIds(stationId, reportedStationIds),
+                this.loadPredictionCandidates(),
+            ])
+            const historicReports = this.predictReports(
+                numberOfReportsToFetch,
+                from,
+                to,
+                allowedStationIds,
+                candidateRows
+            )
             result.push(...historicReports)
         }
 
@@ -164,12 +176,23 @@ export class ReportsService {
         return Math.trunc(clamp(threshold, MIN_PREDICTED_REPORTS_THRESHOLD, MAX_PREDICTED_REPORTS_THRESHOLD))
     }
 
-    private async predictReports(
+    // Recent reports used as the historic sample for prediction. Fetched separately
+    // So getReports can run it concurrently with resolveAllowedStationIds.
+    private async loadPredictionCandidates() {
+        return this.db
+            .select({ stationId: reports.stationId, timestamp: reports.timestamp })
+            .from(reports)
+            .orderBy(desc(reports.timestamp))
+            .limit(1000)
+    }
+
+    private predictReports(
         numberOfReportsToFetch: number,
         from: DateTime,
         to: DateTime,
-        allowedStationIds: ReadonlySet<StationId>
-    ): Promise<ReportSummary[]> {
+        allowedStationIds: ReadonlySet<StationId>,
+        candidateRows: Awaited<ReturnType<ReportsService['loadPredictionCandidates']>>
+    ): ReportSummary[] {
         if (numberOfReportsToFetch <= 0) return []
         if (allowedStationIds.size === 0) return []
 
@@ -190,12 +213,6 @@ export class ReportsService {
 
         const firstQuarterEndMillis = fromMillis + Math.floor(rangeMillis / 4)
         const firstHalfEndMillis = fromMillis + Math.floor(rangeMillis / 2)
-
-        const candidateRows = await this.db
-            .select({ stationId: reports.stationId, timestamp: reports.timestamp })
-            .from(reports)
-            .orderBy(desc(reports.timestamp))
-            .limit(1000)
 
         const usedStationIds = new Set<StationId>()
         const maxUniqueCount = Math.min(numberOfReportsToFetch, allowedStationIds.size)
@@ -302,8 +319,11 @@ export class ReportsService {
     }
 
     async postProcessReport(reportData: RawReport): Promise<InsertReport> {
-        const stations = await this.transitNetworkDataService.getStations()
-        const lines = await this.transitNetworkDataService.getLines()
+        // Independent reads — fetch concurrently instead of back-to-back round-trips.
+        const [stations, lines] = await Promise.all([
+            this.transitNetworkDataService.getStations(),
+            this.transitNetworkDataService.getLines(),
+        ])
 
         const now = DateTime.utc()
 

--- a/packages/api-worker/src/modules/transit/transit-network-data-service.ts
+++ b/packages/api-worker/src/modules/transit/transit-network-data-service.ts
@@ -139,12 +139,13 @@ export class TransitNetworkDataService {
     }
 
     private async loadGraph(): Promise<Graph> {
-        const allStations = await this.db.select().from(stations)
-        const allLineStations = await this.db
-            .select()
-            .from(lineStations)
-            .orderBy(asc(lineStations.lineId), asc(lineStations.order))
-        const allLines = await this.db.select().from(lines)
+        // The three reads are independent, so issue them concurrently rather than as
+        // Three back-to-back D1 round-trips (Sentry "consecutive DB queries").
+        const [allStations, allLineStations, allLines] = await Promise.all([
+            this.db.select().from(stations),
+            this.db.select().from(lineStations).orderBy(asc(lineStations.lineId), asc(lineStations.order)),
+            this.db.select().from(lines),
+        ])
 
         return buildGraph(allStations, allLines, allLineStations)
     }


### PR DESCRIPTION
Fixes API-WORKER-4, Fixes API-WORKER-6, Fixes API-WORKER-1.

## What

Three handlers fired **independent** transit-reference reads with back-to-back `await`s. On D1 each query is a separate round-trip, so Sentry flagged them as *Consecutive DB Queries*. This issues the independent reads concurrently.

| Sentry issue | Endpoint | Change |
|---|---|---|
| API-WORKER-4 | `GET /transit/distance` | `loadGraph` — `stations` / `line_stations` / `lines` now in one `Promise.all` (3 round-trips → 1) |
| API-WORKER-6 | `POST /reports` | `postProcessReport` — `getStations()` + `getLines()` now in one `Promise.all` |
| API-WORKER-1 | `GET /reports` | prediction path — the allowed-station lookup and the historic-candidate fetch now run concurrently |

## Why

These appeared right after the D1 cutover. Under Hyperdrive/Postgres the pooled round-trips were cheap; on D1 every query is a round-trip to the primary (events served from HAM/EEUR to US/ES clients), so sequential independent reads stack latency and trip the detector. They're `info`/`200`/0-users — pure latency, not errors.

## Notes

- For `GET /reports`, the candidate fetch was hoisted out of `predictReports` into `loadPredictionCandidates()` so it can run in parallel with `resolveAllowedStationIds`; `predictReports` is now synchronous and takes the rows. The common path (enough real reports → no prediction) is unchanged and fires no extra query. In the rare scoped-station-already-reported case the candidate fetch may run unnecessarily — one cheap indexed `limit 1000` select — which I judged a fair trade for removing the round-trip on the high-volume unscoped path (117 events).
- Out of scope: these are still per-request reads of effectively static reference data (also behind the `/v0/risk` "Slow DB Query" issues). In-isolate memoization would remove the reads entirely but reintroduces reseed-staleness risk, so it belongs in a separate, version-stamped change.

## Test

`bun test` → 89 pass; eslint clean.
