### PR TITLE
feat: tag worker Sentry events with git-sha releases and register them on deploy

### DIFF
--- a/.github/workflows/api-worker-deploy.yml
+++ b/.github/workflows/api-worker-deploy.yml
@@ -22,6 +22,10 @@ jobs:
         steps:
             - name: Check out code
               uses: actions/checkout@v4
+              with:
+                  # Full history so `sentry-cli releases set-commits --auto` can resolve the
+                  # commit range between the previous release and this deploy.
+                  fetch-depth: 0
 
             - name: Set up Bun
               uses: oven-sh/setup-bun@v1
@@ -46,6 +50,8 @@ jobs:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
                   workingDirectory: packages/api-worker
+                  # The commit SHA becomes the Sentry release the worker reports at runtime.
+                  command: deploy --var SENTRY_RELEASE:${{ github.sha }}
                   secrets: |
                       REPORT_PASSWORD
               env:
@@ -56,3 +62,18 @@ jobs:
                   CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
               run: bun run db:purge-cache
+
+            # Register the release in Sentry (named after the commit SHA the worker reports) so
+            # issues can be resolved "in the next release". Commit association is best-effort:
+            # the release is still created/finalized if set-commits can't resolve the range.
+            - name: Create Sentry release
+              env:
+                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  SENTRY_ORG: freifahren-web
+                  SENTRY_PROJECT: api-worker
+                  SENTRY_URL: https://de.sentry.io
+              run: |
+                  bunx @sentry/cli releases new "$GITHUB_SHA"
+                  bunx @sentry/cli releases set-commits "$GITHUB_SHA" --auto --ignore-missing || echo "set-commits skipped"
+                  bunx @sentry/cli releases finalize "$GITHUB_SHA"
+                  bunx @sentry/cli releases deploys "$GITHUB_SHA" new --env production

--- a/.github/workflows/telegram-worker-deploy.yml
+++ b/.github/workflows/telegram-worker-deploy.yml
@@ -28,6 +28,10 @@ jobs:
         steps:
             - name: Check out code
               uses: actions/checkout@v4
+              with:
+                  # Full history so `sentry-cli releases set-commits --auto` can resolve the
+                  # commit range between the previous release and this deploy.
+                  fetch-depth: 0
 
             - name: Set up Bun
               uses: oven-sh/setup-bun@v2
@@ -45,7 +49,23 @@ jobs:
               run: bun run test
 
             - name: Deploy to Cloudflare Workers
-              run: bunx wrangler@latest deploy
+              # The commit SHA becomes the Sentry release the worker reports at runtime.
+              run: bunx wrangler@latest deploy --var SENTRY_RELEASE:${{ github.sha }}
               env:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+            # Register the release in Sentry (named after the commit SHA the worker reports) so
+            # issues can be resolved "in the next release". Commit association is best-effort:
+            # the release is still created/finalized if set-commits can't resolve the range.
+            - name: Create Sentry release
+              env:
+                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  SENTRY_ORG: freifahren-web
+                  SENTRY_PROJECT: telegram-worker
+                  SENTRY_URL: https://de.sentry.io
+              run: |
+                  bunx @sentry/cli releases new "$GITHUB_SHA"
+                  bunx @sentry/cli releases set-commits "$GITHUB_SHA" --auto --ignore-missing || echo "set-commits skipped"
+                  bunx @sentry/cli releases finalize "$GITHUB_SHA"
+                  bunx @sentry/cli releases deploys "$GITHUB_SHA" new --env production

--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -17,6 +17,9 @@ export type Bindings = {
     TELEGRAM_WORKER_URL?: string
     REPORT_PASSWORD?: string
     SENTRY_DSN?: string
+    // Git SHA injected at deploy via `wrangler deploy --var SENTRY_RELEASE:<sha>`; tags Sentry
+    // Events with a release so issues can be resolved in the next release. Absent locally.
+    SENTRY_RELEASE?: string
     LOG_LEVEL?: LogLevel
 }
 

--- a/packages/api-worker/src/worker.ts
+++ b/packages/api-worker/src/worker.ts
@@ -9,6 +9,8 @@ import { app } from './index'
 export default withSentry(
     (env: Bindings) => ({
         dsn: env.SENTRY_DSN,
+        release: env.SENTRY_RELEASE,
+        environment: env.NODE_ENV,
         enableLogs: true,
         integrations: [consoleLoggingIntegration({ levels: ['info', 'warn', 'error'] })],
         tracesSampleRate: 1.0,

--- a/packages/telegram-worker/src/index.ts
+++ b/packages/telegram-worker/src/index.ts
@@ -9,6 +9,8 @@ import { handleReportForward } from './forwarding'
 export default withSentry(
     (env: Env) => ({
         dsn: env.SENTRY_DSN,
+        release: env.SENTRY_RELEASE,
+        environment: env.NODE_ENV,
         enableLogs: true,
         integrations: [consoleLoggingIntegration({ levels: ['info', 'warn', 'error'] })],
         tracesSampleRate: 1.0,

--- a/packages/telegram-worker/src/types.ts
+++ b/packages/telegram-worker/src/types.ts
@@ -8,6 +8,10 @@ export interface Env {
     MISTRAL_MODEL: string
     TELEGRAM_REPORT_CHAT_ID: string
     SENTRY_DSN: string
+    NODE_ENV?: string
+    // Git SHA injected at deploy via `wrangler deploy --var SENTRY_RELEASE:<sha>`; tags Sentry
+    // Events with a release so issues can be resolved in the next release. Absent locally.
+    SENTRY_RELEASE?: string
 
     // Secrets (wrangler secret put)
     MISTRAL_API_KEY: string

--- a/packages/telegram-worker/wrangler.jsonc
+++ b/packages/telegram-worker/wrangler.jsonc
@@ -6,6 +6,7 @@
     // @sentry/cloudflare needs the AsyncLocalStorage API.
     "compatibility_flags": ["nodejs_compat"],
     "vars": {
+        "NODE_ENV": "production",
         // Backend that serves /v0/transit/* and accepts POST /v0/reports.
         "BACKEND_URL": "https://api.freifahren.org",
         "PUBLIC_APP_URL": "https://app.freifahren.org",


### PR DESCRIPTION
## What

Sets up Sentry **releases** for both Cloudflare Workers (`api-worker`, `telegram-worker`) so issues can be resolved "in the next release" — and so deploys are tracked with commits. `frontend-next` already had this; the Workers didn't.

**Runtime (both workers):**
- `withSentry` now sets `release: env.SENTRY_RELEASE` and `environment: env.NODE_ENV`.
- `SENTRY_RELEASE` is added to the binding types (optional — absent locally).
- `telegram-worker` gains a `NODE_ENV: "production"` var for parity with `api-worker`.

**Deploy (both workflows):**
- The commit SHA is injected as the release at deploy: `wrangler deploy --var SENTRY_RELEASE:${{ github.sha }}` (verified via `--dry-run` that `--var` *merges* with the config `vars`, so `CORS_ORIGINS` etc. are preserved).
- A "Create Sentry release" step registers the same SHA in Sentry: `releases new` → `set-commits --auto` → `finalize` → `deploys new --env production`, using the existing `SENTRY_AUTH_TOKEN` secret and the EU `SENTRY_URL`.
- `fetch-depth: 0` on checkout so `set-commits --auto` can resolve the commit range.

## Why

The release the worker reports at runtime and the release CI creates in Sentry are the **same git SHA** — that's what makes "resolve in the next release", regression detection, and suspect-commits work. Mismatched names silently break the association, so they're deliberately tied together here.

## Notes

- Commit association is **best-effort**: `set-commits` is guarded with `|| echo skipped`, so a deploy never fails just because the commit range couldn't be resolved — the release is still created and finalized, which is all "resolve in next release" needs.
- Org `freifahren-web`; projects `api-worker` / `telegram-worker`; region `de.sentry.io`.

## Test

`api-worker`: `--dry-run` build OK (SENTRY_RELEASE binding present, config vars intact), `bun test` 89 pass. `telegram-worker`: `tsc --noEmit` clean, tests pass. eslint clean.
