### PR TITLE
fix: collapse per-station report transactions in Sentry

### DIFF
--- a/packages/api-worker/src/worker.ts
+++ b/packages/api-worker/src/worker.ts
@@ -5,6 +5,13 @@ import { Bindings } from './app-env'
 
 import { app } from './index'
 
+// The @sentry/cloudflare HTTP instrumentation names transactions from the raw URL pathname.
+// Each station therefore turns GET /v0/reports/<stationId> into its own transaction (…/BAHU,
+// …/BOSB, …). Collapse that single trailing segment into the route pattern so Sentry tracks the
+// per-station reads as one transaction, while leaving the list endpoint (GET /v0/reports) untouched.
+const normalizeTransactionName = (name: string): string =>
+    name.replace(/^(\w+ \/v\d+\/reports)\/[^/]+$/, '$1/:stationId')
+
 // Cloudflare Worker entry. The Hono app lives in index.ts so tests can run it without the Sentry SDK.
 export default withSentry(
     (env: Bindings) => ({
@@ -14,6 +21,16 @@ export default withSentry(
         enableLogs: true,
         integrations: [consoleLoggingIntegration({ levels: ['info', 'warn', 'error'] })],
         tracesSampleRate: 1.0,
+        beforeSendTransaction: (event) => {
+            if (event.transaction === undefined) return event
+            const normalized = normalizeTransactionName(event.transaction)
+            if (normalized !== event.transaction) {
+                event.transaction = normalized
+                // Mark it as a known route so Sentry treats it as a parameterized pattern.
+                if (event.transaction_info) event.transaction_info.source = 'route'
+            }
+            return event
+        },
     }),
     {
         fetch: app.fetch,


### PR DESCRIPTION
## Problem

The `@sentry/cloudflare` HTTP instrumentation names transactions from the **raw URL pathname**, not the matched Hono route pattern. It calls `getHttpSpanDetailsFromUrlObject(...)` without a `routeName`, so it falls back to `urlObject.pathname`.

The effect: every station turns `GET /v0/reports/<stationId>` into its own transaction — `GET /v0/reports/BAHU`, `…/BOSB`, `…/BWKRR`, and ~150 more. In Sentry's last 14 days this fragments one logical endpoint across dozens of transactions, so per-endpoint latency trends are unreadable and the transaction list is flooded.

## Fix

Normalize the transaction name in a `beforeSendTransaction` hook so the trailing station segment collapses to the route pattern:

- `GET /v0/reports/BAHU` → `GET /v0/reports/:stationId`
- `GET /v0/reports` (list) → **unchanged**
- `POST /v0/reports` (submit) and all other routes → **unchanged**

The normalized transaction is marked `transaction_info.source = 'route'` so Sentry treats it as a known parameterized pattern.

This keeps the list endpoint and the per-station endpoint as two distinct, monitorable transactions while merging the per-station noise.

## Why here and not a Hono middleware

All Sentry code lives in `worker.ts` by design — the comment there notes the Hono app is kept in `index.ts` "so tests can run it without the Sentry SDK". Doing this in `beforeSendTransaction` keeps that isolation intact, touches a single file, and avoids the `c.req.routePath` ambiguity that comes with nested `app.route()` mounts.

## Testing

Regex behavior verified against representative transaction names (station IDs, list, submit, other routes, and a future `/v1/reports/<id>`) — only the per-station reads collapse; everything else is left as-is. Lint and typecheck clean for the changed file (pre-existing `router.ts` typecheck errors are unrelated to this change).