### PR TITLE
chore: point api-worker D1 binding at EU-jurisdiction database

### DIFF
--- a/packages/api-worker/wrangler.jsonc
+++ b/packages/api-worker/wrangler.jsonc
@@ -9,8 +9,8 @@
     "d1_databases": [
         {
             "binding": "DB",
-            "database_name": "api-worker-db",
-            "database_id": "f11691e9-e6a5-4da2-a5af-d91ca782ee78",
+            "database_name": "api-worker-db-eu",
+            "database_id": "f8e11f14-15a5-42a8-8eba-5ab513175890",
             "migrations_dir": "drizzle",
         },
     ],


### PR DESCRIPTION
## What

Repoints the `api-worker` D1 binding (`DB`) from `api-worker-db` to **`api-worker-db-eu`**, a freshly created D1 database with `--jurisdiction eu`.

| | Old (`api-worker-db`) | New (`api-worker-db-eu`) |
|---|---|---|
| `database_id` | `f11691e9-…` | `f8e11f14-15a5-42a8-8eba-5ab513175890` |
| `jurisdiction` | `null` | **`eu`** |
| `running_in_region` | EEUR | EEUR |

## Why

The old database had no jurisdiction set — its EU placement (EEUR) was a soft location, not a guarantee. A jurisdiction can only be set at creation and cannot be added later, so locking data residency to the EU for GDPR means moving to a new DB. Both run in EEUR (Frankfurt/Hamburg/Prague), so **Berlin latency is unchanged**.

## Data migration (already done against production)

- Exported the live DB via `wrangler d1 export` and imported into the EU DB (statements reordered into FK-dependency order; `sqlite_sequence` preserved).
- Verified row counts match exactly: reports **103,668**, stations 639, lines 55, line_stations 1,465, segments 1,410, migrations 2.
- `report_id` autoincrement sequence = 203,669 = current max, so new reports continue without collision.
- All 4 indexes copied. The `d1_migrations` ledger came across, so the deploy's `migrations apply` is a no-op.

## After deploy

- Verify `api.freifahren.org` serves correctly and a new report writes to the EU DB.
- Then delete the old `api-worker-db` (not done here — kept as a rollback until verified).
