### PR TITLE
perf: virtualize report and station lists to cut interaction latency

### DIFF
--- a/packages/frontend-next/bun.lock
+++ b/packages/frontend-next/bun.lock
@@ -23,6 +23,7 @@
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-query-persist-client": "^5.101.0",
         "@tanstack/react-router": "^1.170.8",
+        "@tanstack/react-virtual": "^3.14.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "i18next": "^26.2.0",
@@ -767,6 +768,8 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.4", "", { "dependencies": { "@tanstack/virtual-core": "3.17.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw=="],
+
     "@tanstack/router-cli": ["@tanstack/router-cli@1.167.10", "", { "dependencies": { "@tanstack/router-generator": "1.167.10", "chokidar": "^5.0.0", "yargs": "^17.7.2" }, "bin": { "tsr": "bin/tsr.cjs" } }, "sha512-/OOy5OtlfIqj47tTxVAeYOX5QOvUTGl2UWeakVZCdyQrlY9nhkGDoExTpkI70N7pT1sIzeHorHlLfuJOLohbSQ=="],
 
     "@tanstack/router-core": ["@tanstack/router-core@1.171.6", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-Ol6DQ+j6rf/rPVELIzo8LHwOQV2KL+zry3b+39kL/GKrt7YId52WJRAFMzuseY4XceSW+PU7sG/Cc1QkwJr0hg=="],
@@ -778,6 +781,8 @@
     "@tanstack/router-utils": ["@tanstack/router-utils@1.162.1", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-62layyTGmclHDQS/eidwKRfN1hhCKwViG7iEBcVmL0MXgcAB3OOucWCEcDDGd9Cu11H6b4QQ5oOo47MWIqwz0A=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.2", "", {}, "sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
 

--- a/packages/frontend-next/package.json
+++ b/packages/frontend-next/package.json
@@ -32,6 +32,7 @@
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-query-persist-client": "^5.101.0",
     "@tanstack/react-router": "^1.170.8",
+    "@tanstack/react-virtual": "^3.14.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "i18next": "^26.2.0",

--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -1,6 +1,7 @@
 import { getRouteApi, useNavigate } from '@tanstack/react-router';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { ChevronRight, MapPin, Search, TriangleAlert } from 'lucide-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { type SubmitReportResponse, useSubmitReport } from '@/api/reports';
@@ -167,6 +168,19 @@ function StationPicker() {
   const nearbyIds = new Set(nearby.map((s) => s.id));
   const rest = filtered.filter((s) => !nearbyIds.has(s.id));
 
+  // The full station list is hundreds of rows. Virtualize it so only the visible rows mount.
+  // `nearby` (≤3) renders in normal flow above the list, so scrollMargin offsets the virtualizer
+  // past it (the scroll container is `relative` so listRef.offsetTop is measured against it).
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const virtualizer = useVirtualizer({
+    count: rest.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 45,
+    overscan: 10,
+    scrollMargin: listRef.current?.offsetTop ?? 0,
+  });
+
   const renderStation = (station: Station) => (
     <li key={station.id} className="border-border/60 border-b last:border-b-0">
       <button
@@ -212,7 +226,10 @@ function StationPicker() {
               autoComplete="off"
             />
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto mask-b-from-[calc(100%-2.5rem)] mask-b-to-100% pb-2">
+          <div
+            ref={scrollRef}
+            className="relative min-h-0 flex-1 overflow-y-auto mask-b-from-[calc(100%-2.5rem)] mask-b-to-100% pb-2"
+          >
             {nearby.length > 0 && (
               <>
                 <div className="text-muted-foreground flex items-center gap-1.5 px-3 py-2 text-[0.625rem] font-semibold tracking-wide uppercase">
@@ -223,14 +240,46 @@ function StationPicker() {
                 {rest.length > 0 && <Separator className="bg-border my-2 data-horizontal:h-0.5" />}
               </>
             )}
-            <ul>
-              {rest.map(renderStation)}
-              {needle && filtered.length === 0 && (
-                <li className="text-muted-foreground px-3 py-6 text-center text-sm">
-                  {t('noMatch', { query })}
-                </li>
-              )}
-            </ul>
+            {needle && filtered.length === 0 ? (
+              <p className="text-muted-foreground px-3 py-6 text-center text-sm">
+                {t('noMatch', { query })}
+              </p>
+            ) : (
+              <ul
+                ref={listRef}
+                style={{ height: virtualizer.getTotalSize(), position: 'relative' }}
+              >
+                {virtualizer.getVirtualItems().map((virtualRow) => {
+                  const station = rest[virtualRow.index];
+                  return (
+                    <li
+                      key={station.id}
+                      ref={virtualizer.measureElement}
+                      data-index={virtualRow.index}
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: '100%',
+                        transform: `translateY(${virtualRow.start - virtualizer.options.scrollMargin}px)`,
+                      }}
+                      className="border-border/60 border-b"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => {
+                          selectionTap();
+                          selectStation(station.id);
+                        }}
+                        className="hover:bg-muted focus-visible:bg-muted flex w-full items-center rounded-md px-3 py-2.5 text-left text-sm outline-none"
+                      >
+                        <span className="truncate">{station.name}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
           </div>
         </>
       )}

--- a/packages/frontend-next/src/components/reports/ReportRow.tsx
+++ b/packages/frontend-next/src/components/reports/ReportRow.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { ChevronRight } from 'lucide-react';
+import { type CSSProperties, type Ref } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { formatElapsed, type Report } from '@/api/reports';
@@ -12,7 +13,20 @@ import { Route as StationRoute } from '@/routes/_map/station/$stationId';
 
 import { NAMESPACE } from './Reports.i18n';
 
-export function ReportRow({ report, recent }: { report: Report; recent: boolean }) {
+export function ReportRow({
+  report,
+  recent,
+  ref,
+  style,
+  dataIndex,
+}: {
+  report: Report;
+  recent: boolean;
+  // Optional hooks so the row can be positioned by a virtualizer (absolute style + measure ref).
+  ref?: Ref<HTMLLIElement>;
+  style?: CSSProperties;
+  dataIndex?: number;
+}) {
   const { t } = useTranslation(NAMESPACE);
   const { data: lines } = useLines();
   const { data: stations } = useStations();
@@ -50,7 +64,7 @@ export function ReportRow({ report, recent }: { report: Report; recent: boolean 
 
   // A report from the last hour opens the live report view; older ones fall back to the station.
   return (
-    <li className="border-border/60 border-b last:border-b-0">
+    <li ref={ref} data-index={dataIndex} style={style} className="border-border/60 border-b">
       {recent ? (
         <Link
           to={ReportDetailRoute.to}

--- a/packages/frontend-next/src/components/reports/ReportsList.tsx
+++ b/packages/frontend-next/src/components/reports/ReportsList.tsx
@@ -1,3 +1,5 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DAY_MS, HOUR_MS, useReports } from '@/api/reports';
@@ -17,15 +19,45 @@ export function ReportsList() {
 
   const sorted = (reports ?? []).slice().sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 
+  // The day window can hold hundreds of reports (p90 ~416). Virtualize so only the visible rows
+  // mount — mounting the whole list synchronously on tab-switch was the cause of the poor INP.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: sorted.length,
+    getScrollElement: () => scrollRef.current,
+    // Single-line rows are ~57px; rows with a direction line are taller. measureElement corrects
+    // the estimate per row once mounted, so the exact value only affects initial scroll sizing.
+    estimateSize: () => 57,
+    overscan: 8,
+  });
+
   return (
-    <div>
+    <div className="flex h-full flex-col">
       <SectionHeading className="px-4 py-3">{t('sectionReports')}</SectionHeading>
-      <ul>
-        {sorted.map((report, index) => {
-          const key = `${report.stationId}-${report.timestamp}`;
-          return <ReportRow key={`${key}-${index}`} report={report} recent={recentKeys.has(key)} />;
-        })}
-      </ul>
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+        <ul style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const report = sorted[virtualRow.index];
+            const key = `${report.stationId}-${report.timestamp}`;
+            return (
+              <ReportRow
+                key={`${key}-${virtualRow.index}`}
+                ref={virtualizer.measureElement}
+                dataIndex={virtualRow.index}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+                report={report}
+                recent={recentKeys.has(key)}
+              />
+            );
+          })}
+        </ul>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Fixes FRE-689 · refs #731

## Problem
Sentry flagged `/reports/stations` with **INP p75 = 432ms, p90 = 697ms** ("poor"). The Stations tab rendered the **entire day window of reports** — PostHog `reports_overview_opened.report_count` puts that at **p50 250, p90 416, max 485 rows** — as `ReportRow`s in one synchronous commit. Mounting hundreds of subscription-heavy rows on the tab-switch interaction is the long task behind the INP. The report form's station picker (`/report`) had the same shape, mounting the full **~640-station** list at once.

## Change
Virtualize both lists with `@tanstack/react-virtual` so only the visible rows (+ overscan) mount:

- **`ReportsList`** (`/reports/stations`) — self-owned scroll container; dynamic row measurement since rows vary in height (the optional direction line).
- **`StationPicker`** (`/report`) — the long `rest` list is virtualized; the small `nearby` block (≤3) stays in normal flow above it, with `scrollMargin` offsetting the virtualizer past it.
- **`ReportRow`** now forwards an optional `ref` / `style` / `data-index` (React 19 — `ref` as a plain prop) so the virtualizer can absolutely-position and measure it while it stays a valid `<li>`. `ReportsSummary`'s short recent list is untouched.

Scope is limited to virtualization per the issue's primary fix; the lookup-hoist refactor is not included here.

### React Compiler note
The compiler reports it skips memoizing the two components that call `useVirtualizer` (TanStack Virtual returns functions it can't safely memoize, and manages its own caching). This is expected and harmless — surfaces as two `react-hooks/incompatible-library` **warnings** (not errors; CI's `eslint .` does not fail on warnings).

## Verification
Tested locally against a real **347-report / 639-station** dataset (prod payloads, mobile viewport + 4× CPU throttle):

| List | Total rows | Rows in DOM |
|---|---|---|
| `/reports/stations` | 347 | ~19 |
| `/report` station picker | 639 | ~21 |

- Scrolling recycles rows with **no gaps/overlaps** all the way to the last item (index 346 / 638).
- Rows render fully (line badge, station, elapsed, direction).
- Station search still filters (`alexand` → Alexanderplatz) and the no-match state renders.
- `tsc -b` and `vite build` pass.

Per-route INP p75/p90 should be re-checked in Sentry after deploy (target p75 < 200ms) — that needs field data.