### PR TITLE
perf: cache transit reference data at the edge for in-process callers

### DIFF
--- a/docs/adr/0007-transit-reference-data-edge-cache.md
+++ b/docs/adr/0007-transit-reference-data-edge-cache.md
@@ -1,0 +1,75 @@
+# Cache transit reference data at the edge for in-process callers
+
+## Status
+
+accepted
+
+## Context
+
+D1 bills on **rows read**, counted across every query execution — not rows stored. The transit
+reference tables (`stations`, `lines`, `segments`, `line_stations`) are tiny (~3.5k rows total) but
+read in full on every request that needs them, because the getters scan the whole table (and the
+`stations ⋈ line_stations` join amplifies reads, ~4.2k rows/call at ~35% efficiency). Over a day
+that was ~5.3M rows read — **78% of all D1 reads** — against a DB that holds ~107k rows.
+
+The HTTP endpoints `/transit/{stations,lines,segments}` are already edge-cached (the
+`transit-network` `Cache-Tag` + `transitEdgeCacheMiddleware`, see ADR-0006), so they only miss
+occasionally. But the heavy consumers are **in-process**: `RiskService` calls `getStations()` and
+the segment getter on every `/risk` request, and `/risk` is deliberately uncached so its output
+stays live. ~73% of the stations reads came from `/risk` alone, completely bypassing the HTTP cache.
+At current volume the dollar cost is ~zero (well inside the Workers Paid included rows), so this is a
+**latency and scaling-headroom** decision, not a cost cut: reads were scaling with `users × table
+size` instead of `users`.
+
+## Decision
+
+Add a read-through cache (`cachedReference(key, loader, ctx)`) for the static reference getters
+(`getStations`, `getLines`, `getSegments`), backed by the **same Workers Cache API + `transit-network`
+`Cache-Tag`** that already fronts the HTTP responses. The in-process callers (risk, reports) consume
+the cached read-model instead of re-querying D1. D1 stays the source of truth — the tables are
+untouched and remain available for live joins and heavy server-side computation.
+
+**No TTL, no new purge code:** because the cache entry carries the `transit-network` tag, the existing
+`db:purge-cache` (run after a reseed) invalidates it alongside the HTTP responses. The cache falls
+through to a direct D1 read whenever the Cache API is absent (Bun tests, the Node seed CLI), so those
+paths are unchanged.
+
+The general rule this establishes — **cache in `caches.default` only when all hold:** the data changes
+only on an explicit infrequent event, one value serves every caller, a clean invalidation trigger
+exists, the re-read is genuinely expensive, and bounded staleness is acceptable. Otherwise keep it a
+plain D1 read (per-user/high-cardinality data, constantly-changing or strongly-consistent data,
+already-cheap indexed lookups, and live joins/aggregations).
+
+## Considered alternatives
+
+- **Workers KV:** rejected — global replication is unneeded (users are concentrated in Berlin, so one
+  or two colos), and it adds a binding, per-read cost, and a separate purge path. The Cache API reuses
+  the purge we already have.
+- **In-process module-level memo:** rejected — it cannot be invalidated from `purge-transit-cache.ts`,
+  which runs as a separate Bun CLI in the deploy pipeline with no handle into running isolates. Without
+  a TTL a long-lived isolate would serve stale topology until recycled (minutes–hours), the exact
+  "silently breaks the risk map after a reseed" failure ADR-0006's cache notes warn about.
+- **In-memory memo with a short TTL:** rejected — it works without external invalidation but trades a
+  bounded-staleness window for the precise purge-on-reseed we already get for free via the tag.
+- **Keep bespoke `getSegmentSummaries`:** rejected — it existed only to avoid loading segment geometry
+  for the risk model. Now that `getSegments()` is cached, the geometry costs no extra D1 read, so the
+  risk model reuses `getSegments()` and the summary query is removed.
+
+## Consequences
+
+- The Cache API is **per-colo and evictable**: an eviction or a cold colo triggers a one-off D1 refill,
+  never staleness. For Berlin-concentrated traffic this is effectively a shared cache. After a reseed
+  the first request fleet-wide does one D1 read per key and repopulates.
+- Reference reads drop ~95–99% (~5.3M → low tens of thousands of rows/day); overall D1 reads fall ~78%
+  (~6.7M → ~1.5M/day). The win is headroom and lower latency on the `/risk` hot path, not billing.
+- The **reports feed** (`reports ORDER BY timestamp DESC LIMIT 1000`, now the largest single source at
+  ~1.45M rows/day) is intentionally **not** cached this way: it changes constantly and has no clean
+  purge trigger. If it ever needs caching, use a short TTL (seconds), not the tag.
+- `getDistance` / `loadGraph` still read stations/lines/line_stations raw from D1 for pathfinding
+  (~249k rows/day, low call volume, a different shape than the cached read-models). Left uncached for
+  now; revisit if `/distance` traffic grows.
+- Cache writes use `executionCtx.waitUntil`, so they never delay the response; `executionCtx` is
+  resolved per request in `applyServices` and is `undefined` off Workers (tests/seed), where caching
+  is skipped anyway.
+- We cache the **computed read-model** (post-reduce shape), not raw rows, so callers also skip
+  rebuilding it.

--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -5,6 +5,7 @@ import { createLogger, Logger, LogLevel } from './common/logger'
 import { createD1Db, DbConnection } from './db'
 import { ReportsService } from './modules/reports'
 import { RiskService } from './modules/risk'
+import type { CacheCtx } from './modules/transit/reference-cache'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
 
 export type Bindings = {
@@ -95,7 +96,16 @@ export const setErrorReporter = (reporter: ErrorReporter) => {
 export const reportError: ErrorReporter = (error, context) => errorReporter(error, context)
 
 const applyServices = (c: Context<Env>, db: DbConnection, config: AppConfig) => {
-    const transitNetworkDataService = new TransitNetworkDataService(db)
+    // The executionCtx powers the cache write in cachedReference (waitUntil). It throws off
+    // Workers (tests, seed CLI), where the cache is absent anyway, so fall back to undefined.
+    let cacheCtx: CacheCtx
+    try {
+        cacheCtx = c.executionCtx
+    } catch {
+        cacheCtx = undefined
+    }
+
+    const transitNetworkDataService = new TransitNetworkDataService(db, cacheCtx)
     const reportsService = new ReportsService(db, transitNetworkDataService, {
         nodeEnv: config.nodeEnv,
         telegramWorkerUrl: config.telegramWorkerUrl,

--- a/packages/api-worker/src/modules/risk/risk-service.ts
+++ b/packages/api-worker/src/modules/risk/risk-service.ts
@@ -24,17 +24,17 @@ export class RiskService {
     async getRisk(now: DateTime = DateTime.utc()): Promise<RiskData> {
         const oneHourAgo = now.minus({ hours: 1 })
 
-        const [segmentSummaries, realReports, stations] = await Promise.all([
-            this.transitNetworkDataService.getSegmentSummaries(),
+        const [segmentCollection, realReports, stations] = await Promise.all([
+            this.transitNetworkDataService.getSegments(),
             this.reportsService.getRealReports({ from: oneHourAgo, to: now }),
             this.transitNetworkDataService.getStations(),
         ])
 
-        const segments: RiskModelSegment[] = segmentSummaries.map((segment) => ({
-            sid: String(segment.id),
-            lineId: segment.lineId,
-            fromStationId: segment.fromStationId,
-            toStationId: segment.toStationId,
+        const segments: RiskModelSegment[] = segmentCollection.features.map((feature) => ({
+            sid: String(feature.properties.id),
+            lineId: feature.properties.line,
+            fromStationId: feature.properties.from,
+            toStationId: feature.properties.to,
         }))
 
         const reports: RiskModelReport[] = realReports.flatMap((r) => {

--- a/packages/api-worker/src/modules/transit/reference-cache.ts
+++ b/packages/api-worker/src/modules/transit/reference-cache.ts
@@ -1,0 +1,51 @@
+/// <reference types="@cloudflare/workers-types" />
+import { TRANSIT_CACHE_CONTROL, TRANSIT_CACHE_TAG } from './transit-cache-middleware'
+
+// The global CacheStorage type (DOM lib) lacks the Cloudflare-specific `default` cache.
+interface EdgeCache {
+    match(request: Request): Promise<Response | undefined>
+    put(request: Request, response: Response): Promise<void>
+}
+
+// Synthetic origin for internal cache keys — never routed, just a stable key namespace
+// That cannot collide with real request URLs stored by transitEdgeCacheMiddleware.
+const INTERNAL_ORIGIN = 'https://transit-reference.internal'
+
+export type CacheCtx = { waitUntil(promise: Promise<unknown>): void } | undefined
+
+/*
+ * Read-through cache for static transit reference data (stations, lines, segments),
+ * backed by the same Workers Cache API + `transit-network` Cache-Tag that
+ * transitEdgeCacheMiddleware uses for the HTTP responses. Because the entry carries
+ * that tag, the existing `db:purge-cache` tag purge invalidates it too — so a reseed
+ * clears both layers and there is no TTL to tune.
+ *
+ * Falls through to the loader (a direct D1 read) whenever the Cache API is absent —
+ * i.e. under Bun (tests) and the Node seed CLI — so those paths are unchanged.
+ */
+export const cachedReference = async <T>(key: string, loader: () => Promise<T>, ctx: CacheCtx): Promise<T> => {
+    const cache = typeof caches !== 'undefined' ? (caches as unknown as { default: EdgeCache }).default : undefined
+    if (cache === undefined) {
+        return loader()
+    }
+
+    const cacheKey = new Request(`${INTERNAL_ORIGIN}/${key}`)
+    const cached = await cache.match(cacheKey)
+    if (cached !== undefined) {
+        return (await cached.json()) as T
+    }
+
+    const value = await loader()
+    const entry = new Response(JSON.stringify(value), {
+        headers: {
+            'Content-Type': 'application/json',
+            'Cache-Control': TRANSIT_CACHE_CONTROL,
+            'Cache-Tag': TRANSIT_CACHE_TAG,
+        },
+    })
+    // Don't let the cache write delay the response; on Node/tests (no ctx) it is a no-op anyway.
+    if (ctx !== undefined) {
+        ctx.waitUntil(cache.put(cacheKey, entry))
+    }
+    return value
+}

--- a/packages/api-worker/src/modules/transit/transit-network-data-service.ts
+++ b/packages/api-worker/src/modules/transit/transit-network-data-service.ts
@@ -4,12 +4,30 @@ import { AppError, NoPathFoundError } from '../../common/errors'
 import { DbConnection, stations, lineStations, lines, segments } from '../../db'
 
 import { buildGraph, findPathWithAStar, type Graph, type StationId } from './pathfinding'
+import { cachedReference, type CacheCtx } from './reference-cache'
 import type { Line, Lines, SegmentsFeatureCollection, Stations } from './types'
 
 export class TransitNetworkDataService {
-    constructor(private db: DbConnection) {}
+    constructor(
+        private db: DbConnection,
+        private cacheCtx: CacheCtx = undefined
+    ) {}
 
+    // Static reference data — read through the transit edge cache so the hot in-process
+    // Callers (risk, reports) don't re-scan the full tables in D1 on every request.
     async getStations(): Promise<Stations> {
+        return cachedReference('stations', () => this.loadStations(), this.cacheCtx)
+    }
+
+    async getLines(): Promise<Lines> {
+        return cachedReference('lines', () => this.loadLines(), this.cacheCtx)
+    }
+
+    async getSegments(): Promise<SegmentsFeatureCollection> {
+        return cachedReference('segments', () => this.loadSegments(), this.cacheCtx)
+    }
+
+    private async loadStations(): Promise<Stations> {
         const joinedRows = await this.db
             .select({
                 id: stations.id,
@@ -35,7 +53,7 @@ export class TransitNetworkDataService {
         }, {} as Stations)
     }
 
-    async getLines(): Promise<Lines> {
+    private async loadLines(): Promise<Lines> {
         const joinedRows = await this.db
             .select({
                 lineId: lines.id,
@@ -70,7 +88,7 @@ export class TransitNetworkDataService {
         return Array.from(byId.values())
     }
 
-    async getSegments(): Promise<SegmentsFeatureCollection> {
+    private async loadSegments(): Promise<SegmentsFeatureCollection> {
         const rows = await this.db
             .select({
                 id: segments.id,
@@ -100,22 +118,6 @@ export class TransitNetworkDataService {
                 },
             })),
         }
-    }
-
-    // The risk model needs only segment topology, not the large `coordinates`
-    // Geometry that getSegments() returns.
-    async getSegmentSummaries(): Promise<
-        Array<{ id: number; lineId: string; fromStationId: string; toStationId: string }>
-    > {
-        return this.db
-            .select({
-                id: segments.id,
-                lineId: segments.lineId,
-                fromStationId: segments.fromStationId,
-                toStationId: segments.toStationId,
-            })
-            .from(segments)
-            .orderBy(asc(segments.lineId), asc(segments.position))
     }
 
     async getDistance(from: StationId, to: StationId): Promise<number> {


### PR DESCRIPTION
## Why

D1 bills on **rows read** — counted across every query execution, *not* rows stored. The transit reference tables (`stations`, `lines`, `segments`, `line_stations`) hold only ~3.5k rows total, but the getters read them **in full on every request that needs them**, and the `stations ⋈ line_stations` join amplifies that (~4,200 rows/call at ~35% efficiency).

Measured over 24h on the production D1:

| Query (in-process caller) | Calls/day | Rows read/day |
|---|---|---|
| `stations ⋈ line_stations` (`getStations`) | 755 | 3,176,285 |
| `segments` (risk) | 602 | 1,697,640 |
| `line_stations` (`loadGraph`) | 85 | 249,050 |
| `lines ⋈ line_stations` (`getLines`) | 49 | 148,911 |
| **Reference total** | | **~5.27M (78.4% of all reads)** |

The HTTP endpoints `/transit/{stations,lines,segments}` are already edge-cached (the `transit-network` `Cache-Tag`, see ADR-0006), so they rarely miss. But the heavy consumers are **in-process**: `RiskService` calls `getStations()` and the segments getter on every `/risk` request — and `/risk` is deliberately uncached so its output stays live. ~73% of the stations reads came from `/risk` alone, completely bypassing the HTTP cache.

At today's volume this costs ≈ $0 (well inside the Workers Paid included rows), so this is a **latency + scaling-headroom** change, not a cost cut: reads were scaling with `users × table size` instead of `users`.

## What

Add a read-through cache `cachedReference(key, loader, ctx)` for the static reference getters (`getStations`, `getLines`, `getSegments`), backed by the **same Workers Cache API + `transit-network` `Cache-Tag`** that already fronts the HTTP responses. In-process callers consume the cached read-model instead of re-querying D1. D1 stays the source of truth — the tables are untouched and remain available for live joins and heavy server-side compute.

- **No TTL, no new purge code** — the entry carries the `transit-network` tag, so the existing `db:purge-cache` (run after a reseed) invalidates it alongside the HTTP responses.
- **Safe in tests/seed** — when the Cache API is absent (Bun tests, Node seed CLI) it falls through to a direct D1 read, so those paths are unchanged.
- **`getSegmentSummaries` removed** — it existed only to skip loading segment geometry for the risk model. Now that `getSegments()` is cached, the geometry costs no extra D1 read, so the risk model reuses `getSegments()` and the summary query is dropped.

### Files
- `reference-cache.ts` (new) — the read-through helper.
- `transit-network-data-service.ts` — getters wrap their D1 loaders; `getSegmentSummaries` removed.
- `risk-service.ts` — consumes the cached `getSegments()`.
- `app-env.ts` — passes the per-request `executionCtx` into the service (powers the non-blocking `waitUntil` cache write).
- `docs/adr/0007-transit-reference-data-edge-cache.md` (new) — full rationale + the general "cache vs D1 read" rule.

## Why this approach (not the alternatives)

- **Workers KV** — rejected: global replication is unneeded (users are Berlin-concentrated, one/two colos), and it adds a binding, per-read cost, and a *separate* purge path. The Cache API reuses the purge we already have.
- **In-process module memo** — rejected: it can't be invalidated from `purge-transit-cache.ts`, which runs as a separate Bun CLI with no handle into running isolates. Without a TTL it would serve stale topology until the isolate is recycled (minutes–hours) — the exact "silently breaks the risk map after a reseed" failure.
- **In-memory + short TTL** — rejected: works, but trades a bounded-staleness window for the precise purge-on-reseed we get for free via the tag.

## Impact & scope

- Reference reads drop ~95–99% (~5.27M → low tens of thousands/day); overall D1 reads ~6.7M → ~1.5M/day (≈78% fewer). Win is latency on the `/risk` hot path + headroom, not billing.
- **Cache is per-colo and evictable** — an eviction/cold colo triggers a one-off D1 refill, never staleness. For Berlin traffic it's effectively shared.
- **Intentionally not cached:** the reports feed (`… LIMIT 1000`, now the #1 read at ~1.45M/day) changes constantly and has no clean purge trigger — short TTL only if ever needed, not the tag. `loadGraph`/`getDistance` still reads raw rows for pathfinding (~249k/day, low volume, different shape) — a follow-up if `/distance` grows.

## Validation

89/89 tests pass, lint + prettier clean. Behaviour in tests is unchanged (Cache API absent → direct D1 read).
