### PR TITLE
fix: create person profiles for anonymous analytics

### DIFF
--- a/packages/frontend-next/src/lib/posthog-client.ts
+++ b/packages/frontend-next/src/lib/posthog-client.ts
@@ -62,6 +62,13 @@ export function loadPostHog(): Promise<void> {
     posthog.init(apiKey, {
       api_host: apiHost,
       defaults: '2025-05-24',
+      // We never call identify() (the app has no login), so under the default 'identified_only'
+      // mode PostHog ingests every event personless and builds no person profiles at all — which
+      // leaves lifecycle, retention, and stickiness permanently empty. 'always' lets the persistent
+      // anonymous distinct_id form a person profile so returning visits are measurable. Consent still
+      // governs persistence: a 'denied' choice switches to memory + reset() in consent.ts, so declined
+      // users stay un-retained by design, and respect_dnt keeps DNT users out entirely.
+      person_profiles: 'always',
       persistence: PERSISTENT_PERSISTENCE,
       autocapture: false,
       capture_performance: false,


### PR DESCRIPTION
## Problem

PostHog lifecycle / retention / stickiness are **empty** for the Web App project even though DAU is healthy (~900/day). Root cause:

- `posthog-js` defaults `person_profiles` to `'identified_only'`.
- The app has no login and **never calls `identify()`** (verified: 0 `$identify` events against ~83k pageviews).

Under `identified_only`, anonymous events are ingested **personless**, so PostHog builds no person profiles at all. Person-based insights (lifecycle/retention/stickiness) are therefore permanently empty; DAU only works because "unique users" falls back to counting `distinct_id`.

## Fix

Set `person_profiles: 'always'` in `posthog.init()`. The persistent anonymous `distinct_id` (already stored via `localStorage+cookie`) now forms a person profile, making returning visits measurable.

## Notes

- **Consent unchanged:** a `'denied'` choice still switches to `memory` + `reset()` in `consent.ts` (declined users stay un-retained by design); `respect_dnt` still excludes DNT users.
- **No cost change:** PostHog billing is event-based, not person-based.
- **Not retroactive:** the personless events already ingested stay that way; retention starts accumulating from deploy forward.