### PR TITLE
fix: route PostHog through a first-party reverse proxy

### DIFF
--- a/packages/frontend-next/.env.example
+++ b/packages/frontend-next/.env.example
@@ -6,6 +6,7 @@ VITE_MAP_INITIAL_ZOOM=11
 
 VITE_STRIPE_PAYMENT_LINK=
 VITE_POSTHOG_KEY=
+# Local dev hits PostHog EU directly; production uses the first-party reverse proxy (worker/index.ts).
 VITE_POSTHOG_HOST=https://eu.i.posthog.com
 # Id of the API-type PostHog survey that in-app feedback submissions are attributed to.
 VITE_POSTHOG_FEEDBACK_SURVEY_ID=

--- a/packages/frontend-next/.env.production
+++ b/packages/frontend-next/.env.production
@@ -7,7 +7,8 @@ VITE_STRIPE_PAYMENT_LINK=https://buy.stripe.com/28E9AW9Y634e8HQ9Sq3wQ00
 
 # PostHog project API key (public — shipped in the client bundle). EU Cloud.
 VITE_POSTHOG_KEY=phc_rR635vqhSmp6st6GYqJG23uZVCmtESsDQT4Caijwv2N5
-VITE_POSTHOG_HOST=https://eu.i.posthog.com
+# Reverse proxy (worker/index.ts) so ad blockers can't drop events by blocking *.posthog.com.
+VITE_POSTHOG_HOST=https://app.freifahren.org/relay
 VITE_POSTHOG_FEEDBACK_SURVEY_ID=019ec61d-7044-0000-0c79-734d7b31e436
 
 # Sentry DSN for error monitoring (public — shipped in the client bundle). EU region (ingest.de.sentry.io).

--- a/packages/frontend-next/src/lib/posthog-client.ts
+++ b/packages/frontend-next/src/lib/posthog-client.ts
@@ -61,6 +61,8 @@ export function loadPostHog(): Promise<void> {
   loadPromise = import('posthog-js').then(({ default: posthog }) => {
     posthog.init(apiKey, {
       api_host: apiHost,
+      // api_host is our reverse proxy in prod; keep PostHog UI/toolbar links on the real app.
+      ui_host: 'https://eu.posthog.com',
       defaults: '2025-05-24',
       // We never call identify() (the app has no login), so under the default 'identified_only'
       // mode PostHog ingests every event personless and builds no person profiles at all — which

--- a/packages/frontend-next/worker/index.ts
+++ b/packages/frontend-next/worker/index.ts
@@ -1,0 +1,39 @@
+// Reverse proxy so PostHog traffic goes through our own domain, not *.posthog.com (which ad blockers block).
+const API_HOST = 'eu.i.posthog.com';
+const ASSET_HOST = 'eu-assets.i.posthog.com';
+const PREFIX = '/relay';
+
+interface Env {
+  ASSETS: { fetch: (request: Request) => Promise<Response> };
+}
+
+interface Ctx {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: Ctx): Promise<Response> {
+    const url = new URL(request.url);
+    if (!url.pathname.startsWith(`${PREFIX}/`)) {
+      return env.ASSETS.fetch(request);
+    }
+
+    const upstreamPath = url.pathname.slice(PREFIX.length) + url.search;
+
+    if (url.pathname.startsWith(`${PREFIX}/static/`)) {
+      // Fetch without the original request: the asset CDN 302s to a login page if it sees an Origin header.
+      const cache = (caches as unknown as { default: Cache }).default;
+      const cacheKey = new Request(url.toString(), request);
+      let response = await cache.match(cacheKey);
+      if (!response) {
+        response = await fetch(`https://${ASSET_HOST}${upstreamPath}`);
+        ctx.waitUntil(cache.put(cacheKey, response.clone()));
+      }
+      return response;
+    }
+
+    const apiRequest = new Request(`https://${API_HOST}${upstreamPath}`, request);
+    apiRequest.headers.delete('cookie');
+    return fetch(apiRequest);
+  },
+};

--- a/packages/frontend-next/wrangler.jsonc
+++ b/packages/frontend-next/wrangler.jsonc
@@ -1,9 +1,13 @@
 {
   "name": "frontend",
   "compatibility_date": "2026-05-31",
+  "main": "./worker/index.ts",
   "assets": {
     "directory": "./dist",
+    "binding": "ASSETS",
     "not_found_handling": "single-page-application",
+    // Without this the SPA fallback swallows /relay/* before the proxy Worker runs.
+    "run_worker_first": ["/relay/*"],
   },
   "routes": [{ "pattern": "app.freifahren.org", "custom_domain": true }],
 }


### PR DESCRIPTION
## Problem

Analytics requests went straight to `eu.i.posthog.com`, which ad blockers block by domain — silently dropping events and undercounting usage. PostHog's Installation Health flags the missing reverse proxy, and the privacy policy already **claims** one exists ("Analytics requests are routed through our own domain... a reverse proxy"), so this also makes that statement true.

## Change

Turn the static-only `frontend` Worker into one that proxies `/relay/*` to PostHog EU and serves everything else from assets:

- **`worker/index.ts`** — `/relay/static/*` → `eu-assets.i.posthog.com`, `/relay/*` → `eu.i.posthog.com`, otherwise `env.ASSETS`. Static assets are fetched origin-less (avoids the asset CDN's 302-to-login) and edge-cached; cookies are stripped from forwarded API requests.
- **`wrangler.jsonc`** — adds `main`, the `ASSETS` binding, and `run_worker_first: ["/relay/*"]` so the SPA fallback doesn't swallow the proxy path.
- **`.env.production`** — `VITE_POSTHOG_HOST=https://app.freifahren.org/relay`.
- **`posthog-client.ts`** — `ui_host: 'https://eu.posthog.com'` so PostHog UI/toolbar links resolve to the real app, not the proxy.
- Local dev still hits PostHog EU directly (no Worker in front of `vite dev`).

## CORS (verified live)

CORS isn't configured on the Cloudflare side — the Worker relays PostHog's upstream response headers. PostHog reflects the request `Origin`:

- `capacitor://localhost` (native) → `200`, `access-control-allow-origin: capacitor://localhost`
- `https://app.freifahren.org` (web) → `200`, origin reflected (and same-origin in practice, so no preflight)

## Validation

- `bun run format:check` ✅, `bun run lint` ✅ (0 errors)
- `wrangler@latest deploy --dry-run` ✅ — `run_worker_first` accepted, worker bundled, `ASSETS` binding wired

## Rollout

Merging runs the deploy workflow, which `wrangler deploy`s the web Worker **and** publishes a Capacitor OTA bundle — web and native both pick up the proxy host, no App Store submission. Suggested: merge → confirm web events land → verify a `report_submitted` from the native app on a real device.

## Path name

Uses `/relay` rather than `/ingest` — PostHog warns that obvious names get blocklisted. Trivial to change.