### PR TITLE
fix: pin warehouse-export R2 bucket to EU jurisdiction

### DIFF
--- a/packages/warehouse-export/wrangler.jsonc
+++ b/packages/warehouse-export/wrangler.jsonc
@@ -12,7 +12,7 @@
             "database_id": "f8e11f14-15a5-42a8-8eba-5ab513175890",
         },
     ],
-    "r2_buckets": [{ "binding": "WAREHOUSE", "bucket_name": "freifahren-warehouse" }],
+    "r2_buckets": [{ "binding": "WAREHOUSE", "bucket_name": "freifahren-warehouse", "jurisdiction": "eu" }],
     // Daily snapshot at 03:00 UTC; PostHog re-syncs the R2 files on its own schedule.
     "triggers": { "crons": ["0 3 * * *"] },
 }


### PR DESCRIPTION
Creates `freifahren-warehouse` in the **EU jurisdiction** for data residency (consistent with the EU D1 database and PostHog Cloud EU).

An EU-jurisdiction bucket lives in a separate namespace, so the Worker's R2 binding must declare `"jurisdiction": "eu"` — otherwise it resolves the default-jurisdiction namespace and can't find the bucket.

```diff
-    "r2_buckets": [{ "binding": "WAREHOUSE", "bucket_name": "freifahren-warehouse" }],
+    "r2_buckets": [{ "binding": "WAREHOUSE", "bucket_name": "freifahren-warehouse", "jurisdiction": "eu" }],
```

Verified: `wrangler deploy --dry-run` resolves the binding as `freifahren-warehouse (eu)`.

**Depends on** the bucket being created in EU first: `wrangler r2 bucket create freifahren-warehouse --jurisdiction eu` (jurisdiction is a header-only API option, so it can't be done via the dashboard MCP — needs wrangler or the dashboard).