### PR TITLE
feat: add "Get the app" banner for iOS web users

### DIFF
--- a/packages/frontend-next/index.html
+++ b/packages/frontend-next/index.html
@@ -15,6 +15,13 @@
     <!-- Paints the iOS status-bar / dynamic-island area with the card color (matches the
          report form and the map search bar). Keep in sync with --card in src/index.css. -->
     <meta name="theme-color" content="#25272b" />
+    <!-- Native Smart App Banner (iOS Safari only; other iOS browsers get the custom AppBanner). app-argument
+         deep-links to the current URL when the app is installed. Keep app-id in sync with APP_STORE_ID in
+         src/lib/app-banner.ts. -->
+    <meta
+      name="apple-itunes-app"
+      content="app-id=6738277309, app-argument=https://app.freifahren.org/"
+    />
     <!-- Lock page scale: the map owns pinch-zoom, so the page itself must never zoom.
          This also stops iOS Safari auto-zooming when the (position:fixed) search input is focused. -->
     <meta

--- a/packages/frontend-next/src/components/AppBanner.i18n.ts
+++ b/packages/frontend-next/src/components/AppBanner.i18n.ts
@@ -1,0 +1,17 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'appBanner';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  title: 'FreiFahren',
+  text: 'Faster and offline-ready in the app.',
+  open: 'Open in App Store',
+  dismiss: 'Dismiss',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  title: 'FreiFahren',
+  text: 'Schneller und offline-fähig in der App.',
+  open: 'Im App Store öffnen',
+  dismiss: 'Schließen',
+});

--- a/packages/frontend-next/src/components/AppBanner.tsx
+++ b/packages/frontend-next/src/components/AppBanner.tsx
@@ -1,0 +1,65 @@
+import { X } from 'lucide-react';
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { APP_STORE_URL, dismissAppBanner, useShowAppBanner } from '@/lib/app-banner';
+
+import { NAMESPACE } from './AppBanner.i18n';
+
+// "Get the app" banner for iOS users on a non-Safari browser (Safari gets Apple's native Smart App
+// Banner via the meta tag in index.html). While mounted it publishes its height as --app-banner-offset,
+// which the pt-safe / top-safe utilities add in so the top-anchored UI shifts down instead of overlapping.
+export function AppBanner() {
+  const { t } = useTranslation(NAMESPACE);
+  const show = useShowAppBanner();
+
+  useEffect(() => {
+    if (!show) return;
+    const root = document.documentElement;
+    const el = document.getElementById('app-banner');
+    if (!el) return;
+    const apply = () => root.style.setProperty('--app-banner-offset', `${el.offsetHeight}px`);
+    apply();
+    const observer = new ResizeObserver(apply);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      root.style.removeProperty('--app-banner-offset');
+    };
+  }, [show]);
+
+  if (!show) return null;
+
+  return createPortal(
+    <div
+      id="app-banner"
+      className="bg-card text-card-foreground border-border-soft fixed inset-x-0 top-0 z-40 flex items-center gap-3 border-b px-3 pt-[calc(0.5rem+env(safe-area-inset-top))] pb-2 shadow-sm"
+    >
+      <img src="/pwa-192x192.png" alt="" className="size-10 shrink-0 rounded-lg" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold">{t('title')}</p>
+        <p className="text-muted-foreground truncate text-xs">{t('text')}</p>
+      </div>
+      <Button
+        asChild
+        size="xs"
+        className="bg-accent-bright text-primary-foreground hover:bg-accent-press shrink-0"
+      >
+        <a href={APP_STORE_URL} target="_blank" rel="noreferrer">
+          {t('open')}
+        </a>
+      </Button>
+      <button
+        type="button"
+        aria-label={t('dismiss')}
+        onClick={dismissAppBanner}
+        className="text-muted-foreground hover:text-foreground -mr-1 shrink-0 p-1"
+      >
+        <X className="size-4" />
+      </button>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/frontend-next/src/components/AppBanner.tsx
+++ b/packages/frontend-next/src/components/AppBanner.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
+import { track } from '@/lib/analytics';
 import { APP_STORE_URL, dismissAppBanner, useShowAppBanner } from '@/lib/app-banner';
 
 import { NAMESPACE } from './AppBanner.i18n';
@@ -14,6 +15,10 @@ import { NAMESPACE } from './AppBanner.i18n';
 export function AppBanner() {
   const { t } = useTranslation(NAMESPACE);
   const show = useShowAppBanner();
+
+  useEffect(() => {
+    if (show) track('app_banner_shown', {});
+  }, [show]);
 
   useEffect(() => {
     if (!show) return;
@@ -47,14 +52,22 @@ export function AppBanner() {
         size="xs"
         className="bg-accent-bright text-primary-foreground hover:bg-accent-press shrink-0"
       >
-        <a href={APP_STORE_URL} target="_blank" rel="noreferrer">
+        <a
+          href={APP_STORE_URL}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() => track('app_banner_store_clicked', {})}
+        >
           {t('open')}
         </a>
       </Button>
       <button
         type="button"
         aria-label={t('dismiss')}
-        onClick={dismissAppBanner}
+        onClick={() => {
+          track('app_banner_dismissed', {});
+          dismissAppBanner();
+        }}
         className="text-muted-foreground hover:text-foreground -mr-1 shrink-0 p-1"
       >
         <X className="size-4" />

--- a/packages/frontend-next/src/index.css
+++ b/packages/frontend-next/src/index.css
@@ -153,13 +153,19 @@
 
 /* Spacing utilities that add the iOS safe-area inset on top of a normal spacing step, so anchored
    UI clears the status bar / home indicator in the full-bleed native WebView. The inset is 0 on the
-   web. Centralized here so the env() math isn't repeated per component. e.g. pt-safe-6 == pt-6 + top inset. */
+   web. Centralized here so the env() math isn't repeated per component. e.g. pt-safe-6 == pt-6 + top inset.
+   The top variants also clear the "Get the app" banner: --app-banner-offset already includes the safe-area
+   inset, so max() takes the taller of the two — the inset when hidden, the banner height when shown. */
 @utility pt-safe-* {
-  padding-top: calc(var(--spacing) * --value(integer) + env(safe-area-inset-top));
+  padding-top: calc(
+    var(--spacing) * --value(integer) + max(env(safe-area-inset-top), var(--app-banner-offset, 0px))
+  );
 }
 @utility pb-safe-* {
   padding-bottom: calc(var(--spacing) * --value(integer) + env(safe-area-inset-bottom));
 }
 @utility top-safe-* {
-  top: calc(var(--spacing) * --value(integer) + env(safe-area-inset-top));
+  top: calc(
+    var(--spacing) * --value(integer) + max(env(safe-area-inset-top), var(--app-banner-offset, 0px))
+  );
 }

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -41,6 +41,13 @@ type AnalyticsEvents = {
   reports_tab_selected: { tab: 'summary' | 'lines' | 'reports' };
   report_row_selected: { report_age_minutes: number; has_line: boolean; has_direction: boolean };
   detail_modal_closed: { modal: 'station' | 'report'; duration_ms: number };
+  // Custom "Get the app" banner shown to iOS users off Safari (Safari's native Smart App Banner is
+  // OS-owned and can't be instrumented). No props needed: PostHog's auto-captured $browser slices the
+  // funnel — Chrome iOS / Firefox iOS, and "Mobile Safari" here means an in-app webview since these
+  // events never fire in real Safari.
+  app_banner_shown: Record<string, never>;
+  app_banner_store_clicked: Record<string, never>;
+  app_banner_dismissed: Record<string, never>;
 };
 
 export function track<E extends keyof AnalyticsEvents>(

--- a/packages/frontend-next/src/lib/app-banner.ts
+++ b/packages/frontend-next/src/lib/app-banner.ts
@@ -1,0 +1,66 @@
+import { Capacitor } from '@capacitor/core';
+import { useSyncExternalStore } from 'react';
+
+// Numeric App Store ID (not the bundle id). Keep in sync with the apple-itunes-app tag in index.html.
+export const APP_STORE_ID = '6738277309';
+
+export const APP_STORE_URL = `https://apps.apple.com/app/id${APP_STORE_ID}`;
+
+const STORAGE_KEY = 'iosAppBannerDismissed';
+
+function detectIos(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent;
+  if (/iP(hone|ad|od)/.test(ua)) return true;
+  // iPadOS 13+ reports a Mac user-agent; the touch points give it away.
+  return /Mac/.test(ua) && navigator.maxTouchPoints > 1;
+}
+
+// Only genuine iOS Safari renders Apple's native Smart App Banner; every other iOS browser (which tags
+// itself: CriOS/FxiOS/EdgiOS/OPiOS) and in-app WKWebViews (no "Version/"+"Safari" pair) get our custom
+// banner instead, so the two never double up.
+function detectIosSafari(ua: string): boolean {
+  const isOtherBrowser = /CriOS|FxiOS|EdgiOS|OPiOS|OPT\//.test(ua);
+  const hasSafariToken = /Version\//.test(ua) && /Safari/.test(ua);
+  return hasSafariToken && !isOtherBrowser;
+}
+
+const eligible =
+  detectIos() &&
+  !Capacitor.isNativePlatform() &&
+  typeof navigator !== 'undefined' &&
+  !detectIosSafari(navigator.userAgent);
+
+function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+let dismissed = readDismissed();
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function shouldShow(): boolean {
+  return eligible && !dismissed;
+}
+
+export function dismissAppBanner(): void {
+  dismissed = true;
+  try {
+    localStorage.setItem(STORAGE_KEY, '1');
+  } catch {
+    // In-memory flag still hides it for this session.
+  }
+  for (const listener of listeners) listener();
+}
+
+export function useShowAppBanner(): boolean {
+  return useSyncExternalStore(subscribe, shouldShow);
+}

--- a/packages/frontend-next/src/routes/__root.tsx
+++ b/packages/frontend-next/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router';
 
+import { AppBanner } from '@/components/AppBanner';
 import { ConsentBanner } from '@/components/ConsentBanner';
 import { ContributeCard } from '@/components/contribute/ContributeCard';
 import { FeedbackCard } from '@/components/feedback/FeedbackCard';
@@ -15,6 +16,7 @@ export const Route = createRootRoute({
   component: () => (
     <GeolocationProvider>
       <PersistentMapView />
+      <AppBanner />
       <Outlet />
       <LegalDisclaimer />
       <ContributeCard />


### PR DESCRIPTION
## Summary

Promotes the native iOS app to iOS **web** visitors, adapting to the browser (FRE-684):

- **Safari (iOS):** Apple's native **Smart App Banner** via an `apple-itunes-app` meta tag in `index.html`, with `app-argument` deep-linking to the current URL when the app is installed.
- **Other iOS browsers** (Chrome, Firefox, in-app webviews like Instagram/WhatsApp): a **custom dismissible top banner** linking to the App Store, since the native banner only renders in Safari.

## Custom banner gating

Shows only when **all** hold:
- Platform is iOS (incl. the iPadOS-13+ Mac-UA case, detected via `maxTouchPoints > 1`).
- Browser is **not** Safari (Chrome/Firefox/Edge/Opera tag themselves; in-app WKWebViews lack the `Version/`+`Safari` token pair) — so it never doubles up with the native banner.
- **Not** inside the Capacitor native app (`Capacitor.isNativePlatform()`).
- Not previously dismissed (persisted in `localStorage`).

## Layout / safe area

While mounted, the banner publishes its measured height (`ResizeObserver`) as a `--app-banner-offset` CSS var. The shared `pt-safe-*` / `top-safe-*` utilities fold it in via `max(env(safe-area-inset-top), var(--app-banner-offset, 0px))`, so every top-anchored element (search bar, map buttons, toasts) shifts down with a single change — no double-counting, notch-safe.

## Notes

- App Store ID (`6738277309`) lives in one constant (`src/lib/app-banner.ts`) plus the meta tag; a comment keeps them in sync.
- Android/Play Store intentionally out of scope for now.
- en/de strings added.

## Test plan

- [ ] iOS Safari: native Smart App Banner appears.
- [ ] iOS Chrome/Firefox/in-app webview: custom banner appears, links to the App Store, dismiss persists.
- [ ] Capacitor native app: no banner.
- [ ] Non-iOS / desktop: no banner.
- [ ] Search bar and map buttons clear the banner (no overlap) and return to normal once dismissed.

## Analytics

Instrumented the custom banner (Safari's native banner is OS-owned and can't be tracked) with three events: `app_banner_shown`, `app_banner_store_clicked`, `app_banner_dismissed`. No custom `browser` property — PostHog's auto-captured `$browser` already slices it (Chrome iOS / Firefox iOS, and `Mobile Safari` on these events means an in-app webview, since real Safari never fires them).

New PostHog dashboard **[iOS App Banner](https://eu.posthog.com/project/200383/dashboard/786233)** (populates once this ships):
- **Banner → App Store tap-through** — headline shown→click conversion funnel
- **Banner outcomes over time** — weekly shown vs clicked vs dismissed
- **Banner reach by browser** — which iOS browsers see it (`$browser` breakdown)
- **Tap-through by browser** — conversion split by `$browser`
