### PR TITLE
fix: serve the web app shell network-first so deploys roll out immediately

### DIFF
--- a/docs/adr/0008-network-first-app-shell.md
+++ b/docs/adr/0008-network-first-app-shell.md
@@ -1,0 +1,49 @@
+# Web app shell: network-first HTML so deploys roll out on the next load
+
+## Status
+
+accepted
+
+## Context
+
+The web app's service worker precached the app shell (`index.html`) and served it via a
+`navigateFallback` NavigationRoute — cache-first. Even with `registerType: 'autoUpdate'`, the new
+service worker only takes over on a *later* navigation, so a fresh deploy reached users one
+navigation late, and in practice sometimes only after a manual browser cache clear (observed while
+shipping FRE-684). `index.html` is already served `must-revalidate` at the edge (`public/_headers`),
+so the staleness was entirely the service-worker layer. The lag forces us to keep the API and query
+shapes backward-compatible with shells that trail the current build.
+
+## Decision
+
+Serve the HTML document **network-first**: a `runtimeCaching` rule matching `request.mode ===
+'navigate'` (`NetworkFirst`, 3s network timeout, `app-shell` cache). Online, every hard load fetches
+the current `index.html`, which references the latest content-hashed bundle, so users are never a
+version behind. The hashed JS/CSS/fonts stay **precached / cache-first** — they're immutable (a new
+build gets new filenames), so cache-first is correct and keeps the boot instant and offline-capable.
+
+`navigateFallback` is set to `null` (vite-plugin-pwa defaults it to `index.html`). Its NavigationRoute
+is registered *before* `runtimeCaching` and first-match-wins, so leaving it on would shadow the
+network-first rule and keep serving the stale shell. With it off, the network-first rule is the sole
+navigation handler and caches each visited shell, so a returning visitor still cold-boots offline.
+
+Keep the service worker. Dropping it would also make every load latest, but forfeits offline
+cold-boot (the tunnel scenario this app exists for) and installability.
+
+## Considered alternatives
+
+- **Drop the PWA / service worker entirely:** rejected — loses offline cold-boot and Add-to-Home-Screen.
+  The app's core value is checking for inspectors underground with no signal.
+- **Keep the precache shell, add a prompt / auto-reload when a new SW activates:** rejected — still one
+  navigation behind and adds update UI (AGENTS.md: keep update UI minimal). Network-first removes the
+  lag at its source.
+
+## Consequences
+
+- Deploys reach users on the next hard load, no manual cache clear — less backward-compat burden.
+- A hard navigation now waits on a network round-trip when online (3s timeout, then the cached shell).
+  In-app SPA navigation is client-side and unaffected.
+- Offline now covers **previously-visited pages** (the network-first cache) rather than any path (the
+  old precache fallback). This narrows web offline slightly but matches the best-effort framing already
+  in [ADR 0005](0005-offline-basemap-http-cache-web-indexeddb-capacitor.md).
+- Unchanged in the Capacitor build, which ships no service worker at all (FRE-649).

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -112,14 +112,37 @@ export default defineConfig({
           ],
         },
         workbox: {
-          // Precache the app shell: HTML, hashed JS/CSS, the IBM Plex woff2 files, and the lazy
-          // maplibre chunk (~1 MB, under the 2 MB default cap) so the map engine paints offline too.
+          // Precache the immutable, content-hashed assets: JS/CSS, the IBM Plex woff2 files, and the
+          // lazy maplibre chunk (~1 MB, under the 2 MB default cap) so the map engine paints offline
+          // too. Cache-first is correct for these — a new build gets new filenames, so they're never
+          // stale. The HTML document is deliberately handled by the network-first rule below, not this
+          // precache, so a deploy is never served stale.
           globPatterns: ['**/*.{js,css,html,woff2,svg,png,ico}'],
-          // Offline SPA navigations resolve to the precached shell. Navigation routing only matches
-          // navigation requests, so it doesn't touch the cross-origin tile/API fetches, nor does it
-          // clash with wrangler's server-side single-page-application fallback (that only runs online).
-          navigateFallback: '/index.html',
+          // Disable navigateFallback (vite-plugin-pwa defaults it to index.html). Its NavigationRoute is
+          // registered *before* runtimeCaching and first-match-wins, so a precache navigateFallback would
+          // shadow the network-first rule below and keep serving the stale shell. With it off, the
+          // network-first navigation rule is the sole navigation handler; it caches each visited shell, so
+          // returning visitors still cold-boot offline (previously-visited pages only — the best-effort web
+          // offline of ADR 0005). It only matches navigation requests, so it never touches the cross-origin
+          // tile/API fetches.
+          navigateFallback: null,
           runtimeCaching: [
+            {
+              // The HTML document is network-first: a fresh deploy is picked up on the very next load,
+              // not one navigation later (the autoUpdate lag) and never needing a manual cache clear.
+              // The hashed JS/CSS it references stay precache/cache-first (immutable, so never stale).
+              // The last successful shell is cached, so a returning visitor still cold-boots offline.
+              // See ADR 0008.
+              urlPattern: ({ request }) => request.mode === 'navigate',
+              handler: 'NetworkFirst',
+              options: {
+                cacheName: 'app-shell',
+                // Fall back to the cached shell quickly on a flaky/tunnel connection rather than hanging.
+                networkTimeoutSeconds: 3,
+                expiration: { maxEntries: 8, maxAgeSeconds: 60 * 60 * 24 * 30 },
+                cacheableResponse: { statuses: [0, 200] },
+              },
+            },
             {
               // Style JSON is the one mutable pointer (it names the current immutable /v<sha>/ archive).
               // StaleWhileRevalidate paints instantly from cache but refreshes in the background, so a


### PR DESCRIPTION
## Problem

A fresh deploy didn't reach users promptly: the service worker precached `index.html` and served it **cache-first** via `navigateFallback`. Even with `registerType: 'autoUpdate'`, the new SW only takes over on a *later* navigation, so users were a version behind — and sometimes stuck until a manual browser cache clear (seen while shipping the FRE-684 banner). `index.html` is already `must-revalidate` at the edge (`public/_headers`), so the staleness was entirely the service-worker layer.

## Change

Serve the HTML document **network-first**:
- New `runtimeCaching` rule matching `request.mode === 'navigate'` → `NetworkFirst` (3s network timeout, `app-shell` cache). Online, every hard load fetches the current `index.html` → latest hashed bundle. Users are never a version behind.
- Content-hashed JS/CSS/fonts stay **precache / cache-first** — immutable (new build = new filename), so cache-first is correct and keeps the boot instant + offline-capable.
- `navigateFallback: null` — vite-plugin-pwa defaults it to `index.html`, and its NavigationRoute is registered *before* `runtimeCaching` (first-match-wins), so leaving it on would shadow the network-first rule and keep serving the stale shell. Verified against the generated `dist/sw.js`: no `NavigationRoute`, network-first navigate route present.

The service worker stays — dropping it would forfeit offline cold-boot (the underground/no-signal scenario the app exists for) and installability.

## Trade-off

Offline now covers **previously-visited pages** (from the network-first cache) rather than any path (the old precache fallback). This narrows web offline slightly but matches the best-effort framing already in ADR 0005. In-app SPA navigation is client-side and unaffected; only hard loads take a network round-trip when online.

Decision recorded in **ADR 0008** (`docs/adr/0008-network-first-app-shell.md`), cross-referencing ADR 0005 and the FRE-649 no-SW-in-Capacitor context.
