### PR TITLE
feat: two-tier feedback on the report-success screen

### DIFF
--- a/packages/api-worker/package.json
+++ b/packages/api-worker/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "wrangler dev",
+    "seed": "./scripts/seed-local-d1.sh",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
     "test": "bun test",

--- a/packages/api-worker/scripts/seed-local-d1.sh
+++ b/packages/api-worker/scripts/seed-local-d1.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Seed the local D1 database used by `wrangler dev`: seed the libsql file, apply D1 migrations, then
+# copy the reference tables (stations/lines/line_stations/segments) into D1.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+LIBSQL_FILE="local.db"
+SEED_SQL="$(mktemp -t freifahren-d1-seed).sql"
+trap 'rm -f "$SEED_SQL"' EXIT
+
+echo "→ Seeding libsql reference data ($LIBSQL_FILE)..."
+DATABASE_URL="file:./$LIBSQL_FILE" bun run db:seed
+
+echo "→ Applying D1 migrations to local D1..."
+bunx wrangler d1 migrations apply DB --local
+
+echo "→ Copying reference tables into local D1..."
+# Parents before children for FK order; INSERT OR IGNORE keeps re-runs idempotent and reports intact.
+: > "$SEED_SQL"
+for t in stations lines line_stations segments; do
+  sqlite3 "$LIBSQL_FILE" ".mode insert $t" "select * from $t;" |
+    sed 's/^INSERT INTO/INSERT OR IGNORE INTO/' >> "$SEED_SQL"
+done
+bunx wrangler d1 execute DB --local --file="$SEED_SQL"
+
+echo "✓ Local D1 seeded. Run 'bun run dev'."

--- a/packages/frontend-next/src/components/feedback/FeedbackCard.tsx
+++ b/packages/frontend-next/src/components/feedback/FeedbackCard.tsx
@@ -20,7 +20,6 @@ function FeedbackCardContent() {
   return (
     <DetailCard title={t('title')} closeLabel={t('close')} onClose={closeFeedbackModal}>
       <CardContent>
-        {/* Brief success confirmation, then dismiss. */}
         <FeedbackForm onSubmitted={() => window.setTimeout(closeFeedbackModal, 1200)} />
       </CardContent>
     </DetailCard>

--- a/packages/frontend-next/src/components/feedback/FeedbackCard.tsx
+++ b/packages/frontend-next/src/components/feedback/FeedbackCard.tsx
@@ -1,16 +1,10 @@
-import { useRouterState } from '@tanstack/react-router';
-import { Check } from 'lucide-react';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DetailCard } from '@/components/map/DetailCard';
-import { Button } from '@/components/ui/button';
 import { CardContent } from '@/components/ui/card';
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
-import { captureSurveySent, type FeedbackType } from '@/lib/analytics';
-import { closeFeedbackModal, FEEDBACK_SURVEY_ID, useFeedbackModalOpen } from '@/lib/feedback-modal';
-import { cn } from '@/lib/utils';
+import { closeFeedbackModal, useFeedbackModalOpen } from '@/lib/feedback-modal';
 
+import { FeedbackForm } from './FeedbackForm';
 import { NAMESPACE } from './FeedbackCard.i18n';
 
 export function FeedbackCard() {
@@ -20,107 +14,14 @@ export function FeedbackCard() {
   return <FeedbackCardContent />;
 }
 
-const TYPE_OPTIONS: { value: FeedbackType; labelKey: string }[] = [
-  { value: 'feature_request', labelKey: 'typeFeature' },
-  { value: 'bug_report', labelKey: 'typeBug' },
-  { value: 'general', labelKey: 'typeGeneral' },
-];
-
 function FeedbackCardContent() {
   const { t } = useTranslation(NAMESPACE);
-  const pageRoute = useRouterState({ select: (s) => s.location.pathname });
-
-  const [feedbackType, setFeedbackType] = useState<FeedbackType>('feature_request');
-  const [message, setMessage] = useState('');
-  const [status, setStatus] = useState<'editing' | 'sending' | 'done' | 'error'>('editing');
-
-  const handleSubmit = () => {
-    const trimmed = message.trim();
-    if (!trimmed) return;
-    setStatus('sending');
-    try {
-      captureSurveySent(FEEDBACK_SURVEY_ID, {
-        feedbackType,
-        message: trimmed,
-        pageRoute,
-        appVersion: __BUILD_ID__,
-      });
-      setStatus('done');
-      // Brief success confirmation, then dismiss.
-      window.setTimeout(closeFeedbackModal, 1200);
-    } catch {
-      setStatus('error');
-    }
-  };
-
-  if (status === 'done') {
-    return (
-      <DetailCard title={t('title')} closeLabel={t('close')} onClose={closeFeedbackModal}>
-        <CardContent className="flex flex-col items-center gap-3 py-6 text-center">
-          <div className="bg-accent-bright text-primary-foreground animate-in zoom-in-50 fade-in flex size-14 items-center justify-center rounded-full duration-300">
-            <Check className="size-7" />
-          </div>
-          <h3 className="font-heading text-lg font-semibold">{t('successTitle')}</h3>
-          <p className="text-muted-foreground text-sm">{t('successText')}</p>
-        </CardContent>
-      </DetailCard>
-    );
-  }
-
-  const sending = status === 'sending';
-  const canSubmit = message.trim().length > 0 && !sending;
 
   return (
     <DetailCard title={t('title')} closeLabel={t('close')} onClose={closeFeedbackModal}>
-      <CardContent className="flex flex-col gap-4">
-        <div className="flex flex-col gap-2">
-          <span className="text-sm font-semibold">{t('typeLabel')}</span>
-          <ToggleGroup
-            type="single"
-            variant="outline"
-            value={feedbackType}
-            // Radix clears the value when re-selecting the active item; keep a selection always.
-            onValueChange={(value) => value && setFeedbackType(value as FeedbackType)}
-            className="grid w-full grid-cols-3"
-          >
-            {TYPE_OPTIONS.map((option) => (
-              <ToggleGroupItem key={option.value} value={option.value} className="text-xs">
-                {t(option.labelKey)}
-              </ToggleGroupItem>
-            ))}
-          </ToggleGroup>
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <label htmlFor="feedback-message" className="text-sm font-semibold">
-            {t('messageLabel')}
-          </label>
-          <textarea
-            id="feedback-message"
-            value={message}
-            onChange={(event) => setMessage(event.target.value)}
-            placeholder={t('messagePlaceholder')}
-            rows={4}
-            className="border-input bg-input/20 placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 dark:bg-input/30 min-h-24 w-full resize-none rounded-md border px-3 py-2 text-sm transition-colors outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50"
-          />
-        </div>
-
-        {status === 'error' && <p className="text-destructive text-sm">{t('error')}</p>}
-
-        <Button
-          type="button"
-          size="lg"
-          disabled={!canSubmit}
-          onClick={handleSubmit}
-          className={cn(
-            'h-11 w-full gap-2',
-            canSubmit
-              ? 'bg-accent-bright text-primary-foreground hover:bg-accent-press'
-              : 'bg-surface-solid text-muted-foreground border-border border',
-          )}
-        >
-          {sending ? t('submitting') : status === 'error' ? t('retry') : t('submit')}
-        </Button>
+      <CardContent>
+        {/* Brief success confirmation, then dismiss. */}
+        <FeedbackForm onSubmitted={() => window.setTimeout(closeFeedbackModal, 1200)} />
       </CardContent>
     </DetailCard>
   );

--- a/packages/frontend-next/src/components/feedback/FeedbackForm.tsx
+++ b/packages/frontend-next/src/components/feedback/FeedbackForm.tsx
@@ -1,0 +1,127 @@
+import { useRouterState } from '@tanstack/react-router';
+import { Check } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { captureSurveySent, type FeedbackType } from '@/lib/analytics';
+import { FEEDBACK_SURVEY_ID } from '@/lib/feedback-modal';
+import { cn } from '@/lib/utils';
+
+import { NAMESPACE } from './FeedbackCard.i18n';
+
+const TYPE_OPTIONS: { value: FeedbackType; labelKey: string }[] = [
+  { value: 'feature_request', labelKey: 'typeFeature' },
+  { value: 'bug_report', labelKey: 'typeBug' },
+  { value: 'general', labelKey: 'typeGeneral' },
+];
+
+// The feedback form body, decoupled from any surface. Used both inside the modal (FeedbackCard) and
+// embedded directly into a page (e.g. the report-success screen). onSubmitted lets the modal auto-
+// dismiss after the success state; embedded usages can leave the thank-you in place. `compact`
+// shrinks the footprint (smaller textarea, tighter spacing) so it's easy to skip past when embedded.
+export function FeedbackForm({
+  onSubmitted,
+  compact = false,
+}: {
+  onSubmitted?: () => void;
+  compact?: boolean;
+}) {
+  const { t } = useTranslation(NAMESPACE);
+  const pageRoute = useRouterState({ select: (s) => s.location.pathname });
+
+  const [feedbackType, setFeedbackType] = useState<FeedbackType>('feature_request');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<'editing' | 'sending' | 'done' | 'error'>('editing');
+
+  const handleSubmit = () => {
+    const trimmed = message.trim();
+    if (!trimmed) return;
+    setStatus('sending');
+    try {
+      captureSurveySent(FEEDBACK_SURVEY_ID, {
+        feedbackType,
+        message: trimmed,
+        pageRoute,
+        appVersion: __BUILD_ID__,
+      });
+      setStatus('done');
+      onSubmitted?.();
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  if (status === 'done') {
+    return (
+      <div className="flex flex-col items-center gap-3 py-6 text-center">
+        <div className="bg-accent-bright text-primary-foreground animate-in zoom-in-50 fade-in flex size-14 items-center justify-center rounded-full duration-300">
+          <Check className="size-7" />
+        </div>
+        <h3 className="font-heading text-lg font-semibold">{t('successTitle')}</h3>
+        <p className="text-muted-foreground text-sm">{t('successText')}</p>
+      </div>
+    );
+  }
+
+  const sending = status === 'sending';
+  const canSubmit = message.trim().length > 0 && !sending;
+
+  return (
+    <div className={cn('flex flex-col', compact ? 'gap-2.5' : 'gap-4')}>
+      <div className="flex flex-col gap-2">
+        <span className="text-sm font-semibold">{t('typeLabel')}</span>
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          value={feedbackType}
+          // Radix clears the value when re-selecting the active item; keep a selection always.
+          onValueChange={(value) => value && setFeedbackType(value as FeedbackType)}
+          className="grid w-full grid-cols-3"
+        >
+          {TYPE_OPTIONS.map((option) => (
+            <ToggleGroupItem key={option.value} value={option.value} className="text-xs">
+              {t(option.labelKey)}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="feedback-message" className="text-sm font-semibold">
+          {t('messageLabel')}
+        </label>
+        <textarea
+          id="feedback-message"
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          placeholder={t('messagePlaceholder')}
+          rows={compact ? 2 : 4}
+          className={cn(
+            'border-input bg-input/20 placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 dark:bg-input/30 w-full resize-none rounded-md border px-3 py-2 text-sm transition-colors outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50',
+            compact ? 'min-h-16' : 'min-h-24',
+          )}
+        />
+      </div>
+
+      {status === 'error' && <p className="text-destructive text-sm">{t('error')}</p>}
+
+      <Button
+        type="button"
+        size="lg"
+        disabled={!canSubmit}
+        onClick={handleSubmit}
+        className={cn(
+          'w-full gap-2',
+          compact ? 'h-10' : 'h-11',
+          canSubmit
+            ? 'bg-accent-bright text-primary-foreground hover:bg-accent-press'
+            : 'bg-surface-solid text-muted-foreground border-border border',
+        )}
+      >
+        {sending ? t('submitting') : status === 'error' ? t('retry') : t('submit')}
+      </Button>
+    </div>
+  );
+}

--- a/packages/frontend-next/src/components/feedback/FeedbackForm.tsx
+++ b/packages/frontend-next/src/components/feedback/FeedbackForm.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
-import { captureSurveySent, type FeedbackType } from '@/lib/analytics';
+import { captureSurveySent, type FeedbackSentiment, type FeedbackType } from '@/lib/analytics';
 import { FEEDBACK_SURVEY_ID } from '@/lib/feedback-modal';
 import { cn } from '@/lib/utils';
 
@@ -17,16 +17,17 @@ const TYPE_OPTIONS: { value: FeedbackType; labelKey: string }[] = [
   { value: 'general', labelKey: 'typeGeneral' },
 ];
 
-// The feedback form body, decoupled from any surface. Used both inside the modal (FeedbackCard) and
-// embedded directly into a page (e.g. the report-success screen). onSubmitted lets the modal auto-
-// dismiss after the success state; embedded usages can leave the thank-you in place. `compact`
-// shrinks the footprint (smaller textarea, tighter spacing) so it's easy to skip past when embedded.
+// The feedback form body, shared by the modal (FeedbackCard) and the embedded report-success screen.
 export function FeedbackForm({
   onSubmitted,
   compact = false,
+  sentiment,
+  submitVariant = 'accent',
 }: {
   onSubmitted?: () => void;
   compact?: boolean;
+  sentiment?: FeedbackSentiment;
+  submitVariant?: 'accent' | 'neutral';
 }) {
   const { t } = useTranslation(NAMESPACE);
   const pageRoute = useRouterState({ select: (s) => s.location.pathname });
@@ -45,6 +46,7 @@ export function FeedbackForm({
         message: trimmed,
         pageRoute,
         appVersion: __BUILD_ID__,
+        sentiment,
       });
       setStatus('done');
       onSubmitted?.();
@@ -115,9 +117,13 @@ export function FeedbackForm({
         className={cn(
           'w-full gap-2',
           compact ? 'h-10' : 'h-11',
-          canSubmit
-            ? 'bg-accent-bright text-primary-foreground hover:bg-accent-press'
-            : 'bg-surface-solid text-muted-foreground border-border border',
+          canSubmit &&
+            submitVariant === 'accent' &&
+            'bg-accent-bright text-primary-foreground hover:bg-accent-press',
+          canSubmit &&
+            submitVariant === 'neutral' &&
+            'bg-foreground text-background hover:bg-foreground/90',
+          !canSubmit && 'bg-surface-solid text-muted-foreground border-border border',
         )}
       >
         {sending ? t('submitting') : status === 'error' ? t('retry') : t('submit')}

--- a/packages/frontend-next/src/components/report/ReportFeedback.tsx
+++ b/packages/frontend-next/src/components/report/ReportFeedback.tsx
@@ -1,0 +1,65 @@
+import { ThumbsDown, ThumbsUp } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { FeedbackForm } from '@/components/feedback/FeedbackForm';
+import { Button } from '@/components/ui/button';
+import { captureSurveyShown, type FeedbackSentiment, track } from '@/lib/analytics';
+import { FEEDBACK_SURVEY_ID } from '@/lib/feedback-modal';
+
+import { NAMESPACE } from './ReportSuccess.i18n';
+
+// Two-tier feedback: a single 👍/👎 tap, expanding to the full comment form only once opted in.
+export function ReportFeedback({ onDone }: { onDone?: () => void }) {
+  const { t } = useTranslation(NAMESPACE);
+  const [sentiment, setSentiment] = useState<FeedbackSentiment | null>(null);
+
+  useEffect(() => {
+    captureSurveyShown(FEEDBACK_SURVEY_ID);
+  }, []);
+
+  const choose = (value: FeedbackSentiment) => {
+    setSentiment(value);
+    // Capture on the tap so we get sentiment even from users who don't elaborate.
+    track('feedback_sentiment_selected', { sentiment: value });
+  };
+
+  if (!sentiment) {
+    return (
+      <div className="flex flex-col items-center gap-3">
+        <span className="text-muted-foreground text-sm">{t('sentimentPrompt')}</span>
+        <div className="flex gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => choose('positive')}
+            aria-label={t('sentimentYes')}
+            className="border-border size-12 rounded-full"
+          >
+            <ThumbsUp className="size-5" />
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => choose('negative')}
+            aria-label={t('sentimentNo')}
+            className="border-border size-12 rounded-full"
+          >
+            <ThumbsDown className="size-5" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="animate-in fade-in slide-in-from-top-1 flex flex-col text-left duration-200">
+      <FeedbackForm
+        compact
+        submitVariant="neutral"
+        sentiment={sentiment}
+        onSubmitted={onDone ? () => window.setTimeout(onDone, 1200) : undefined}
+      />
+    </div>
+  );
+}

--- a/packages/frontend-next/src/components/report/ReportSuccess.i18n.ts
+++ b/packages/frontend-next/src/components/report/ReportSuccess.i18n.ts
@@ -5,7 +5,9 @@ export const NAMESPACE = 'reportSuccess';
 i18n.addResourceBundle('en', NAMESPACE, {
   title: 'Thank you for your report!',
   description: 'people appreciate your help',
-  feedbackHeading: 'Got a moment? Tell us what you think',
+  sentimentPrompt: 'Do you like FreiFahren?',
+  sentimentYes: 'Yes, I like it',
+  sentimentNo: 'No, not really',
   syncText: 'Your report was synced with @FreiFahren_BE',
   continue: 'Continue',
 });
@@ -13,7 +15,9 @@ i18n.addResourceBundle('en', NAMESPACE, {
 i18n.addResourceBundle('de', NAMESPACE, {
   title: 'Danke für deine Meldung!',
   description: 'Menschen schätzen deine Hilfe',
-  feedbackHeading: 'Hast du kurz Zeit? Sag uns deine Meinung',
+  sentimentPrompt: 'Gefällt dir FreiFahren?',
+  sentimentYes: 'Ja, gefällt mir',
+  sentimentNo: 'Nein, eher nicht',
   syncText: 'Deine Meldung wurde mit @FreiFahren_BE synchronisiert.',
   continue: 'Weiter',
 });

--- a/packages/frontend-next/src/components/report/ReportSuccess.i18n.ts
+++ b/packages/frontend-next/src/components/report/ReportSuccess.i18n.ts
@@ -5,6 +5,7 @@ export const NAMESPACE = 'reportSuccess';
 i18n.addResourceBundle('en', NAMESPACE, {
   title: 'Thank you for your report!',
   description: 'people appreciate your help',
+  feedbackHeading: 'Got a moment? Tell us what you think',
   syncText: 'Your report was synced with @FreiFahren_BE',
   continue: 'Continue',
 });
@@ -12,6 +13,7 @@ i18n.addResourceBundle('en', NAMESPACE, {
 i18n.addResourceBundle('de', NAMESPACE, {
   title: 'Danke für deine Meldung!',
   description: 'Menschen schätzen deine Hilfe',
+  feedbackHeading: 'Hast du kurz Zeit? Sag uns deine Meinung',
   syncText: 'Deine Meldung wurde mit @FreiFahren_BE synchronisiert.',
   continue: 'Weiter',
 });

--- a/packages/frontend-next/src/components/report/ReportSuccess.tsx
+++ b/packages/frontend-next/src/components/report/ReportSuccess.tsx
@@ -1,14 +1,16 @@
 import { Check, Users } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { SubmitReportResponse } from '@/api/reports';
 import { useLines, useStations } from '@/api/transit';
-import { FeedbackButton } from '@/components/feedback/FeedbackButton';
+import { FeedbackForm } from '@/components/feedback/FeedbackForm';
 import { SocialLinks } from '@/components/map/SocialLinks';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Button } from '@/components/ui/button';
 import { useCountAnimation } from '@/hooks/useCountAnimation';
+import { captureSurveyShown } from '@/lib/analytics';
+import { FEEDBACK_SURVEY_ID } from '@/lib/feedback-modal';
 import { pickReporterCount } from '@/lib/reporters';
 
 import { NAMESPACE } from './ReportSuccess.i18n';
@@ -26,44 +28,63 @@ export function ReportSuccess({
   const [reporters] = useState(pickReporterCount);
   const count = useCountAnimation(reporters, 1500);
 
+  // The feedback form is embedded (not behind a button), so record that it was shown on arrival.
+  useEffect(() => {
+    captureSurveyShown(FEEDBACK_SURVEY_ID);
+  }, []);
+
   const stationName = stations?.[result.stationId]?.name;
   const lineName = result.lineId ? lines?.find((l) => l.id === result.lineId)?.name : null;
 
   return (
-    <div className="flex h-full flex-col items-center px-6 pt-16 pb-6 text-center">
-      <div className="bg-accent-bright text-primary-foreground animate-in zoom-in-50 fade-in flex size-16 items-center justify-center rounded-full shadow-[0_6px_16px_rgba(214,59,59,0.28)] duration-300">
-        <Check className="size-8" />
-      </div>
-      <h1 className="font-heading mt-5 text-2xl font-semibold">{t('title')}</h1>
-
-      {stationName && (
-        <div className="mt-4 flex items-center gap-2">
-          {lineName && <LineBadge name={lineName} />}
-          <span className="text-sm font-semibold">{stationName}</span>
+    <div className="flex h-full flex-col">
+      {/* Scrollable content: keeps the footer (Continue) pinned and always visible. */}
+      <div className="flex flex-1 flex-col items-center overflow-y-auto px-6 pt-6 pb-4 text-center">
+        <div className="flex items-center gap-3">
+          <div className="bg-accent-bright text-primary-foreground animate-in zoom-in-50 fade-in flex size-10 items-center justify-center rounded-full shadow-[0_6px_16px_rgba(214,59,59,0.28)] duration-300">
+            <Check className="size-6" />
+          </div>
+          <h1 className="font-heading text-xl font-semibold">{t('title')}</h1>
         </div>
-      )}
 
-      <div className="flex flex-1 flex-col items-center justify-center gap-1">
-        <div className="text-foreground flex items-center gap-2">
-          <Users className="text-muted-foreground size-6" />
-          <span className="font-heading text-4xl font-bold tabular-nums">
-            {count.toLocaleString()}
-          </span>
+        {stationName && (
+          <div className="mt-4 flex items-center gap-2">
+            {lineName && <LineBadge name={lineName} />}
+            <span className="text-sm font-semibold">{stationName}</span>
+          </div>
+        )}
+
+        <div className="mt-5 flex flex-col items-center gap-1">
+          <div className="text-foreground flex items-center gap-2">
+            <Users className="text-muted-foreground size-6" />
+            <span className="font-heading text-4xl font-bold tabular-nums">
+              {count.toLocaleString()}
+            </span>
+          </div>
+          <p className="text-muted-foreground text-sm">{t('description')}</p>
         </div>
-        <p className="text-muted-foreground text-sm">{t('description')}</p>
-        <FeedbackButton source="report_success" variant="outline" className="border-border mt-4" />
+
+        <div className="mt-6 w-full text-left">
+          <h2 className="text-muted-foreground mb-2 text-center text-sm font-semibold">
+            {t('feedbackHeading')}
+          </h2>
+          <FeedbackForm compact />
+        </div>
       </div>
 
-      <p className="text-muted-foreground text-[0.6875rem]">{t('syncText')}</p>
-      <Button
-        type="button"
-        size="lg"
-        onClick={onClose}
-        className="bg-accent-bright text-primary-foreground hover:bg-accent-press mt-4 h-12 w-full rounded-lg text-base font-semibold shadow-[0_6px_16px_rgba(214,59,59,0.28)]"
-      >
-        {t('continue')}
-      </Button>
-      <SocialLinks appearance="inline" className="mt-3 justify-center" />
+      {/* Pinned footer — the primary action stays reachable regardless of form size. */}
+      <div className="border-border/60 bg-card flex shrink-0 flex-col items-center border-t px-6 pt-3 pb-6">
+        <p className="text-muted-foreground text-[0.6875rem]">{t('syncText')}</p>
+        <Button
+          type="button"
+          size="lg"
+          onClick={onClose}
+          className="bg-accent-bright text-primary-foreground hover:bg-accent-press mt-2 h-12 w-full rounded-lg text-base font-semibold shadow-[0_6px_16px_rgba(214,59,59,0.28)]"
+        >
+          {t('continue')}
+        </Button>
+        <SocialLinks appearance="inline" className="mt-3 justify-center" />
+      </div>
     </div>
   );
 }

--- a/packages/frontend-next/src/components/report/ReportSuccess.tsx
+++ b/packages/frontend-next/src/components/report/ReportSuccess.tsx
@@ -1,18 +1,16 @@
 import { Check, Users } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { SubmitReportResponse } from '@/api/reports';
 import { useLines, useStations } from '@/api/transit';
-import { FeedbackForm } from '@/components/feedback/FeedbackForm';
 import { SocialLinks } from '@/components/map/SocialLinks';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Button } from '@/components/ui/button';
 import { useCountAnimation } from '@/hooks/useCountAnimation';
-import { captureSurveyShown } from '@/lib/analytics';
-import { FEEDBACK_SURVEY_ID } from '@/lib/feedback-modal';
 import { pickReporterCount } from '@/lib/reporters';
 
+import { ReportFeedback } from './ReportFeedback';
 import { NAMESPACE } from './ReportSuccess.i18n';
 
 export function ReportSuccess({
@@ -28,18 +26,12 @@ export function ReportSuccess({
   const [reporters] = useState(pickReporterCount);
   const count = useCountAnimation(reporters, 1500);
 
-  // The feedback form is embedded (not behind a button), so record that it was shown on arrival.
-  useEffect(() => {
-    captureSurveyShown(FEEDBACK_SURVEY_ID);
-  }, []);
-
   const stationName = stations?.[result.stationId]?.name;
   const lineName = result.lineId ? lines?.find((l) => l.id === result.lineId)?.name : null;
 
   return (
     <div className="flex h-full flex-col">
-      {/* Scrollable content: keeps the footer (Continue) pinned and always visible. */}
-      <div className="flex flex-1 flex-col items-center overflow-y-auto px-6 pt-6 pb-4 text-center">
+      <div className="flex flex-1 flex-col items-center overflow-y-auto px-6 pt-14 pb-4 text-center">
         <div className="flex items-center gap-3">
           <div className="bg-accent-bright text-primary-foreground animate-in zoom-in-50 fade-in flex size-10 items-center justify-center rounded-full shadow-[0_6px_16px_rgba(214,59,59,0.28)] duration-300">
             <Check className="size-6" />
@@ -64,15 +56,11 @@ export function ReportSuccess({
           <p className="text-muted-foreground text-sm">{t('description')}</p>
         </div>
 
-        <div className="mt-6 w-full text-left">
-          <h2 className="text-muted-foreground mb-2 text-center text-sm font-semibold">
-            {t('feedbackHeading')}
-          </h2>
-          <FeedbackForm compact />
+        <div className="mt-6 w-full">
+          <ReportFeedback onDone={onClose} />
         </div>
       </div>
 
-      {/* Pinned footer — the primary action stays reachable regardless of form size. */}
       <div className="border-border/60 bg-card flex shrink-0 flex-col items-center border-t px-6 pt-3 pb-6">
         <p className="text-muted-foreground text-[0.6875rem]">{t('syncText')}</p>
         <Button

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -41,13 +41,10 @@ type AnalyticsEvents = {
   reports_tab_selected: { tab: 'summary' | 'lines' | 'reports' };
   report_row_selected: { report_age_minutes: number; has_line: boolean; has_direction: boolean };
   detail_modal_closed: { modal: 'station' | 'report'; duration_ms: number };
-  // Custom "Get the app" banner shown to iOS users off Safari (Safari's native Smart App Banner is
-  // OS-owned and can't be instrumented). No props needed: PostHog's auto-captured $browser slices the
-  // funnel — Chrome iOS / Firefox iOS, and "Mobile Safari" here means an in-app webview since these
-  // events never fire in real Safari.
   app_banner_shown: Record<string, never>;
   app_banner_store_clicked: Record<string, never>;
   app_banner_dismissed: Record<string, never>;
+  feedback_sentiment_selected: { sentiment: FeedbackSentiment };
 };
 
 export function track<E extends keyof AnalyticsEvents>(
@@ -82,6 +79,8 @@ export function setSuperProperties(properties: Partial<SuperProperties>): void {
 }
 
 export type FeedbackType = 'feature_request' | 'bug_report' | 'general';
+
+export type FeedbackSentiment = 'positive' | 'negative';
 
 export const SURVEY_QUESTIONS = [
   { id: 'feedback_type', question: 'What kind of feedback is this?' },
@@ -123,6 +122,7 @@ export function captureSurveySent(
     message: string;
     pageRoute: string;
     appVersion: string;
+    sentiment?: FeedbackSentiment;
   },
 ): void {
   const properties = {
@@ -136,6 +136,7 @@ export function captureSurveySent(
     feedback_message: response.message,
     page_route: response.pageRoute,
     app_version: response.appVersion,
+    ...(response.sentiment ? { feedback_sentiment: response.sentiment } : {}),
   };
   if (import.meta.env.DEV) {
     console.log('[analytics] survey sent', properties);


### PR DESCRIPTION
## What

Reworks the feedback ask on the report-success screen into a two-tier, opt-in flow, and adds a one-command local D1 seed script.

### Report-success feedback (two-tier)

Previously the full feedback form (category + textarea + Submit) was shown open on every successful report, competing with the success moment and the primary Continue action.

Now:
- **Tier 1** — celebration + social proof stay the focus, with a single low-effort prompt: *"Do you like FreiFahren?"* 👍 / 👎.
- **Tier 2** — tapping a thumb reveals the full comment form (progressive disclosure). Submitting drops a brief thank-you and returns to the map.
- **Single primary CTA** — Continue stays the red primary; the feedback Submit uses a neutral (light) colour so the two never compete.
- **Layout** — content scrolls while Continue stays pinned; compact form footprint so it's easy to skip.

### Analytics

- New `feedback_sentiment_selected` event fires on the 👍/👎 tap, so we capture sentiment even from users who don't write a comment.
- `survey sent` now carries `feedback_sentiment` as a plain property (no change to the survey question schema, so response attribution is unaffected).

### Local dev

- `bun run seed` (api-worker) now does the full local D1 setup in one shot: seed the libsql file, apply D1 migrations, copy reference tables into D1. Idempotent (INSERT OR IGNORE) and preserves submitted reports.

## Testing

- `tsc --noEmit`, ESLint, and Prettier pass on all changed files.
- The modal feedback entry points (settings / report-form header) are unchanged — they keep the red Submit.

## Notes

- Mobile keyboard: the pinned Continue sits behind the on-screen keyboard while typing (expected; it returns on dismiss). Robust `visualViewport`/`interactive-widget` handling is out of scope here.
