### PR TITLE
refactor: add shared packages/cities registry and source api-worker seed from it

### DIFF
--- a/packages/api-worker/src/db/seed/config.ts
+++ b/packages/api-worker/src/db/seed/config.ts
@@ -1,24 +1,17 @@
-// This file contains the configuration for the seeding process.
-// Adapt this file to your needs. Based on your cities requirements.
+// Seed configuration. City-specific inputs (operators, admin level, colors,
+// Route-type priority) come from the shared `@freifahren/cities` registry; the
+// Pipeline-global tuning below (Overpass endpoint, merge threshold, geometry
+// Tolerance) doesn't vary by city and stays here with the pipeline.
 
-// Ordered most-to-least prioritized — used to pick a single "highest"
-// Route type when a station is served by several.
-export const ROUTE_TYPE_PRIORITY = ['subway', 'tram', 'light_rail', 'train'] as const
+import { BERLIN, type RouteType } from '@freifahren/cities'
 
-export type RouteType = (typeof ROUTE_TYPE_PRIORITY)[number]
+const CITY = BERLIN
 
-// Route types listed here always get the configured color regardless of the
-// OSM relation tags (used to give all S-Bahn lines one shared green and all
-// Tram lines one shared red). Route types absent from this map fall back to
-// The OSM colour/color tag — best for subway lines with per-line branding.
-export const ROUTE_COLORS: Partial<Record<RouteType, string>> = {
-    tram: '#be1414', // Classic Berlin tram red (tram and metro tram M* lines).
-    light_rail: '#007734', // Berlin S-Bahn green (S2), applied to all S-Bahn lines.
-}
+export type { RouteType }
 
-// Fallback when neither a configured route color nor an OSM colour/color tag is
-// Available. Mirrors the DB default on `lines.color`.
-export const DEFAULT_LINE_COLOR = '#000000'
+export const ROUTE_TYPE_PRIORITY = CITY.seed.routeTypePriority
+export const ROUTE_COLORS: Partial<Record<RouteType, string>> = CITY.seed.colors
+export const DEFAULT_LINE_COLOR = CITY.seed.defaultLineColor
 
 // Resolves the canonical color for an OSM route relation: configured route-type
 // Color first, then the OSM colour/color tag, then the default. Color is a line
@@ -33,16 +26,9 @@ export const resolveLineColor = (tags: Record<string, string | undefined>): stri
 }
 
 export const SEED_CONFIG = {
-    city: 'Berlin', // The city you want to seed.
-    adminLevel: '^[4-6]$', // The admin level of the city. Usually 4-6 for a city boundary.
-
-    // OSM `operator` tag values whose route relations should be seeded.
-    // Filtering by operator keeps the query focused without coupling the
-    // Pipeline to a hand-maintained list of line refs that drifts whenever
-    // The network changes.
-    operators: ['Berliner Verkehrsbetriebe', 'S-Bahn Berlin GmbH'],
-
-    // OSM `route` tag values to include.
+    city: CITY.displayName,
+    adminLevel: CITY.seed.adminLevel,
+    operators: CITY.seed.operators,
     routeTypes: ROUTE_TYPE_PRIORITY,
 
     // The Overpass API configuration.

--- a/packages/cities/README.md
+++ b/packages/cities/README.md
@@ -1,0 +1,30 @@
+# @freifahren/cities
+
+The shared **city registry** — the single source of truth for everything that
+differs between the cities FreiFahren serves (Berlin today, Leipzig next).
+
+City is a runtime dimension resolved from the hostname (frontend) or an explicit
+`?city=` query param (API). Code stays shared across cities; per-city differences
+live here as **data**, never as forked code.
+
+## Constraints
+
+This package is consumed by four heterogeneous toolchains — the Vite frontend
+build, three Cloudflare Worker bundles, and the Node/Bun seed scripts. It is
+therefore **dependency-free plain TypeScript data**: no runtime dependencies, no
+build step. Consumers import the source directly.
+
+## Usage
+
+```ts
+import { CITIES, getCity, DEFAULT_CITY_SLUG } from '@freifahren/cities'
+
+const city = getCity(slug) ?? CITIES[DEFAULT_CITY_SLUG]
+```
+
+## Shape
+
+See `src/types.ts` for the full `CityConfig`. Each entry carries identity
+(`slug`, `subdomain`, `displayName`, `lang`), database mapping (`dbName`,
+`dbBinding`), `map` defaults, the `seed` pipeline inputs, the Telegram language
+`profile`, and public `community` channels.

--- a/packages/cities/package.json
+++ b/packages/cities/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@freifahren/cities",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared, dependency-free city registry consumed by every FreiFahren toolchain.",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./src/index.ts"
+}

--- a/packages/cities/src/berlin.ts
+++ b/packages/cities/src/berlin.ts
@@ -1,0 +1,94 @@
+import type { CityConfig } from './types'
+
+// Few-shot examples appended to the Telegram extraction prompt. Tuned to teach
+// disambiguation the model gets wrong: slang names, direction-vs-station,
+// all-clear messages, the implicit-direction case. Kept in German since the chat
+// is mixed German/English.
+const promptExamples = `Message: "U2 alex hab in dem bahnstation gesehen"
+{"stationName": "Alex", "directionName": null}
+
+Message: "3x kotti u3 am Gleis"
+{"stationName": "Kottbusser Tor", "directionName": null}
+
+Message: "gorli u1/u3 3 Männer"
+{"stationName": "Görlitzer Bahnhof", "directionName": null}
+
+Message: "U7 Rathaus Spandau Richt Rudow Höhe sbhf Neukölln 4 Mann BOS"
+{"stationName": "Neukölln", "directionName": "Rudow"}
+
+Message: "u 8 wittenau in blauen westen höhe osloer"
+{"stationName": "osloer", "directionName": "wittenau"}
+
+Message: "Gesundbrunnen clean on u8"
+{"stationName": "Gesundbrunnen", "directionName": null}
+
+Message: "M29 bus moritzplatz"
+{"stationName": "Moritzplatz", "directionName": null}
+
+Message: "3 Bos Jacken M29 Anhalter Bahnhof Richtung Hermannplatz"
+{"stationName": "Anhalter Bahnhof", "directionName": "Hermannplatz"}
+
+Message: "S3 nach ostbahnof"
+{"stationName": null, "directionName": "Ostbahnhof"}
+
+Message: "To Rathaus SPANDAU"
+{"stationName": null, "directionName": "Rathaus Spandau"}
+
+Message: "U7 Rathaus Neukölln 3x BOS just got off the train"
+{"stationName": "Rathaus Neukölln", "directionName": null}
+
+Message: "U6 Kaiserin Augusta 2x bos"
+{"stationName": "Kaiserin-Augusta-Straße", "directionName": null}
+
+Message: "Zoo Richtung Steglitz"
+{"stationName": "Zoo", "directionName": "Steglitz"}
+
+Message: "Hi, kann mir wer ein Ticket verkaufen?"
+{"stationName": null, "directionName": null}
+`
+
+export const BERLIN: CityConfig = {
+    slug: 'berlin',
+    subdomain: 'berlin',
+    displayName: 'Berlin',
+    // D1 databases can't be renamed and we don't migrate data, so Berlin keeps
+    // the existing database and its `DB` binding.
+    dbName: 'api-worker-db-eu',
+    dbBinding: 'DB',
+    lang: 'de',
+    map: {
+        center: [13.388, 52.5162],
+        zoom: 11,
+        // Approximate S-Bahn-network extent [west, south, east, north].
+        bounds: [13.088, 52.338, 13.761, 52.675],
+        styleUrl: 'https://tiles.freifahren.org/styles/berlin.json',
+    },
+    seed: {
+        adminLevel: '^[4-6]$',
+        operators: ['Berliner Verkehrsbetriebe', 'S-Bahn Berlin GmbH'],
+        routeTypePriority: ['subway', 'tram', 'light_rail', 'train'],
+        colors: {
+            tram: '#be1414', // Classic Berlin tram red (tram and metro tram M* lines).
+            light_rail: '#007734', // Berlin S-Bahn green (S2), applied to all S-Bahn lines.
+        },
+        defaultLineColor: '#000000',
+    },
+    telegram: {
+        inspectorKeywords: 'Kontrolleur, BVG-Kontrolle, BOS, BW, Blauwesten, Zivilkontrolle, blaue Westen',
+        circularLineAlias: 'Ringbahn',
+        circularLinePattern: String.raw`(?<![A-Za-z])(?:s[-\s]?)?ring(?:bahn)?`,
+        abbreviations: [
+            [String.raw`straße`, 'strasse'],
+            [String.raw`str\.?(?=\s|$|\/|,|\)|-)`, 'strasse'],
+            [String.raw`str$`, 'strasse'],
+            [String.raw`\bbhf\.?\b`, 'bahnhof'],
+            [String.raw`\bhbf\.?\b`, 'hauptbahnhof'],
+            [String.raw`\bpl\.?\b`, 'platz'],
+        ],
+        promptExamples,
+    },
+    community: {
+        telegramHandle: '@FreiFahren_BE',
+        instagram: 'frei.fahren',
+    },
+}

--- a/packages/cities/src/index.ts
+++ b/packages/cities/src/index.ts
@@ -1,0 +1,29 @@
+import { BERLIN } from './berlin'
+import type { CityConfig } from './types'
+
+export * from './types'
+export { BERLIN }
+
+/**
+ * The city registry: the single source of truth for everything that differs
+ * between cities. Keyed by slug. City is a runtime dimension resolved from the
+ * hostname (frontend) or an explicit `?city=` param (API).
+ */
+export const CITIES = {
+    berlin: BERLIN,
+} as const satisfies Record<string, CityConfig>
+
+export type CitySlug = keyof typeof CITIES
+
+/**
+ * Default city for callers that don't (or can't) resolve one: legacy API clients
+ * with no `?city=` param, the Capacitor origin, and old PWA shells.
+ */
+export const DEFAULT_CITY_SLUG: CitySlug = 'berlin'
+
+export const CITY_SLUGS = Object.keys(CITIES) as CitySlug[]
+
+export const isCitySlug = (value: string): value is CitySlug => Object.prototype.hasOwnProperty.call(CITIES, value)
+
+/** Look up a city by slug, or `undefined` if the slug is unknown. */
+export const getCity = (slug: string): CityConfig | undefined => (isCitySlug(slug) ? CITIES[slug] : undefined)

--- a/packages/cities/src/types.ts
+++ b/packages/cities/src/types.ts
@@ -1,0 +1,124 @@
+// Shared city-registry types. Dependency-free plain TS so this package can be
+// consumed unchanged by every toolchain in the monorepo (Vite build, the three
+// Worker bundles, and the seed scripts). Do not import runtime dependencies here.
+
+/** The transit route types the pipeline understands, in no particular order. */
+export const ROUTE_TYPES = ['subway', 'tram', 'light_rail', 'train'] as const
+
+export type RouteType = (typeof ROUTE_TYPES)[number]
+
+/** `[longitude, latitude]` — GeoJSON/MapLibre order. */
+export type LngLat = readonly [number, number]
+
+/** `[west, south, east, north]` — GeoJSON bbox order. */
+export type BBox = readonly [number, number, number, number]
+
+/**
+ * City-specific seed configuration. The pipeline-global tuning (Overpass
+ * endpoint, merge threshold, geometry tolerance) is intentionally NOT here — it
+ * doesn't vary by city and lives with the seed pipeline.
+ */
+export interface CitySeedConfig {
+    /**
+     * OSM `admin_level` regex identifying the city boundary relation. Usually
+     * 4–6 for a city-sized boundary.
+     */
+    adminLevel: string
+    /**
+     * OSM `operator` tag values whose route relations should be seeded.
+     * Filtering by operator keeps the query focused without coupling the
+     * pipeline to a hand-maintained list of line refs that drifts whenever the
+     * network changes.
+     */
+    operators: readonly string[]
+    /**
+     * Route types ordered most-to-least prioritized — used to pick a single
+     * "highest" route type when a station is served by several. Also the set of
+     * OSM `route` values to include.
+     */
+    routeTypePriority: readonly [RouteType, ...RouteType[]]
+    /**
+     * Route types listed here always get the configured color regardless of the
+     * OSM relation tags (used to give all S-Bahn lines one shared green and all
+     * tram lines one shared red). Route types absent from this map fall back to
+     * the OSM colour/color tag — best for subway lines with per-line branding.
+     */
+    colors: Partial<Record<RouteType, string>>
+    /**
+     * Fallback color when neither a configured route color nor an OSM
+     * colour/color tag is available. Mirrors the DB default on `lines.color`.
+     */
+    defaultLineColor: string
+}
+
+/**
+ * Per-city language/extraction profile for the Telegram bot. Extraction logic
+ * stays city-agnostic and reads everything it needs from here.
+ */
+export interface CityTelegramProfile {
+    /** Inspector-report vocabulary the LLM prompt highlights to the model. */
+    inspectorKeywords: string
+    /** Free-text reminder of the local circular-line name. Empty = no circular line. */
+    circularLineAlias: string
+    /** Regex source recognizing user shorthand for the circular line. Empty = no circular line. */
+    circularLinePattern: string
+    /**
+     * `[pattern, replacement]` regex-source pairs applied during normalization
+     * so user-typed abbreviations match canonical names (e.g. "str." -> "strasse").
+     * Patterns are matched globally after lowercasing and letter folding.
+     */
+    abbreviations: readonly (readonly [string, string])[]
+    /**
+     * Few-shot examples appended to the extraction prompt, in the local
+     * language. Empty string disables few-shot.
+     */
+    promptExamples: string
+}
+
+/** Public community channels surfaced in the app for a city. */
+export interface CityCommunity {
+    /** Telegram group handle reports are synced with (e.g. `@FreiFahren_BE`). */
+    telegramHandle: string
+    /** Instagram handle (without the `@` or URL). */
+    instagram: string
+}
+
+/** Map defaults for the city's basemap. */
+export interface CityMap {
+    /** Initial map center. */
+    center: LngLat
+    /** Initial zoom level. */
+    zoom: number
+    /** Metro-area extent. Not yet consumed by the frontend; recorded for camera/bounds work. */
+    bounds: BBox
+    /** URL of the MapLibre style JSON served by the tile-server. */
+    styleUrl: string
+}
+
+/**
+ * A single city's complete configuration. City is a runtime dimension resolved
+ * from the hostname (or an explicit `?city=` param on the API); this registry is
+ * the single source of truth for everything that differs between cities.
+ */
+export interface CityConfig {
+    /** Stable identifier used as the registry key and the API `?city=` value. */
+    slug: string
+    /** Subdomain the city is served from (`<subdomain>.freifahren.org`). */
+    subdomain: string
+    /** Human-readable name shown in the UI. */
+    displayName: string
+    /**
+     * D1 database name. Berlin keeps the existing `api-worker-db-eu` — D1
+     * databases can't be renamed and we don't migrate data. New cities follow
+     * `api-worker-db-<slug>`.
+     */
+    dbName: string
+    /** Static Worker binding name for this city's D1 database. */
+    dbBinding: string
+    /** BCP-47 language tag for the city's primary language. */
+    lang: string
+    map: CityMap
+    seed: CitySeedConfig
+    telegram: CityTelegramProfile
+    community: CityCommunity
+}

--- a/packages/cities/tsconfig.json
+++ b/packages/cities/tsconfig.json
@@ -4,11 +4,10 @@
         "module": "esnext",
         "moduleResolution": "bundler",
         "strict": true,
-        "jsx": "react-jsx",
-        "jsxImportSource": "hono/jsx",
+        "declaration": true,
+        "noEmit": true,
         "esModuleInterop": true,
-        "paths": {
-            "@freifahren/cities": ["../cities/src/index.ts"]
-        }
-    }
+        "skipLibCheck": true
+    },
+    "include": ["src"]
 }


### PR DESCRIPTION
## What

Creates `packages/cities` — a dependency-free plain-TS **city registry**, the single source of truth for everything that differs between the cities FreiFahren serves. This is the keystone of the multi-city expansion (Leipzig); Berlin is the only entry, so it's a **pure refactor**.

- `src/types.ts` — `CityConfig` and sub-types (`CityMap`, `CitySeedConfig`, `CityTelegramProfile`, `CityCommunity`) + `ROUTE_TYPES`/`RouteType`.
- `src/berlin.ts` — `BERLIN`, populated with the **real current** Berlin values gathered from across the repo (seed config, `VITE_MAP_*`, telegram `config.ts`, social handles).
- `src/index.ts` — the `CITIES` registry keyed by slug + `getCity`, `isCitySlug`, `CITY_SLUGS`, `DEFAULT_CITY_SLUG`.

**api-worker fold:** `src/db/seed/config.ts` now sources its city-specific inputs (operators, admin level, colors, route-type priority) from `BERLIN` while re-exporting the same symbols. The ~7 downstream importers are untouched, and the resolved `SEED_CONFIG` is **byte-identical** to before.

## Design notes

- **Dependency-free, no build step.** The registry must be consumable by four heterogeneous toolchains, so consumers import the source via a tsconfig `paths` alias (`@freifahren/cities` → `../cities/src/index.ts`) — verified to resolve in tsc, `bun run`, `bun test`, the wrangler/esbuild bundle, `drizzle-kit`, and the eslint resolver.
- Pipeline-global seed tuning (Overpass endpoint, merge threshold, geometry tolerance) stays in api-worker — it doesn't vary by city.
- `risk` params are intentionally omitted (no values yet; FRE-720 adds that field).

## Verification

- Resolved `SEED_CONFIG` + color exports are byte-identical.
- `bun test` → 89 pass / 0 fail; full `bun run lint` → 0 errors; `format:check` clean.
- `wrangler deploy --dry-run` bundles the sibling package; `drizzle-kit generate` → no schema changes.

## Follow-up

Deploy path filters are per-package, so a future change touching only `packages/cities/**` won't auto-redeploy consuming workers — tracked in FRE-729 (blocks FRE-715).

Closes FRE-705