### PR TITLE
refactor: resolve telegram city profile from the registry at runtime

### DIFF
--- a/packages/telegram-worker/evals/run.ts
+++ b/packages/telegram-worker/evals/run.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { profileFor, type CityProfile } from '../src/config'
 import { getTransitIndex } from '../src/transit'
 import {
     buildLinePattern,
@@ -38,10 +39,6 @@ interface RowOutcome {
 
 const fullyCorrect = (o: RowOutcome): boolean => o.correctStation && o.correctDirection && o.correctLine
 
-// ---------------------------------------------------------------------------
-// Line scoring (port of expected_line_tokens / line_correct)
-// ---------------------------------------------------------------------------
-
 const LINE_TOKEN_RE = /^([A-Za-z]+)(\d+)$/
 
 /**
@@ -77,10 +74,6 @@ function lineCorrect(expected: string | null, actual: string | null): boolean {
     }
     return actual !== null && tokens.has(actual)
 }
-
-// ---------------------------------------------------------------------------
-// Metrics (port of field_metrics) — null treated as a negative prediction.
-// ---------------------------------------------------------------------------
 
 interface FieldMetrics {
     accuracy: number
@@ -129,10 +122,6 @@ function fieldMetrics(
     const f1 = precision + recall ? (2 * precision * recall) / (precision + recall) : 0
     return { accuracy: total ? correct / total : 0, correct, total, tp, fp, fn, tn, precision, recall, f1 }
 }
-
-// ---------------------------------------------------------------------------
-// Report (port of build_report)
-// ---------------------------------------------------------------------------
 
 const pct = (x: number): string => `${(x * 100).toFixed(1)}%`
 
@@ -195,10 +184,6 @@ function buildReport(opts: {
     )
     return lines.join('\n') + '\n'
 }
-
-// ---------------------------------------------------------------------------
-// Runtime plumbing
-// ---------------------------------------------------------------------------
 
 /** Load .dev.vars (KEY=VALUE, # comments) into process.env without overriding what's set. */
 function loadDevVars(): void {
@@ -274,7 +259,7 @@ async function extractWithRetry(
     systemPrompt: string,
     apiKey: string,
     model: string,
-    attempts = 7,
+    attempts = 7
 ): Promise<Awaited<ReturnType<typeof extractWithMistral>>> {
     let last: unknown
     for (let i = 0; i < attempts; i++) {
@@ -298,14 +283,15 @@ async function runOne(
     linePattern: RegExp,
     systemPrompt: string,
     apiKey: string,
-    model: string
+    model: string,
+    profile: CityProfile
 ): Promise<RowOutcome> {
     let result: ExtractionResult = NULL_RESULT
     let error: string | null = null
     try {
-        const detectedLine = detectLineName(row.text, index.lineNames, linePattern, index.circularLineNames)
+        const detectedLine = detectLineName(row.text, index.lineNames, linePattern, index.circularLineNames, profile)
         const parsed = await extractWithRetry(row.text, systemPrompt, apiKey, model)
-        result = parsed === null ? NULL_RESULT : resolveExtraction(index, parsed, detectedLine)
+        result = parsed === null ? NULL_RESULT : resolveExtraction(index, parsed, detectedLine, profile)
     } catch (exc) {
         error = exc instanceof Error ? `${exc.name}: ${exc.message}` : String(exc)
     }
@@ -362,14 +348,15 @@ async function main(): Promise<void> {
     const datasetSize = dataset.length
     const rows = args.smoke ? sample(dataset, args.n, args.seed) : dataset
 
-    const index = await getTransitIndex(backendUrl)
+    const profile = profileFor(cityName)
+    const index = await getTransitIndex(backendUrl, profile)
     const linePattern = buildLinePattern(index.lineNames)
-    const systemPrompt = buildSystemPrompt(index, cityName)
+    const systemPrompt = buildSystemPrompt(index, profile)
 
     console.log(`running ${rows.length} rows with parallel=${args.parallel} model=${model}...`)
     const start = performance.now()
     const outcomes = await mapPool(rows, args.parallel, (row) =>
-        runOne(row, index, linePattern, systemPrompt, apiKey, model)
+        runOne(row, index, linePattern, systemPrompt, apiKey, model, profile)
     )
     const durationS = (performance.now() - start) / 1000
 

--- a/packages/telegram-worker/src/config.ts
+++ b/packages/telegram-worker/src/config.ts
@@ -1,29 +1,12 @@
+import { getCity } from '@freifahren/cities'
+
 import type { Env } from './types'
 
-// =============================================================================
-// City / language profile
-//
-// THIS IS THE ONLY PLACE with Berlin/German specifics. Extraction logic in
-// extractor.ts reads from here and never hardcodes city specifics. To port the
-// bot to another city, swap the constants below (and the CITY_NAME var).
-// =============================================================================
-
-/** Free-text reminder of the local circular-line name. Empty = no circular line. */
-export const CIRCULAR_LINE_ALIAS = 'Ringbahn'
-
-/** Regex recognizing user shorthand for the circular line. Empty = no circular line. */
-export const CIRCULAR_LINE_PATTERN = String.raw`(?<![A-Za-z])(?:s[-\s]?)?ring(?:bahn)?`
-
-/**
- * Language-specific letter folding for normalization.
- *
- * Collapse umlauts to their base letter rather than the digraph form: when users
- * type on ASCII keyboards they almost always write "u"/"o"/"a" (sudkreuz, mockern,
- * bulow), not the "ue"/"oe"/"ae" expansion. Mapping to the base letter makes user
- * input line up with normalized station names. ß stays "ss" — the universally
- * typed substitute.
- */
-export const LANGUAGE_LETTER_MAP: Record<string, string> = {
+// German language normalization. Shared by every German-speaking city, so kept here
+// rather than in the per-city registry; city-specific data comes from packages/cities
+// via profileFor() below. Umlauts fold to their base letter, not the digraph, because
+// on ASCII keyboards users type "u"/"o"/"a" (sudkreuz, mockern), not "ue"/"oe"/"ae".
+const GERMAN_LETTER_MAP: Record<string, string> = {
     ä: 'a',
     ö: 'o',
     ü: 'u',
@@ -33,25 +16,11 @@ export const LANGUAGE_LETTER_MAP: Record<string, string> = {
     Ü: 'u',
 }
 
-/**
- * (pattern, replacement) pairs applied during normalization so user-typed
- * abbreviations match canonical names. German: "str."/"straße" -> "strasse", etc.
- * Patterns run after lowercasing and letter folding, so they target lowercase.
- */
-export const LANGUAGE_ABBREVIATIONS: [RegExp, string][] = [
-    [/straße/g, 'strasse'],
-    [/str\.?(?=\s|$|\/|,|\)|-)/g, 'strasse'],
-    [/str$/g, 'strasse'],
-    [/\bbhf\.?\b/g, 'bahnhof'],
-    [/\bhbf\.?\b/g, 'hauptbahnhof'],
-    [/\bpl\.?\b/g, 'platz'],
-]
+// Leading prefixes users type that aren't part of the station name ("S Alexanderplatz").
+const GERMAN_STATION_NAME_PREFIX_PATTERN = /^(?:bahnhof\s+|bhf\s+|s\s+|u\s+|s-bahn\s+|u-bahn\s+)+/i
 
-/** Prefixes users write before a station name that aren't part of it ("S Alexanderplatz"). */
-export const STATION_NAME_PREFIX_PATTERN = /^(?:bahnhof\s+|bhf\s+|s\s+|u\s+|s-bahn\s+|u-bahn\s+)+/i
-
-/** Words the LLM might emit as a stationName that really refer to platforms/vehicles. */
-export const GENERIC_NON_STATION_WORDS: ReadonlySet<string> = new Set([
+// Words that are never a station name on their own (platforms, vehicle types).
+const GERMAN_GENERIC_NON_STATION_WORDS: ReadonlySet<string> = new Set([
     'bahnsteig',
     'bahnsteige',
     'bahnhof',
@@ -70,58 +39,46 @@ export const GENERIC_NON_STATION_WORDS: ReadonlySet<string> = new Set([
     'stop',
 ])
 
-/** Inspector-report vocabulary the prompt highlights to the model. */
-export const INSPECTOR_KEYWORDS =
-    'Kontrolleur, BVG-Kontrolle, BOS, BW, Blauwesten, Zivilkontrolle, blaue Westen'
-
 /**
- * Few-shot examples appended to the prompt. Tuned to teach disambiguation the model
- * gets wrong: slang names, direction-vs-station, all-clear messages, the implicit-
- * direction case. Kept in the local language since the chat is mixed German/English.
- * Empty string disables few-shot.
+ * Everything the extractor needs, resolved once per run: the German constants above
+ * plus the city's registry profile (see CityTelegramProfile in packages/cities), with
+ * its regex sources compiled here.
  */
-export const PROMPT_EXAMPLES = `Message: "U2 alex hab in dem bahnstation gesehen"
-{"stationName": "Alex", "directionName": null}
+export interface CityProfile {
+    displayName: string
+    letterMap: Record<string, string>
+    stationNamePrefixPattern: RegExp
+    genericNonStationWords: ReadonlySet<string>
+    abbreviations: [RegExp, string][]
+    /** null when the city has no circular line. */
+    circularLineRegex: RegExp | null
+    inspectorKeywords: string
+    promptExamples: string
+}
 
-Message: "3x kotti u3 am Gleis"
-{"stationName": "Kottbusser Tor", "directionName": null}
-
-Message: "gorli u1/u3 3 Männer"
-{"stationName": "Görlitzer Bahnhof", "directionName": null}
-
-Message: "U7 Rathaus Spandau Richt Rudow Höhe sbhf Neukölln 4 Mann BOS"
-{"stationName": "Neukölln", "directionName": "Rudow"}
-
-Message: "u 8 wittenau in blauen westen höhe osloer"
-{"stationName": "osloer", "directionName": "wittenau"}
-
-Message: "Gesundbrunnen clean on u8"
-{"stationName": "Gesundbrunnen", "directionName": null}
-
-Message: "M29 bus moritzplatz"
-{"stationName": "Moritzplatz", "directionName": null}
-
-Message: "3 Bos Jacken M29 Anhalter Bahnhof Richtung Hermannplatz"
-{"stationName": "Anhalter Bahnhof", "directionName": "Hermannplatz"}
-
-Message: "S3 nach ostbahnof"
-{"stationName": null, "directionName": "Ostbahnhof"}
-
-Message: "To Rathaus SPANDAU"
-{"stationName": null, "directionName": "Rathaus Spandau"}
-
-Message: "U7 Rathaus Neukölln 3x BOS just got off the train"
-{"stationName": "Rathaus Neukölln", "directionName": null}
-
-Message: "U6 Kaiserin Augusta 2x bos"
-{"stationName": "Kaiserin-Augusta-Straße", "directionName": null}
-
-Message: "Zoo Richtung Steglitz"
-{"stationName": "Zoo", "directionName": "Steglitz"}
-
-Message: "Hi, kann mir wer ein Ticket verkaufen?"
-{"stationName": null, "directionName": null}
-`
+// Throws on an unknown city so a misconfigured deployment fails loudly rather than
+// silently prompting the model with the wrong city's examples.
+export function profileFor(cityName: string): CityProfile {
+    const city = getCity(cityName.toLowerCase())
+    if (!city) {
+        throw new Error(`No city registry entry for CITY_NAME="${cityName}"`)
+    }
+    const { telegram } = city
+    return {
+        displayName: city.displayName,
+        letterMap: GERMAN_LETTER_MAP,
+        stationNamePrefixPattern: GERMAN_STATION_NAME_PREFIX_PATTERN,
+        genericNonStationWords: GERMAN_GENERIC_NON_STATION_WORDS,
+        abbreviations: telegram.abbreviations.map(
+            ([pattern, replacement]): [RegExp, string] => [new RegExp(pattern, 'g'), replacement],
+        ),
+        circularLineRegex: telegram.circularLinePattern
+            ? new RegExp(telegram.circularLinePattern, 'i')
+            : null,
+        inspectorKeywords: telegram.inspectorKeywords,
+        promptExamples: telegram.promptExamples,
+    }
+}
 
 // =============================================================================
 // Runtime config (from env bindings) — non-city-specific.

--- a/packages/telegram-worker/src/extractor.ts
+++ b/packages/telegram-worker/src/extractor.ts
@@ -1,4 +1,4 @@
-import * as config from './config'
+import type { CityProfile } from './config'
 import { StationNameExtraction, type TransitIndex } from './types'
 import { stationLineNames } from './transit'
 
@@ -20,17 +20,17 @@ export function extractionToLog(result: ExtractionResult): string {
     })
 }
 
-function translateLetters(s: string): string {
-    return s.replace(/[äöüßÄÖÜ]/g, (c) => config.LANGUAGE_LETTER_MAP[c] ?? c)
+function translateLetters(s: string, letterMap: Record<string, string>): string {
+    return s.replace(/[äöüßÄÖÜ]/g, (c) => letterMap[c] ?? c)
 }
 
-export function normalizeName(name: string): string {
+export function normalizeName(name: string, profile: CityProfile): string {
     let n = name.trim().toLowerCase()
-    n = n.replace(config.STATION_NAME_PREFIX_PATTERN, '')
-    n = translateLetters(n)
+    n = n.replace(profile.stationNamePrefixPattern, '')
+    n = translateLetters(n, profile.letterMap)
     // Strip any diacritics that survived the letter map.
     n = n.normalize('NFKD').replace(/\p{M}/gu, '')
-    for (const [pattern, repl] of config.LANGUAGE_ABBREVIATIONS) {
+    for (const [pattern, repl] of profile.abbreviations) {
         n = n.replace(pattern, repl)
     }
     n = n.replace(/[^a-z0-9]+/g, '')
@@ -145,9 +145,10 @@ function candidates(
     index: TransitIndex,
     query: string,
     lineName: string | null,
+    profile: CityProfile,
     minScore = 0.6,
 ): [string, number][] {
-    const full = normalizeName(query)
+    const full = normalizeName(query, profile)
     if (!full) {
         return []
     }
@@ -168,7 +169,7 @@ function candidates(
         const wordQueries = query
             .split(/[\s\-/,]+/)
             .filter((p) => p.trim() && p.trim().length > 4)
-            .map((p) => normalizeName(p))
+            .map((p) => normalizeName(p, profile))
             .filter((w) => w && w !== full)
         for (const candNorm of Object.keys(index.byNorm)) {
             for (const w of wordQueries) {
@@ -210,20 +211,21 @@ export function pickStation(
     index: TransitIndex,
     query: string | null,
     lineName: string | null,
+    profile: CityProfile,
     allowOffLine = true,
 ): [string, boolean] | null {
     if (!query) {
         return null
     }
-    if (config.GENERIC_NON_STATION_WORDS.has(normalizeName(query))) {
+    if (profile.genericNonStationWords.has(normalizeName(query, profile))) {
         return null
     }
-    const onLine = lineName !== null ? candidates(index, query, lineName) : []
+    const onLine = lineName !== null ? candidates(index, query, lineName, profile) : []
     let offLine: [string, number][] = []
     if (allowOffLine && (onLine.length === 0 || (lineName !== null && onLine[0][1] < 0.92))) {
         // Only compare against an unfiltered search when the line-filtered match isn't
         // already near-exact, else we'd risk swapping in a slightly higher off-line station.
-        offLine = candidates(index, query, null)
+        offLine = candidates(index, query, null, profile)
     }
 
     if (onLine.length === 0 && offLine.length === 0) {
@@ -250,11 +252,12 @@ export function pickDirection(
     index: TransitIndex,
     query: string | null,
     lineName: string | null,
+    profile: CityProfile,
 ): string | null {
     if (!query) {
         return null
     }
-    const picked = pickStation(index, query, lineName, lineName === null)
+    const picked = pickStation(index, query, lineName, profile, lineName === null)
     return picked !== null ? picked[0] : null
 }
 
@@ -266,8 +269,9 @@ export function resolveExtraction(
     index: TransitIndex,
     parsed: StationNameExtraction,
     detectedLine: string | null,
+    profile: CityProfile,
 ): ExtractionResult {
-    const picked = pickStation(index, parsed.stationName, detectedLine)
+    const picked = pickStation(index, parsed.stationName, detectedLine, profile)
     const stationId = picked !== null ? picked[0] : null
     const stationOnLine = picked !== null ? picked[1] : false
 
@@ -279,15 +283,11 @@ export function resolveExtraction(
     return {
         stationId,
         lineName,
-        directionId: pickDirection(index, parsed.directionName, lineName),
+        directionId: pickDirection(index, parsed.directionName, lineName, profile),
     }
 }
 
 const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-
-const CIRCULAR_LINE_REGEX = config.CIRCULAR_LINE_PATTERN
-    ? new RegExp(config.CIRCULAR_LINE_PATTERN, 'i')
-    : null
 
 export function buildLinePattern(lineNames: string[]): RegExp {
     const alternatives: string[] = []
@@ -308,7 +308,8 @@ export function detectLineName(
     message: string,
     lineNames: string[],
     linePattern: RegExp,
-    circularLineNames: string[] = [],
+    circularLineNames: string[],
+    profile: CityProfile,
 ): string | null {
     const normalizedLines = new Map<string, string>()
     for (const lineName of lineNames) {
@@ -321,18 +322,22 @@ export function detectLineName(
             return hit
         }
     }
-    if (circularLineNames.length > 0 && CIRCULAR_LINE_REGEX !== null && CIRCULAR_LINE_REGEX.test(message)) {
+    if (
+        circularLineNames.length > 0 &&
+        profile.circularLineRegex !== null &&
+        profile.circularLineRegex.test(message)
+    ) {
         return circularLineNames[0]
     }
     return null
 }
 
-export function buildSystemPrompt(index: TransitIndex, cityName: string): string {
+export function buildSystemPrompt(index: TransitIndex, profile: CityProfile): string {
     const tracked = [...index.lineNames].sort().join(', ')
-    const examples = config.PROMPT_EXAMPLES.trim()
+    const examples = profile.promptExamples.trim()
     return (
-        `This is a ${cityName} public-transit chat where users report ticket-inspector ` +
-        `sightings (${config.INSPECTOR_KEYWORDS}, etc.). Almost every message is a sighting report.\n` +
+        `This is a ${profile.displayName} public-transit chat where users report ticket-inspector ` +
+        `sightings (${profile.inspectorKeywords}, etc.). Almost every message is a sighting report.\n` +
         '\n' +
         'Respond with ONLY a JSON object — no prose, no markdown — exactly matching this shape:\n' +
         '{"stationName": <string or null>, "directionName": <string or null>}\n' +

--- a/packages/telegram-worker/src/forwarding.ts
+++ b/packages/telegram-worker/src/forwarding.ts
@@ -1,7 +1,7 @@
 import type { Env, ForwardedReport, TransitIndex } from './types'
 import { lineNameForId, stationLineNames } from './transit'
 import { getTransitIndex } from './transit'
-import { readConfig } from './config'
+import { profileFor, readConfig } from './config'
 import { reportError } from './observability'
 
 /** HTML-escape for Telegram markup, quotes included. */
@@ -140,7 +140,7 @@ export async function handleReportForward(request: Request, env: Env): Promise<R
 
     let index: TransitIndex
     try {
-        index = await getTransitIndex(cfg.backendUrl)
+        index = await getTransitIndex(cfg.backendUrl, profileFor(cfg.cityName))
     } catch (err) {
         reportError('Failed to load transit data', err)
         return json({ error: 'transit_unavailable' }, 502)

--- a/packages/telegram-worker/src/pipeline.ts
+++ b/packages/telegram-worker/src/pipeline.ts
@@ -1,5 +1,5 @@
 import type { Env } from './types'
-import { readConfig } from './config'
+import { profileFor, readConfig } from './config'
 import { isSpam } from './spam'
 import { getTransitIndex } from './transit'
 import {
@@ -26,19 +26,20 @@ export async function processMessage(text: string, env: Env): Promise<void> {
     }
 
     const cfg = readConfig(env)
-    const index = await getTransitIndex(cfg.backendUrl)
+    const profile = profileFor(cfg.cityName)
+    const index = await getTransitIndex(cfg.backendUrl, profile)
 
     const linePattern = buildLinePattern(index.lineNames)
-    const detectedLine = detectLineName(text, index.lineNames, linePattern, index.circularLineNames)
+    const detectedLine = detectLineName(text, index.lineNames, linePattern, index.circularLineNames, profile)
 
-    const systemPrompt = buildSystemPrompt(index, cfg.cityName)
+    const systemPrompt = buildSystemPrompt(index, profile)
     const parsed = await extractWithMistral(text, systemPrompt, cfg.mistralApiKey, cfg.mistralModel)
     if (parsed === null) {
         console.info('No extraction produced (LLM error or unparseable)')
         return
     }
 
-    const result = resolveExtraction(index, parsed, detectedLine)
+    const result = resolveExtraction(index, parsed, detectedLine, profile)
     const ids = reportIdentifiers(index, result)
     if (ids === null) {
         return

--- a/packages/telegram-worker/src/transit.ts
+++ b/packages/telegram-worker/src/transit.ts
@@ -1,3 +1,4 @@
+import type { CityProfile } from './config'
 import type { IndexVariant, TransitIndex } from './types'
 import { normalizeName } from './extractor'
 
@@ -16,7 +17,11 @@ interface RawLine {
 // Lines-per-station are derived from the variants (not the /stations `lines` field) so we
 // index PUBLIC line names ("S85") rather than variant names ("S85-a") the /stations endpoint
 // sometimes returns.
-export function buildIndex(rawStations: Record<string, RawStation>, rawLines: RawLine[]): TransitIndex {
+export function buildIndex(
+    rawStations: Record<string, RawStation>,
+    rawLines: RawLine[],
+    profile: CityProfile,
+): TransitIndex {
     const variants: IndexVariant[] = rawLines.map((line) => ({
         id: line.id,
         name: line.name,
@@ -37,7 +42,7 @@ export function buildIndex(rawStations: Record<string, RawStation>, rawLines: Ra
     const byNorm: Record<string, string[]> = {}
     for (const [stationId, props] of Object.entries(rawStations)) {
         stations[stationId] = { id: stationId, name: props.name }
-        const norm = normalizeName(props.name)
+        const norm = normalizeName(props.name, profile)
         ;(byNorm[norm] ??= []).push(stationId)
         linesByStation[stationId] ??= []
     }
@@ -51,7 +56,7 @@ export function buildIndex(rawStations: Record<string, RawStation>, rawLines: Ra
 }
 
 // No caching here; the api-worker serves these from its edge cache.
-export async function getTransitIndex(backendUrl: string): Promise<TransitIndex> {
+export async function getTransitIndex(backendUrl: string, profile: CityProfile): Promise<TransitIndex> {
     const [stationsResp, linesResp] = await Promise.all([
         fetch(`${backendUrl}/v0/transit/stations`),
         fetch(`${backendUrl}/v0/transit/lines`),
@@ -64,7 +69,7 @@ export async function getTransitIndex(backendUrl: string): Promise<TransitIndex>
     }
     const rawStations = (await stationsResp.json()) as Record<string, RawStation>
     const rawLines = (await linesResp.json()) as RawLine[]
-    return buildIndex(rawStations, rawLines)
+    return buildIndex(rawStations, rawLines, profile)
 }
 
 export function stationLineNames(index: TransitIndex, stationId: string): string[] {

--- a/packages/telegram-worker/test/fixtures.ts
+++ b/packages/telegram-worker/test/fixtures.ts
@@ -1,5 +1,9 @@
+import { profileFor } from '../src/config'
 import { buildIndex } from '../src/transit'
 import type { TransitIndex } from '../src/types'
+
+/** Berlin profile for tests — mirrors the production CITY_NAME default. */
+export const berlinProfile = profileFor('Berlin')
 
 export const ALLOWED_CHAT_ID = '-1001'
 export const PUBLIC_APP_URL = 'https://app.example.test'
@@ -35,7 +39,7 @@ export function rawTransit() {
 
 export function makeIndex(): TransitIndex {
     const { rawStations, rawLines } = rawTransit()
-    return buildIndex(rawStations, rawLines)
+    return buildIndex(rawStations, rawLines, berlinProfile)
 }
 
 export interface PickedStation {

--- a/packages/telegram-worker/test/resolution.test.ts
+++ b/packages/telegram-worker/test/resolution.test.ts
@@ -5,7 +5,7 @@ import {
     pickStation,
     resolveExtraction,
 } from '../src/extractor'
-import { makeIndex } from './fixtures'
+import { berlinProfile, makeIndex } from './fixtures'
 
 const index = makeIndex()
 
@@ -19,41 +19,41 @@ describe('normalizeName', () => {
         ['Leinestr.', 'leinestrasse'],
         ['Leinestr', 'leinestrasse'],
     ])('normalizes %s -> %s', (raw, expected) => {
-        expect(normalizeName(raw)).toBe(expected)
+        expect(normalizeName(raw, berlinProfile)).toBe(expected)
     })
 })
 
 describe('pickStation', () => {
     it('resolves a diacritic typo off-line', () => {
-        expect(pickStation(index, 'sudkreuz', null)).toEqual(['S-suedkreuz', false])
+        expect(pickStation(index, 'sudkreuz', null, berlinProfile)).toEqual(['S-suedkreuz', false])
     })
 
     it('flags an on-line match', () => {
-        expect(pickStation(index, 'Rudow', 'U7')).toEqual(['U-rudow', true])
+        expect(pickStation(index, 'Rudow', 'U7', berlinProfile)).toEqual(['U-rudow', true])
     })
 
     it('drops the line when the station is off it', () => {
         // 'u6 turmstr' — Turmstraße is on U9, so trust the station and drop the wrong line.
-        expect(pickStation(index, 'turmstr', 'U6')).toEqual(['U-turmstrasse', false])
+        expect(pickStation(index, 'turmstr', 'U6', berlinProfile)).toEqual(['U-turmstrasse', false])
     })
 
     it('rejects a generic non-station word', () => {
-        expect(pickStation(index, 'Bahnhof', null)).toBeNull()
+        expect(pickStation(index, 'Bahnhof', null, berlinProfile)).toBeNull()
     })
 
     it('returns null for an empty query', () => {
-        expect(pickStation(index, null, null)).toBeNull()
-        expect(pickStation(index, '', null)).toBeNull()
+        expect(pickStation(index, null, null, berlinProfile)).toBeNull()
+        expect(pickStation(index, '', null, berlinProfile)).toBeNull()
     })
 })
 
 describe('pickDirection', () => {
     it('restricts to the line', () => {
-        expect(pickDirection(index, 'Rudow', 'U7')).toBe('U-rudow')
+        expect(pickDirection(index, 'Rudow', 'U7', berlinProfile)).toBe('U-rudow')
     })
 
     it('returns null for a missing query', () => {
-        expect(pickDirection(index, null, 'U7')).toBeNull()
+        expect(pickDirection(index, null, 'U7', berlinProfile)).toBeNull()
     })
 })
 
@@ -63,6 +63,7 @@ describe('resolveExtraction', () => {
             index,
             { stationName: 'Rathaus Neukölln', directionName: 'Rudow' },
             'U7',
+            berlinProfile,
         )
         expect(result.stationId).toBe('U-rathaus-neukoelln')
         expect(result.lineName).toBe('U7')
@@ -70,13 +71,18 @@ describe('resolveExtraction', () => {
     })
 
     it('drops the line for an off-line station', () => {
-        const result = resolveExtraction(index, { stationName: 'Turmstraße', directionName: null }, 'U6')
+        const result = resolveExtraction(
+            index,
+            { stationName: 'Turmstraße', directionName: null },
+            'U6',
+            berlinProfile,
+        )
         expect(result.stationId).toBe('U-turmstrasse')
         expect(result.lineName).toBeNull()
     })
 
     it('is empty when nothing matches', () => {
-        const result = resolveExtraction(index, { stationName: null, directionName: null }, null)
+        const result = resolveExtraction(index, { stationName: null, directionName: null }, null, berlinProfile)
         expect(result.stationId).toBeNull()
         expect(result.lineName).toBeNull()
         expect(result.directionId).toBeNull()

--- a/packages/telegram-worker/tsconfig.json
+++ b/packages/telegram-worker/tsconfig.json
@@ -9,7 +9,10 @@
     "skipLibCheck": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "paths": {
+      "@freifahren/cities": ["../cities/src/index.ts"]
+    }
   },
   "include": ["src", "test"]
 }

--- a/packages/telegram-worker/vitest.config.ts
+++ b/packages/telegram-worker/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config'
 
+// Vitest/Vite doesn't read tsconfig `paths`, so alias the shared registry here to match
+// the tsconfig alias the rest of the toolchain (tsc, esbuild, bun) resolves on its own.
 export default defineWorkersConfig({
+    resolve: {
+        alias: {
+            '@freifahren/cities': new URL('../cities/src/index.ts', import.meta.url).pathname,
+        },
+    },
     test: {
         poolOptions: {
             workers: {


### PR DESCRIPTION
## What

The telegram-worker's Berlin/German extraction constants — inspector keywords, circular-line shorthand, abbreviations, and especially the Mistral **few-shot examples** — were module-level constants. Wrangler environments only swap env vars, so a Leipzig deployment would still prompt the LLM with Berlin's examples.

This replaces them with `profileFor(CITY_NAME)`, which resolves the per-city profile from the shared `@freifahren/cities` registry at runtime.

## How

- **`config.ts`**: `profileFor(cityName)` looks up the registry (`getCity(cityName.toLowerCase())`) and compiles its regex sources. Throws on an unknown city so a misconfigured deployment fails loudly instead of silently using Berlin. City-varying data (inspector keywords, circular line, abbreviations, prompt examples) now comes from the registry; **language-level** German normalization (letter folding, station-name prefixes, generic words) stays local since it's shared by every German-speaking city.
- **Extractor is city-agnostic** (per AGENTS.md): `normalizeName` / `buildIndex` / `pickStation` / `detectLineName` / `buildSystemPrompt` take the resolved `CityProfile` instead of reading module constants. `pipeline.ts` and `forwarding.ts` resolve it once per run; the eval runner threads it too.
- Added the `@freifahren/cities` tsconfig alias plus a `resolve.alias` in `vitest.config.ts` (Vitest/Vite doesn't read tsconfig `paths`).

## Verification

- **Acceptance met**: Berlin extraction results unchanged — the registry values are byte-identical to the old constants.
- Typecheck clean; **53/53 tests pass** (resolution/pipeline/forwarding/webhook/spam); `wrangler deploy --dry-run` bundles (esbuild resolves the alias); `profileFor('Berlin')` resolves and `profileFor('Leipzig')` throws as expected.
- The LLM eval (`evals/run.ts`) needs a Mistral key + the gitignored dataset, so it can't run in CI, but `buildSystemPrompt` output is byte-identical for Berlin.

## Notes

- No dependency/lockfile change (registry is referenced via tsconfig path, not a package dep).
- Deploy path filters remain per-package, so a future registry-only change (adding Leipzig) won't auto-redeploy this worker — tracked in FRE-729.

Closes FRE-706