### PR TITLE
refactor: derive tile cities from the registry and un-hardcode the tilemaker schema

### DIFF
--- a/.github/workflows/tile-server-deploy.yml
+++ b/.github/workflows/tile-server-deploy.yml
@@ -51,7 +51,9 @@ jobs:
               run: |
                   set -euo pipefail
                   SHA="${GITHUB_SHA::8}"
-                  for city in $(jq -r '.cities[].name' cities.json); do
+                  # Upload exactly what `generate` produced — one archive per dist/<city>.pmtiles.
+                  for f in dist/*.pmtiles; do
+                      city="$(basename "$f" .pmtiles)"
                       # Immutable, versioned archive — long cache, never purged (the /v<sha>/ path is
                       # the cache-bust).
                       bunx wrangler@latest r2 object put "freifahren-tiles/v$SHA/$city.pmtiles" \

--- a/docs/adr/0004-static-pmtiles-basemap-on-cloudflare-r2.md
+++ b/docs/adr/0004-static-pmtiles-basemap-on-cloudflare-r2.md
@@ -37,8 +37,8 @@ edge-cached.
 - No tile server to operate; tiles are globally edge-cached and range-served from the nearest PoP.
 - The frontend must register the `pmtiles://` protocol. Overlays are unaffected (separate GeoJSON
   sources).
-- New cities become add-an-archive + pointer rather than a new server — the `cities.json`-driven
-  generalisation is a planned follow-up.
+- New cities become add-an-archive + pointer rather than a new server — driven by the
+  `@freifahren/cities` registry (a city's `tiles` block), not a hand-maintained list.
 - CORS is per-origin (`Vary: Origin` from R2); an unconditional `Access-Control-Allow-Origin: *`
   transform rule is an option if cold-cache CORS races appear.
 - Provisioning (bucket, custom domain, cache rule) currently lives in the Cloudflare API/MCP, not

--- a/packages/cities/src/berlin.ts
+++ b/packages/cities/src/berlin.ts
@@ -63,6 +63,9 @@ export const BERLIN: CityConfig = {
         bounds: [13.088, 52.338, 13.761, 52.675],
         styleUrl: 'https://tiles.freifahren.org/styles/berlin.json',
     },
+    tiles: {
+        osmUrl: 'https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf',
+    },
     seed: {
         adminLevel: '^[4-6]$',
         operators: ['Berliner Verkehrsbetriebe', 'S-Bahn Berlin GmbH'],

--- a/packages/cities/src/types.ts
+++ b/packages/cities/src/types.ts
@@ -83,6 +83,16 @@ export interface CityCommunity {
     instagram: string
 }
 
+/**
+ * Basemap tile-build inputs for a city. Consumed by the tile-server pipeline
+ * (packages/tile-server). The archive's suggested view is derived from `map`
+ * (center + zoom), so there is no separate view to keep in sync here.
+ */
+export interface CityTiles {
+    /** Geofabrik OSM extract the basemap is built from. */
+    osmUrl: string
+}
+
 /** Map defaults for the city's basemap. */
 export interface CityMap {
     /** Initial map center. */
@@ -118,6 +128,8 @@ export interface CityConfig {
     /** BCP-47 language tag for the city's primary language. */
     lang: string
     map: CityMap
+    /** Basemap tile-build inputs. Every city ships with a basemap. */
+    tiles: CityTiles
     seed: CitySeedConfig
     telegram: CityTelegramProfile
     community: CityCommunity

--- a/packages/tile-server/README.md
+++ b/packages/tile-server/README.md
@@ -5,11 +5,14 @@ server: an OSM extract is turned into a single `.pmtiles` archive per city, uplo
 `freifahren-tiles` R2 bucket behind `tiles.freifahren.org`, and read directly by the browser via HTTP
 range requests (MapLibre's `pmtiles://` protocol).
 
-Which cities get built is driven by [`cities.json`](./cities.json).
+Which cities get built is a projection of the shared [`@freifahren/cities`](../cities) registry: every
+city in it (each carries a `tiles` block with its Geofabrik `osmUrl`). There is no hand-maintained list.
 
 ## Layout
 
-- `cities.json` — the cities to build (`name` + Geofabrik `osmUrl`).
+- `packages/cities` — the registry; a city's `tiles` block is what makes it buildable here.
+- `tilemaker/config-freifahren.json` — city-agnostic layer/settings tuning. Per-city identity (name,
+  description, schema, `default_view`) is injected by `generate.ts` from the registry.
 - `tilemaker/` — Tilemaker config + Lua that map OSM into the basemap layers (city-agnostic).
 - `source/freifahren-style.json` — the source MapLibre style (the only committed `source/` file).
 - `scripts/generate.ts` — download extract → tilemaker → `dist/<city>.pmtiles` + `dist/styles/<city>.json`.
@@ -26,7 +29,7 @@ Which cities get built is driven by [`cities.json`](./cities.json).
 
 ```sh
 cd packages/tile-server
-bun run generate     # all cities in cities.json → dist/  (CITY=berlin builds just one)
+bun run generate     # all buildable cities in the registry → dist/  (CITY=berlin builds just one)
 bun run serve        # serve dist/ with range + CORS on http://localhost:3000
 ```
 
@@ -56,19 +59,21 @@ The deploy job is gated on the `TILES_BASE_URL` repo variable (the R2 custom dom
 
 ## Adding a city
 
-1. Add an entry to `cities.json` (`name` is the slug used in URLs/filenames; `osmUrl` is its Geofabrik
-   extract):
+1. Add a `tiles` block to the city's entry in `packages/cities` (`slug` is used in URLs/filenames;
+   `osmUrl` is its Geofabrik extract):
 
-   ```json
-   { "name": "munich", "osmUrl": "https://download.geofabrik.de/europe/germany/bayern/oberbayern-latest.osm.pbf" }
+   ```ts
+   tiles: {
+       osmUrl: 'https://download.geofabrik.de/europe/germany/bayern/oberbayern-latest.osm.pbf',
+   },
    ```
 
-2. Push. The deploy builds and uploads `v<sha>/munich.pmtiles` + `styles/munich.json` alongside the
+2. Push. The deploy builds and uploads `v<sha>/<slug>.pmtiles` + `styles/<slug>.json` alongside the
    existing cities — additive, so other cities' URLs are untouched.
 
-3. Point the relevant frontend deployment at `https://tiles.freifahren.org/styles/munich.json` and set
-   its map center/zoom. (The Tilemaker config is city-agnostic; only its embedded `default_view`/name
-   metadata is Berlin-flavoured and unused by the frontend.)
+3. Point the relevant frontend deployment at `https://tiles.freifahren.org/styles/<slug>.json`. (The
+   Tilemaker config is city-agnostic; `generate.ts` injects the per-city name/description/schema from
+   the registry, and the archive's `default_view` from the city's `map` center + zoom.)
 
 See `docs/adr/0004-static-pmtiles-basemap-on-cloudflare-r2.md` for why this is static-on-R2 rather
 than a tile server.

--- a/packages/tile-server/cities.json
+++ b/packages/tile-server/cities.json
@@ -1,8 +1,0 @@
-{
-  "cities": [
-    {
-      "name": "berlin",
-      "osmUrl": "https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf"
-    }
-  ]
-}

--- a/packages/tile-server/scripts/generate.ts
+++ b/packages/tile-server/scripts/generate.ts
@@ -1,24 +1,28 @@
-// Generates the PMTiles archive + MapLibre style for each city in cities.json, into dist/.
+// Generates the PMTiles archive + MapLibre style for each buildable city, into dist/.
 // Single source of truth for both local dev and the deploy workflow.
 //
 //   bun scripts/generate.ts
 //
+// Which cities get built is a projection of the shared @freifahren/cities registry:
+// every city that has a `tiles` block. There is no hand-maintained city list.
+//
 // Env:
-//   CITY              limit to one city (by name); default: all cities in cities.json
+//   CITY              limit to one city (by slug); default: all buildable cities
 //   TILES_BASE_URL    style host; default http://localhost:3000 (the deploy sets the R2 domain)
 //   TILES_VERSION     immutable path segment, i.e. the git sha (deploy only); default none (flat path)
 import { mkdir } from 'node:fs/promises'
 import { basename, resolve } from 'node:path'
 
-import { rewritePmtilesStyle, type Style } from '../styles/rewrite-style'
+import { CITIES } from '@freifahren/cities'
 
-type City = { name: string; osmUrl: string }
+import { rewritePmtilesStyle, type Style } from '../styles/rewrite-style'
 
 const PKG = resolve(import.meta.dir, '..') // packages/tile-server
 const REPO = resolve(PKG, '../..') // repo root — mounted into the tilemaker container
 const DIST = resolve(PKG, 'dist')
 const SOURCE = resolve(PKG, 'source')
 const STYLE_SRC = resolve(SOURCE, 'freifahren-style.json')
+const BASE_CONFIG = resolve(PKG, 'tilemaker/config-freifahren.json')
 
 const baseUrl = process.env.TILES_BASE_URL ?? 'http://localhost:3000'
 const version = process.env.TILES_VERSION ?? ''
@@ -27,33 +31,59 @@ const only = process.env.CITY
 // Map a host path to its location inside the container's /work mount.
 const inContainer = (p: string) => p.replace(`${REPO}/`, '/work/')
 
-const { cities } = (await Bun.file(resolve(PKG, 'cities.json')).json()) as { cities: City[] }
-const selected = only ? cities.filter((c) => c.name === only) : cities
+const cities = Object.values(CITIES)
+const selected = only ? cities.filter((c) => c.slug === only) : cities
 if (selected.length === 0) {
-  console.error(`No cities${only ? ` matching "${only}"` : ''} in cities.json`)
+  console.error(`No cities${only ? ` matching "${only}"` : ''} in the @freifahren/cities registry`)
   process.exit(1)
 }
 
 await mkdir(resolve(DIST, 'styles'), { recursive: true })
 await mkdir(SOURCE, { recursive: true })
 
+// The committed tilemaker config carries only the city-agnostic layer/settings tuning.
+// The per-city identity (name, description, schema, default_view) is injected below, so
+// The base file holds no city specifics.
+type TilemakerConfig = {
+  settings: {
+    name?: string
+    description?: string
+    default_view?: readonly [number, number, number]
+    metadata: { schema?: string; [k: string]: unknown }
+    [k: string]: unknown
+  }
+  [k: string]: unknown
+}
+const baseConfig = (await Bun.file(BASE_CONFIG).json()) as TilemakerConfig
+
 for (const city of selected) {
   // 1. OSM extract — download once if not already present locally.
-  const pbf = resolve(SOURCE, basename(new URL(city.osmUrl).pathname))
+  const pbf = resolve(SOURCE, basename(new URL(city.tiles.osmUrl).pathname))
   if (!(await Bun.file(pbf).exists())) {
-    console.log(`↓ ${city.name}: ${city.osmUrl}`)
+    console.log(`↓ ${city.slug}: ${city.tiles.osmUrl}`)
     // curl, not fetch + Bun.write: streaming the ~100 MB extract through Bun.write stalled on CI
     // (the whole deploy hung). curl streams straight to disk and retries. --remove-on-error so an
     // interrupted transfer can't leave a truncated file the exists() check above would later reuse.
-    const dl = Bun.spawn(['curl', '-fSL', '--retry', '3', '--remove-on-error', '-o', pbf, city.osmUrl], {
+    const dl = Bun.spawn(['curl', '-fSL', '--retry', '3', '--remove-on-error', '-o', pbf, city.tiles.osmUrl], {
       stdout: 'inherit',
       stderr: 'inherit',
     })
-    if ((await dl.exited) !== 0) throw new Error(`OSM download failed for ${city.name}`)
+    if ((await dl.exited) !== 0) throw new Error(`OSM download failed for ${city.slug}`)
   }
 
-  // 2. Vector tiles via tilemaker (in Docker — paths resolved inside the /work mount).
-  console.log(`▦ ${city.name}: tilemaker`)
+  // 2. Per-city tilemaker config: base tuning + this city's identity, written into dist/
+  // (inside the /work mount) so tilemaker can read it. The archive's suggested view is
+  // the city's map center + zoom — one source, no drift.
+  const config = structuredClone(baseConfig)
+  config.settings.name = `FreiFahren ${city.displayName} vector tiles`
+  config.settings.description = `OSM-derived vector tiles for the FreiFahren ${city.displayName} basemap.`
+  config.settings.default_view = [...city.map.center, city.map.zoom]
+  config.settings.metadata.schema = `freifahren-${city.slug}`
+  const configPath = resolve(DIST, `tilemaker-config.${city.slug}.json`)
+  await Bun.write(configPath, `${JSON.stringify(config, null, 2)}\n`)
+
+  // 3. Vector tiles via tilemaker (in Docker — paths resolved inside the /work mount).
+  console.log(`▦ ${city.slug}: tilemaker`)
   const proc = Bun.spawn(
     [
       'docker',
@@ -66,20 +96,20 @@ for (const city of selected) {
       'ghcr.io/systemed/tilemaker:master',
       inContainer(pbf),
       '--output',
-      inContainer(resolve(DIST, `${city.name}.pmtiles`)),
+      inContainer(resolve(DIST, `${city.slug}.pmtiles`)),
       '--config',
-      inContainer(resolve(PKG, 'tilemaker/config-freifahren.json')),
+      inContainer(configPath),
       '--process',
       inContainer(resolve(PKG, 'tilemaker/process-freifahren.lua')),
     ],
     { stdout: 'inherit', stderr: 'inherit' },
   )
-  if ((await proc.exited) !== 0) throw new Error(`tilemaker failed for ${city.name}`)
+  if ((await proc.exited) !== 0) throw new Error(`tilemaker failed for ${city.slug}`)
 
-  // 3. Style pointing at this city's archive. Parse fresh per city so mutation can't leak across them.
+  // 4. Style pointing at this city's archive. Parse fresh per city so mutation can't leak across them.
   const style = (await Bun.file(STYLE_SRC).json()) as Style
-  const rewritten = rewritePmtilesStyle(style, { city: city.name, baseUrl, version })
-  await Bun.write(resolve(DIST, 'styles', `${city.name}.json`), `${JSON.stringify(rewritten, null, 2)}\n`)
+  const rewritten = rewritePmtilesStyle(style, { city: city.slug, baseUrl, version })
+  await Bun.write(resolve(DIST, 'styles', `${city.slug}.json`), `${JSON.stringify(rewritten, null, 2)}\n`)
 
-  console.log(`✓ ${city.name}: dist/${city.name}.pmtiles + dist/styles/${city.name}.json`)
+  console.log(`✓ ${city.slug}: dist/${city.slug}.pmtiles + dist/styles/${city.slug}.json`)
 }

--- a/packages/tile-server/tilemaker/config-freifahren.json
+++ b/packages/tile-server/tilemaker/config-freifahren.json
@@ -59,15 +59,11 @@
     "basezoom": 14,
     "include_ids": false,
     "compress": "gzip",
-    "name": "FreiFahren Berlin vector tiles",
     "version": "0.1.0",
-    "description": "OSM-derived vector tiles for the FreiFahren Berlin basemap.",
     "high_resolution": false,
-    "default_view": [13.40587, 52.51346, 11],
     "mvt_version": 2,
     "metadata": {
-      "attribution": "OpenStreetMap contributors",
-      "schema": "freifahren-berlin"
+      "attribution": "OpenStreetMap contributors"
     }
   }
 }

--- a/packages/tile-server/tsconfig.json
+++ b/packages/tile-server/tsconfig.json
@@ -7,7 +7,10 @@
     "types": ["bun"],
     "strict": true,
     "skipLibCheck": true,
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@freifahren/cities": ["../cities/src/index.ts"]
+    }
   },
   "include": ["scripts", "styles"]
 }


### PR DESCRIPTION
Closes FRE-707.

Makes the tile pipeline a projection of the shared `@freifahren/cities` registry, so a new city needs no tile-server changes — unblocks FRE-716 (Leipzig tiles).

## What changed
- **Registry**: added a required `tiles: { osmUrl }` to `CityConfig`. Every city ships with a basemap, so it's not optional.
- **`generate.ts`**: imports the registry (via a new `@freifahren/cities` tsconfig alias) and builds every city in it. The hand-maintained **`cities.json` is deleted**.
- **`config-freifahren.json`**: stripped of all city specifics (`name`, `description`, `default_view`, `metadata.schema`) — it's now purely city-agnostic layer/settings tuning. `generate.ts` injects the per-city identity at build time: `name`/`description`/`schema` from the registry, and `default_view` derived from the city's `map` center + zoom (one source, no drift).
- **Deploy workflow**: the upload loop iterates `dist/*.pmtiles` (exactly what `generate` produced) instead of `jq cities.json`.
- **Docs**: README "Adding a city" + ADR-0004 updated to the registry-driven flow.

## Berlin equivalence
`name` / `description` / `schema` (`freifahren-berlin`) / `osmUrl` are byte-identical to before. The one delta is the archive's `default_view` metadata: `[13.40587, 52.51346, 11]` → `[13.388, 52.5162, 11]` (the registry map center). That's TileJSON `center` metadata only — MapLibre renders from the style, not the archive center — so tiles are **verified-equivalent**, and the redundant second center is gone.

Verified locally: tile-server `tsc` passes (compiles the registry through the alias), the registry import resolves under bun, and the injected Berlin config values match the above. (Full tile generation needs Docker + a ~100 MB extract, so it runs in the deploy; the inputs that determine the output are verified here.)

## Adding a city later (FRE-716)
Add a `tiles` block to the city's registry entry — the next push builds and uploads its archive + style.