### PR TITLE
feat: resolve the city per request and scope the DB to it

### DIFF
--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -1,6 +1,8 @@
 import type { D1Database } from '@cloudflare/workers-types'
+import { CITY_SLUGS, type CityConfig, DEFAULT_CITY_SLUG, getCity } from '@freifahren/cities'
 import { Context, Hono } from 'hono'
 
+import { AppError } from './common/errors'
 import { createLogger, Logger, LogLevel } from './common/logger'
 import { createD1Db, DbConnection } from './db'
 import { ReportsService } from './modules/reports'
@@ -42,6 +44,9 @@ export type Env = {
     Variables: Services & {
         logger: Logger
         config: AppConfig
+        // The city resolved for this request (from `?city=`), the single source for
+        // Which DB the request talks to and how downstream code scopes per-city work.
+        city: CityConfig
     }
 }
 
@@ -95,6 +100,42 @@ export const setErrorReporter = (reporter: ErrorReporter) => {
 
 export const reportError: ErrorReporter = (error, context) => errorReporter(error, context)
 
+// Injected by worker.ts to set a tag on the current Sentry request scope (via
+// @sentry/cloudflare's AsyncLocalStorage scope). Injected — like reportError above —
+// So the SDK stays out of index.ts and the test bundle. No-op until injected.
+type ScopeTagger = (key: string, value: string) => void
+
+let scopeTagger: ScopeTagger = () => undefined
+
+export const setScopeTagger = (tagger: ScopeTagger) => {
+    scopeTagger = tagger
+}
+
+// Resolve the request's city from the explicit `?city=` query parameter. It is a
+// Query param, not a header, because the transit edge cache keys on the full request
+// URL — a header would let one city's cached responses serve another. A missing param
+// Defaults to Berlin (legacy clients: the Capacitor app and old PWA shells); an unknown
+// City is a 400 rather than a silent fallback.
+const resolveCity = (c: Context<Env>): CityConfig => {
+    const requested = c.req.query('city') ?? DEFAULT_CITY_SLUG
+    const city = getCity(requested)
+    if (city === undefined) {
+        throw new AppError({
+            message: `Unknown city "${requested}"`,
+            statusCode: 400,
+            internalCode: 'UNKNOWN_CITY',
+            description: `Supported cities: ${CITY_SLUGS.join(', ')}`,
+        })
+    }
+    return city
+}
+
+// Look up a city's D1 binding by name on the Worker env. Dynamic by design: today
+// Every city resolves to the single `DB` binding, but this is the switch that will
+// Fan out to per-city bindings (DB_LEIPZIG, …) once they exist.
+const cityDbBinding = (env: Bindings, dbBinding: string): D1Database | undefined =>
+    (env as unknown as Record<string, D1Database | undefined>)[dbBinding]
+
 const applyServices = (c: Context<Env>, db: DbConnection, config: AppConfig) => {
     // The executionCtx powers the cache write in cachedReference (waitUntil). It throws off
     // Workers (tests, seed CLI), where the cache is absent anyway, so fall back to undefined.
@@ -125,10 +166,19 @@ export const registerContext = (app: Hono<Env>) => {
 
         const config = resolveConfig(c.env)
 
-        // On Workers the D1 binding is the connection — no per-request lifecycle to manage. Off
-        // Workers (tests, seed CLI) there is no binding, so use the injected libsql provider.
-        if (c.env.DB !== undefined) {
-            applyServices(c, createD1Db(c.env.DB), config)
+        // Resolve the city first: it decides which DB this request talks to, and every
+        // Downstream query goes through the services built from that one binding below.
+        const city = resolveCity(c)
+        c.set('city', city)
+        // Tag the Sentry request scope so every event/transaction is filterable by city.
+        scopeTagger('city', city.slug)
+
+        // On Workers the city's D1 binding is the connection — no per-request lifecycle to
+        // Manage. Off Workers (tests, seed CLI) there is no binding, so use the injected
+        // Libsql provider.
+        const binding = cityDbBinding(c.env, city.dbBinding)
+        if (binding !== undefined) {
+            applyServices(c, createD1Db(binding), config)
         } else {
             if (nodeDbProvider === null) {
                 throw new Error('No D1 binding and no Node db provider registered (call setNodeDbProvider)')

--- a/packages/api-worker/src/common/errors.ts
+++ b/packages/api-worker/src/common/errors.ts
@@ -8,6 +8,7 @@ export type InternalCode =
     | 'RISK_MODEL_FAILED'
     | 'STATION_NOT_FOUND'
     | 'NO_PATH_FOUND'
+    | 'UNKNOWN_CITY'
 export interface AppErrorDetails {
     internal_code: InternalCode
     description?: string

--- a/packages/api-worker/src/worker.ts
+++ b/packages/api-worker/src/worker.ts
@@ -1,13 +1,16 @@
 /// <reference types="@cloudflare/workers-types" />
-import { captureException, consoleLoggingIntegration, withSentry } from '@sentry/cloudflare'
+import { captureException, consoleLoggingIntegration, setTag, withSentry } from '@sentry/cloudflare'
 
-import { Bindings, setErrorReporter } from './app-env'
+import { Bindings, setErrorReporter, setScopeTagger } from './app-env'
 
 import { app } from './index'
 
 // Wired here, not in index.ts, so @sentry/cloudflare stays out of the test bundle.
 // AsyncLocalStorage (set up by withSentry) keeps captures inside a request's waitUntil on its scope.
 setErrorReporter((error, context) => captureException(error, context))
+
+// Same reason: let app-env tag the request scope (e.g. the resolved city) without importing the SDK.
+setScopeTagger((key, value) => setTag(key, value))
 
 // The @sentry/cloudflare HTTP instrumentation names transactions from the raw URL pathname.
 // Each station therefore turns GET /v0/reports/<stationId> into its own transaction (…/BAHU,

--- a/packages/api-worker/tests/city.test.ts
+++ b/packages/api-worker/tests/city.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test'
+
+import { app } from '../src'
+import { testEnv } from './test-utils'
+
+describe('per-request city resolution', () => {
+    it('defaults to berlin when ?city is omitted', async () => {
+        const response = await app.request('/v0/reports', undefined, testEnv())
+        expect(response.status).toBe(200)
+    })
+
+    it('accepts an explicit, known ?city', async () => {
+        const response = await app.request('/v0/reports?city=berlin', undefined, testEnv())
+        expect(response.status).toBe(200)
+    })
+
+    it('rejects an unknown city with 400 UNKNOWN_CITY', async () => {
+        const response = await app.request('/v0/reports?city=atlantis', undefined, testEnv())
+        expect(response.status).toBe(400)
+        const body = (await response.json()) as { details?: { internal_code?: string } }
+        expect(body.details?.internal_code).toBe('UNKNOWN_CITY')
+    })
+})


### PR DESCRIPTION
Closes FRE-708.

Adds per-request city resolution + a city-scoped DB to the api-worker — the switch multi-city plugs into, with Berlin behaviour unchanged. Unblocks FRE-709 (city-scoped caches), FRE-712 (subdomain switcher), FRE-714 (Leipzig DB binding).

## Decision: `?city=` query param, not a header
The transit edge cache keys on the full request URL (`transit-cache-middleware.ts` → `new Request(c.req.url)`), so a header selector would serve one city's cached responses to another. A query param is part of the cache key, so entries stay per-city. Missing param defaults to `berlin` (legacy Capacitor app + old PWA shells); an unknown city is a `400` (`UNKNOWN_CITY`), not a silent fallback.

## What changed
- **`registerContext` (`app-env.ts`)**: resolve the city from `?city=` → validate against the `@freifahren/cities` registry → build the request's DB/services from the city's `dbBinding`. Every query already flows through the services built here, so this is the single scoped chokepoint.
- **Dynamic binding lookup** (`cityDbBinding`): today all cities resolve to the one `DB` binding; this is the N-binding switch per-city bindings (`DB_LEIPZIG`, …) plug into in FRE-714. Test/seed path (libsql via `nodeDbProvider`) is preserved when no binding is present.
- **Resolved `CityConfig` on the context** (`c.get('city')`) — the source FRE-709 reads for per-city cache tags.
- **Sentry scope tag**: `city = <slug>` on every request, via an injected `setScopeTagger` (same pattern as the existing `setErrorReporter`, keeping `@sentry/cloudflare` out of the test bundle). No hardcoded tag existed to replace, so this sets it directly.

## Verification
- New `tests/city.test.ts`: omitted `?city` → 200 (defaults berlin), `?city=berlin` → 200, `?city=atlantis` → 400 `UNKNOWN_CITY`.
- **91 tests pass** (88 + 3). Typecheck unchanged (pre-existing drizzle-noise baseline, 0 new). Lint: 0 errors; `format:check` clean.