### PR TITLE
feat: add a city dimension to PostHog and Sentry (berlin-only)

### DIFF
--- a/packages/frontend-next/src/lib/error-monitoring.ts
+++ b/packages/frontend-next/src/lib/error-monitoring.ts
@@ -28,7 +28,9 @@ export function initErrorMonitoring(): void {
     release: __BUILD_ID__,
     environment: import.meta.env.MODE,
     // Tag every event with the runtime so native (ios/android) and web issues are filterable.
-    initialScope: { tags: { platform: Capacitor.getPlatform() } },
+    // city is hardcoded to berlin for now; switches to hostname-resolved once runtime city
+    // resolution lands on the frontend.
+    initialScope: { tags: { platform: Capacitor.getPlatform(), city: 'berlin' } },
     // No IP address, cookies, or request payloads — see the file header.
     sendDefaultPii: false,
     // Performance: capture page-load/navigation timing and Web Vitals (LCP, INP, CLS, ...) on a 50%

--- a/packages/frontend-next/src/lib/posthog-client.ts
+++ b/packages/frontend-next/src/lib/posthog-client.ts
@@ -81,9 +81,13 @@ export function loadPostHog(): Promise<void> {
       capture_pageview: false,
     });
     // Stamp every event with the runtime so funnels can be split by web vs native.
+    // city is a registered super property (not derived from $host) because native
+    // (Capacitor) events have no meaningful host. Hardcoded to berlin for now;
+    // switches to hostname-resolved once runtime city resolution lands on the frontend.
     posthog.register({
       platform: Capacitor.getPlatform(),
       is_native: Capacitor.isNativePlatform(),
+      city: 'berlin',
     });
     instance = posthog;
     for (const op of queue) op(posthog);

--- a/packages/telegram-worker/src/index.ts
+++ b/packages/telegram-worker/src/index.ts
@@ -14,6 +14,9 @@ export default withSentry(
         enableLogs: true,
         integrations: [consoleLoggingIntegration({ levels: ['info', 'warn', 'error'] })],
         tracesSampleRate: 1.0,
+        // Tag every event with the city so all three Sentry projects are filterable by it.
+        // Static berlin for now (this worker is Berlin-only); resolve per-message later.
+        initialScope: { tags: { city: 'berlin' } },
     }),
     {
         async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {


### PR DESCRIPTION
Closes FRE-704.

Rollout step 1 of the multi-city work: give analytics + error monitoring a `city` filter dimension now, hardcoded to `berlin`. No behaviour change — it switches to resolved values in later tickets.

## What changed
- **Frontend PostHog** (`src/lib/posthog-client.ts`): `city: 'berlin'` registered as a super property. It's a *registered* property rather than `$host`-derived because native (Capacitor) events have no meaningful host. Set right after `init` and before the buffered-event queue flushes, so every event carries it — buffered startup events, manual pageviews, and all future events.
- **Frontend Sentry** (`src/lib/error-monitoring.ts`): `city: 'berlin'` added to `initialScope.tags`, so it applies to both errors and performance transactions.
- **telegram-worker** (`src/index.ts`): `initialScope: { tags: { city: 'berlin' } }` on `withSentry`.

## Two items from the ticket's file list, handled differently
- **api-worker**: the ticket asked for a static `'berlin'` tag, but FRE-708 already sets a **resolved** per-request `city` scope tag — strictly better — so it's left as-is.
- **frontend worker** (`worker/index.ts`): the ticket lists it, but this file has **no Sentry** — it's purely the PostHog `/relay` reverse-proxy (grepped the whole package + wrangler config: zero Sentry refs). Nothing to tag; adding a Sentry setup to it is out of scope for this ticket. The frontend's Sentry lives in `src/lib/error-monitoring.ts`, which is tagged above.

## Acceptance
Every new PostHog event carries `city=berlin` (super property, all event types). All active Sentry projects (frontend browser, api-worker via FRE-708, telegram-worker) show the `city` tag on new events. Historical events can't be retroactively tagged — platform limitation.

## Verification
telegram-worker typecheck + 53 tests pass; the two frontend files lint clean.