### PR TITLE
feat: resolve the frontend city at runtime from the hostname

### DIFF
--- a/packages/cities/src/berlin.ts
+++ b/packages/cities/src/berlin.ts
@@ -92,6 +92,5 @@ export const BERLIN: CityConfig = {
     },
     community: {
         telegramHandle: '@FreiFahren_BE',
-        instagram: 'frei.fahren',
     },
 }

--- a/packages/cities/src/types.ts
+++ b/packages/cities/src/types.ts
@@ -75,12 +75,14 @@ export interface CityTelegramProfile {
     promptExamples: string
 }
 
-/** Public community channels surfaced in the app for a city. */
+/**
+ * Public community channels surfaced in the app for a city. Only genuinely per-city
+ * channels live here — Instagram/GitHub are shared across all cities (one account
+ * each) and stay as frontend constants.
+ */
 export interface CityCommunity {
     /** Telegram group handle reports are synced with (e.g. `@FreiFahren_BE`). */
     telegramHandle: string
-    /** Instagram handle (without the `@` or URL). */
-    instagram: string
 }
 
 /**

--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/rea
 import type { TFunction } from 'i18next';
 import { useEffect, useState } from 'react';
 
+import { currentCitySlug } from '@/lib/city';
 import { traceAction } from '@/lib/error-monitoring';
 import { requireEnv } from '@/lib/utils';
 
@@ -230,7 +231,9 @@ export function useSubmitReport() {
     mutationFn: (input: SubmitReportInput): Promise<SubmitReportResponse> =>
       traceAction('Submit Report', async () => {
         const lineId = resolveLineId(input, lines);
-        const response = await fetch(`${API_URL}/v0/reports`, {
+        const submitUrl = new URL(`${API_URL}/v0/reports`);
+        submitUrl.searchParams.set('city', currentCitySlug);
+        const response = await fetch(submitUrl, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', 'ff-platform': 'web' },
           body: JSON.stringify({

--- a/packages/frontend-next/src/api/transit.ts
+++ b/packages/frontend-next/src/api/transit.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import type { Feature, FeatureCollection, LineString, Point } from 'geojson';
 
+import { currentCitySlug } from '@/lib/city';
 import { distanceMeters } from '@/lib/geo';
 import { requireEnv } from '@/lib/utils';
 
@@ -92,7 +93,10 @@ export function resolveStationLineNames(
 }
 
 export async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(`${API_URL}${path}`, init);
+  // Every API call carries the resolved city so the worker scopes it to the right DB/cache.
+  const url = new URL(`${API_URL}${path}`);
+  url.searchParams.set('city', currentCitySlug);
+  const response = await fetch(url, init);
   if (!response.ok) {
     throw new Error(`Request to ${path} failed: ${response.status}`);
   }

--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -15,7 +15,7 @@ maplibregl.addProtocol('pmtiles', pmtilesProtocol.tile);
 
 import { useRisk } from '@/api/risk';
 import { useSegments } from '@/api/transit';
-import { requireEnv } from '@/lib/utils';
+import { currentCity } from '@/lib/city';
 
 import { LineLayer } from './LineLayer';
 import { MapCameraController } from './MapCameraController';
@@ -27,12 +27,12 @@ import { REPORTS_HIT_LAYER_ID } from '../../hooks/useReportsLayer';
 import { useRiskLayer } from '../../hooks/useRiskLayer';
 import { useStationSelection } from '../../hooks/useStationSelection';
 
-const MAP_STYLE_URL = requireEnv('VITE_MAP_STYLE_URL');
+const MAP_STYLE_URL = currentCity.map.styleUrl;
 
 const INITIAL_VIEW = {
-  longitude: requireEnv('VITE_MAP_CENTER_LNG', 'number'),
-  latitude: requireEnv('VITE_MAP_CENTER_LAT', 'number'),
-  zoom: requireEnv('VITE_MAP_INITIAL_ZOOM', 'number'),
+  longitude: currentCity.map.center[0],
+  latitude: currentCity.map.center[1],
+  zoom: currentCity.map.zoom,
 };
 
 // Keep the city in view: stop users from zooming out past the metro-area level.

--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -7,7 +7,7 @@ import { LineBadge } from '@/components/transit/LineBadge';
 import { CardContent } from '@/components/ui/card';
 import { useGeolocation } from '@/contexts/Geolocation.context';
 import { useModalViewDuration } from '@/hooks/useModalViewDuration';
-import { optionalEnv } from '@/lib/utils';
+import { currentCity } from '@/lib/city';
 
 import { DetailCard } from './DetailCard';
 import { NAMESPACE } from './ReportDetail.i18n';
@@ -19,7 +19,7 @@ type ReportDetailProps = {
 };
 
 // Telegram group the reports are synced with.
-const REPORTS_GROUP_HANDLE = optionalEnv('VITE_REPORTS_GROUP_HANDLE') ?? '@FreiFahren_BE';
+const REPORTS_GROUP_HANDLE = currentCity.community.telegramHandle;
 
 export function ReportDetail({ station, onClose }: ReportDetailProps) {
   const { t } = useTranslation(NAMESPACE);

--- a/packages/frontend-next/src/components/map/SocialLinks.tsx
+++ b/packages/frontend-next/src/components/map/SocialLinks.tsx
@@ -2,6 +2,7 @@ import { GithubIcon, InstagramIcon } from '@/components/brand-icons';
 import { Button } from '@/components/ui/button';
 import { cn, optionalEnv } from '@/lib/utils';
 
+// GitHub and Instagram are the same across all cities (one shared account each).
 const GITHUB_URL = optionalEnv('VITE_GITHUB_URL') ?? 'https://github.com/FreiFahren/FreiFahren';
 const INSTAGRAM_URL = optionalEnv('VITE_INSTAGRAM_URL') ?? 'https://www.instagram.com/frei.fahren';
 

--- a/packages/frontend-next/src/lib/city.ts
+++ b/packages/frontend-next/src/lib/city.ts
@@ -1,0 +1,39 @@
+import { Capacitor } from '@capacitor/core';
+import { CITIES, DEFAULT_CITY_SLUG, getCity, type CityConfig } from '@freifahren/cities';
+
+// Runtime city resolution. One build serves every city; the active city is resolved at boot
+// from a source that depends on the platform, then held for the session. The registry
+// (packages/cities) is small static data bundled into the client.
+
+// Persisted native city preference, written by the in-app switcher (FRE-721). Until then it's
+// unset and native falls back to the default.
+const NATIVE_CITY_PREFERENCE_KEY = 'freifahren.city';
+
+const defaultCity = (): CityConfig => getCity(DEFAULT_CITY_SLUG) as CityConfig;
+
+// Native (Capacitor): the WebView origin is capacitor://localhost, so the hostname can't
+// select a city. Resolve from a persisted preference instead (localStorage is synchronous and
+// available in the WebView). The switcher UI that writes it ships in FRE-721.
+const resolveNativeCity = (): CityConfig => {
+  try {
+    const stored = localStorage.getItem(NATIVE_CITY_PREFERENCE_KEY);
+    return (stored ? getCity(stored) : undefined) ?? defaultCity();
+  } catch {
+    return defaultCity();
+  }
+};
+
+// Web: the subdomain selects the city (berlin.freifahren.org -> berlin). Unknown hosts
+// (freifahren.org, app./www., localhost, preview deploys) fall back to the default.
+const resolveWebCity = (hostname: string): CityConfig => {
+  const label = hostname.split('.')[0];
+  return Object.values(CITIES).find((city) => city.subdomain === label) ?? defaultCity();
+};
+
+// The active city for this session. The resolution source is pluggable (stored preference on
+// native, hostname on web); the resolved city is fixed once the app boots.
+export const currentCity: CityConfig = Capacitor.isNativePlatform()
+  ? resolveNativeCity()
+  : resolveWebCity(typeof location !== 'undefined' ? location.hostname : '');
+
+export const currentCitySlug = currentCity.slug;

--- a/packages/frontend-next/src/lib/error-monitoring.ts
+++ b/packages/frontend-next/src/lib/error-monitoring.ts
@@ -1,6 +1,7 @@
 import { Capacitor } from '@capacitor/core';
 import * as SentryReact from '@sentry/react';
 
+import { currentCitySlug } from '@/lib/city';
 import { optionalEnv } from '@/lib/utils';
 
 // Provider-agnostic error-monitoring facade. The rest of the app never imports the Sentry SDK
@@ -28,9 +29,8 @@ export function initErrorMonitoring(): void {
     release: __BUILD_ID__,
     environment: import.meta.env.MODE,
     // Tag every event with the runtime so native (ios/android) and web issues are filterable.
-    // city is hardcoded to berlin for now; switches to hostname-resolved once runtime city
-    // resolution lands on the frontend.
-    initialScope: { tags: { platform: Capacitor.getPlatform(), city: 'berlin' } },
+    // city is resolved at boot from the hostname (web) or stored preference (native).
+    initialScope: { tags: { platform: Capacitor.getPlatform(), city: currentCitySlug } },
     // No IP address, cookies, or request payloads — see the file header.
     sendDefaultPii: false,
     // Performance: capture page-load/navigation timing and Web Vitals (LCP, INP, CLS, ...) on a 50%

--- a/packages/frontend-next/src/lib/posthog-client.ts
+++ b/packages/frontend-next/src/lib/posthog-client.ts
@@ -1,6 +1,7 @@
 import { Capacitor } from '@capacitor/core';
 import type { PostHog } from 'posthog-js';
 
+import { currentCitySlug } from './city';
 import { optionalEnv } from './utils';
 
 // In the native WKWebView (capacitor://localhost) cookies are unreliable, so persistent capture uses
@@ -82,12 +83,12 @@ export function loadPostHog(): Promise<void> {
     });
     // Stamp every event with the runtime so funnels can be split by web vs native.
     // city is a registered super property (not derived from $host) because native
-    // (Capacitor) events have no meaningful host. Hardcoded to berlin for now;
-    // switches to hostname-resolved once runtime city resolution lands on the frontend.
+    // (Capacitor) events have no meaningful host. Resolved at boot from the hostname
+    // (web) or the stored preference (native).
     posthog.register({
       platform: Capacitor.getPlatform(),
       is_native: Capacitor.isNativePlatform(),
-      city: 'berlin',
+      city: currentCitySlug,
     });
     instance = posthog;
     for (const op of queue) op(posthog);

--- a/packages/frontend-next/tsconfig.app.json
+++ b/packages/frontend-next/tsconfig.app.json
@@ -23,7 +23,8 @@
 
     /* Path aliases */
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@freifahren/cities": ["../cities/src/index.ts"]
     }
   },
   "include": ["src"]

--- a/packages/frontend-next/tsconfig.json
+++ b/packages/frontend-next/tsconfig.json
@@ -3,7 +3,8 @@
   "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@freifahren/cities": ["../cities/src/index.ts"]
     }
   }
 }

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -208,6 +208,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      // Shared city registry (small static data), bundled into the client. Vite does not
+      // read tsconfig `paths`, so the alias is declared here too.
+      '@freifahren/cities': path.resolve(__dirname, '../cities/src/index.ts'),
     },
   },
 });


### PR DESCRIPTION
Closes FRE-710.

One build now serves every city. The active city is resolved once at boot instead of being baked in via `import.meta.env`, so subdomains can serve different cities without a rebuild. Unblocks FRE-712 (city switcher) and FRE-721 (native switcher).

## What changed
- **`src/lib/city.ts`** resolves the active city at boot, source pluggable per platform:
  - **Web**: `location.hostname` first label matched against the registry `subdomain` (unknown host — root, `app.`/`www.`, localhost, previews — → default `berlin`).
  - **Native (Capacitor)**: origin is `capacitor://localhost`, so resolve from a persisted `localStorage` preference (default `berlin`). This PR only makes the source pluggable; the in-app switcher that *writes* it ships in FRE-721.
- **Consumed the resolved city**: Map center/zoom/style ← `currentCity.map`; Telegram group handle ← `community.telegramHandle`; PostHog super property + Sentry tag ← `currentCitySlug` (replacing the hardcoded `'berlin'` from FRE-704).
- **All API calls append `?city=`** — centrally in `transit.ts` `fetchJson` (stations/lines/segments/risk/reports-GET/distance) plus the report POST.
- **Bundled `@freifahren/cities` into the client** (Vite `resolve.alias` + both tsconfig `paths`). Verified it works in the frontend's `tsc -b` composite build + Vite bundle.
- **Instagram + GitHub are one shared account across all cities**, so they stay frontend constants; removed the now-unused per-city `community.instagram` from the registry (only `telegramHandle` is per-city).

## Scope (per the ticket)
`VITE_API_URL` and PostHog/Sentry keys stay build-time (identical across cities). Per-host meta/manifest/robots are out — they land with the Leipzig launch ticket.

## Verification
Full build passes (`tsr generate && tsc -b && vite build`); lint 0 errors. A resolution probe confirms `berlin.freifahren.org` → berlin and every unknown host → berlin default (and `leipzig.freifahren.org` will resolve to leipzig once FRE-715 registers it). Berlin is behaviour-equivalent — the registry values equal the old env defaults. No frontend test runner exists, so build + lint are the gates.