### PR TITLE
test: exercise Cloudflare runtime behavior (Cache API, waitUntil, purge contract)

### DIFF
--- a/packages/api-worker/tests/city-cache.test.ts
+++ b/packages/api-worker/tests/city-cache.test.ts
@@ -5,18 +5,13 @@ import { purgeTransitCache } from '../src/db/seed/purge-transit-cache'
 import { referenceCacheKey } from '../src/modules/transit/reference-cache'
 import { cityCacheKey, transitCacheTag } from '../src/modules/transit/transit-cache-middleware'
 
-// The real Workers Cache API is absent under Bun (the middleware falls through) and only
-// berlin is in the registry today, so we prove city-scoping at the key/tag derivation
-// level: distinct cities -> distinct cache entries (distinct keys) and purge isolation
-// (distinct tags, city-scoped purge). That is what keeps two cities from bleeding.
-//
-// TODO(vitest-cloudflare): once the suite runs on @cloudflare/vitest-pool-workers (or a
-// getPlatformProxy-backed harness) there is a real caches.default, so replace these
-// derivation-level checks with a true end-to-end integration test: drive GET
-// /v0/transit/stations for two cities through transitEdgeCacheMiddleware, assert each
-// stores its own entry and a second request is an X-Edge-Cache HIT, then purge one
-// city's tag and assert that city misses while the other still hits. Needs a second
-// city in the registry (or a test-only stub) to exercise the multi-city path fully.
+// Only berlin is in the registry today, so city-scoping is proven at the key/tag
+// derivation level: distinct cities -> distinct cache entries (distinct keys) and purge
+// isolation (distinct tags, city-scoped purge). That is what keeps two cities from
+// bleeding. The single-city end-to-end behavior (real caches.default: MISS/HIT, 304,
+// purge-and-repopulate) lives in edge-cache.test.ts; once a second city joins the
+// registry, extend that suite to drive both cities and assert one city's purge leaves
+// the other's entries hitting.
 
 describe('edge cache key is city-scoped', () => {
     const url = 'https://api.freifahren.org/v0/transit/stations'

--- a/packages/api-worker/tests/edge-cache.test.ts
+++ b/packages/api-worker/tests/edge-cache.test.ts
@@ -1,0 +1,219 @@
+import { getCity } from '@freifahren/cities'
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { Hono } from 'hono'
+import { afterAll, afterEach, describe, expect, it } from 'vitest'
+
+import type { Env } from '../src/app-env'
+import { app } from '../src/index'
+import { referenceCacheKey } from '../src/modules/transit/reference-cache'
+import {
+    cityCacheKey,
+    TRANSIT_CACHE_CONTROL,
+    transitCacheMiddleware,
+    transitCacheTag,
+    transitEdgeCacheMiddleware,
+} from '../src/modules/transit/transit-cache-middleware'
+import { testEnv } from './test-utils'
+
+// The Workers pool provides a real caches.default (the DOM CacheStorage type lacks it).
+const cache = (
+    caches as unknown as {
+        default: {
+            match(request: Request): Promise<Response | undefined>
+            put(request: Request, response: Response): Promise<void>
+            delete(request: Request): Promise<boolean>
+        }
+    }
+).default
+
+const BASE = 'https://api.test'
+
+// Storage is shared across suites (isolatedStorage: false), so every entry a test warms is
+// tracked and deleted again — no other suite may observe this file's cache state.
+const warmedUrls: string[] = []
+
+const keyFor = (url: string): Request => {
+    warmedUrls.push(url)
+    return cityCacheKey(url, 'berlin')
+}
+
+// Real request through the whole app with a real ExecutionContext, so c.executionCtx exists and
+// waitOnExecutionContext genuinely awaits the waitUntil(cache.put) before the test goes on.
+const edgeRequest = async (url: string, headers: Record<string, string> = {}) => {
+    warmedUrls.push(url)
+    const ctx = createExecutionContext()
+    const response = await app.request(url, { headers }, testEnv(), ctx)
+    await waitOnExecutionContext(ctx)
+    return response
+}
+
+afterEach(async () => {
+    for (const url of warmedUrls.splice(0)) {
+        await cache.delete(cityCacheKey(url, 'berlin'))
+    }
+})
+
+// Requests with a real ExecutionContext also warm the internal reference cache
+// (cachedReference); drop those entries so later suites keep reading straight from D1.
+afterAll(async () => {
+    for (const key of ['stations', 'lines', 'segments']) {
+        await cache.delete(new Request(referenceCacheKey('berlin', key)))
+    }
+})
+
+describe('transitEdgeCacheMiddleware (real Cache API)', () => {
+    it('serves the second request from the edge cache', async () => {
+        const url = `${BASE}/v0/transit/lines?t=hit`
+
+        const miss = await edgeRequest(url)
+        expect(miss.status).toBe(200)
+        expect(miss.headers.get('X-Edge-Cache')).toBe('MISS')
+
+        const hit = await edgeRequest(url)
+        expect(hit.status).toBe(200)
+        expect(hit.headers.get('X-Edge-Cache')).toBe('HIT')
+        expect(await hit.json()).toEqual(await miss.json())
+    })
+
+    it('stores the entry under the city-scoped key with the Cache-Tag the tag purge targets', async () => {
+        const url = `${BASE}/v0/transit/stations?t=tag`
+        await edgeRequest(url)
+
+        const entry = await cache.match(keyFor(url))
+        expect(entry).toBeDefined()
+        expect(entry!.headers.get('Cache-Tag')).toBe(transitCacheTag('berlin'))
+        expect(entry!.headers.get('Cache-Control')).toBe(TRANSIT_CACHE_CONTROL)
+        expect(entry!.headers.get('ETag')).not.toBeNull()
+    })
+
+    it('strips origin-specific headers from the stored entry and re-derives CORS per request', async () => {
+        const url = `${BASE}/v0/transit/lines?t=cors`
+
+        const first = await edgeRequest(url, { Origin: 'http://localhost' })
+        expect(first.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost')
+
+        const entry = await cache.match(keyFor(url))
+        expect(entry).toBeDefined()
+        expect(entry!.headers.get('Access-Control-Allow-Origin')).toBeNull()
+        expect(entry!.headers.get('Access-Control-Allow-Credentials')).toBeNull()
+        expect(entry!.headers.get('Vary')).toBeNull()
+
+        // A hit from another origin must get its own CORS headers, not the first origin's.
+        const otherOrigin = await edgeRequest(url, { Origin: 'http://127.0.0.1:1871' })
+        expect(otherOrigin.headers.get('X-Edge-Cache')).toBe('HIT')
+        expect(otherOrigin.headers.get('Access-Control-Allow-Origin')).toBe('http://127.0.0.1:1871')
+    })
+
+    it('answers If-None-Match on a warm entry with a 304 preserving ETag and Cache-Control', async () => {
+        const url = `${BASE}/v0/transit/segments?t=etag`
+
+        const miss = await edgeRequest(url)
+        const etag = miss.headers.get('ETag')
+        expect(etag).not.toBeNull()
+
+        const revalidated = await edgeRequest(url, { 'If-None-Match': etag! })
+        expect(revalidated.status).toBe(304)
+        expect(revalidated.headers.get('X-Edge-Cache')).toBe('HIT')
+        expect(revalidated.headers.get('ETag')).toBe(etag)
+        expect(revalidated.headers.get('Cache-Control')).toBe(TRANSIT_CACHE_CONTROL)
+        expect(await revalidated.text()).toBe('')
+
+        // Weak comparison: a W/-prefixed client tag and a bare * both revalidate.
+        const weak = await edgeRequest(url, { 'If-None-Match': `W/${etag!}` })
+        expect(weak.status).toBe(304)
+        const star = await edgeRequest(url, { 'If-None-Match': '*' })
+        expect(star.status).toBe(304)
+
+        // A stale tag (post-reseed ETag change) must get the full body again, not a 304.
+        const stale = await edgeRequest(url, { 'If-None-Match': '"no-longer-current"' })
+        expect(stale.status).toBe(200)
+        expect(stale.headers.get('X-Edge-Cache')).toBe('HIT')
+    })
+
+    it('does not cache a non-200: an origin 304 on a cold cache stays uncached', async () => {
+        const url = `${BASE}/v0/transit/lines?t=cold304`
+
+        const miss = await edgeRequest(url)
+        const etag = miss.headers.get('ETag')
+        expect(etag).not.toBeNull()
+        await cache.delete(cityCacheKey(url, 'berlin'))
+
+        // Cold cache + matching If-None-Match: the origin's etag middleware answers 304, which
+        // the edge middleware must pass through without storing.
+        const coldRevalidation = await edgeRequest(url, { 'If-None-Match': etag! })
+        expect(coldRevalidation.status).toBe(304)
+        expect(coldRevalidation.headers.get('X-Edge-Cache')).toBeNull()
+        expect(await cache.match(cityCacheKey(url, 'berlin'))).toBeUndefined()
+    })
+
+    it('misses after a purge (key delete) and repopulates the entry', async () => {
+        const url = `${BASE}/v0/transit/stations?t=purge`
+
+        await edgeRequest(url)
+        expect((await edgeRequest(url)).headers.get('X-Edge-Cache')).toBe('HIT')
+
+        // Local analogue of the production tag purge (the Cloudflare API call itself is
+        // covered in city-cache.test.ts): the entry disappears, the next request misses
+        // and re-caches, and traffic keeps flowing.
+        expect(await cache.delete(cityCacheKey(url, 'berlin'))).toBe(true)
+
+        const afterPurge = await edgeRequest(url)
+        expect(afterPurge.status).toBe(200)
+        expect(afterPurge.headers.get('X-Edge-Cache')).toBe('MISS')
+        expect((await edgeRequest(url)).headers.get('X-Edge-Cache')).toBe('HIT')
+    })
+})
+
+// Error paths can't be forced through the real routes, so a minimal app around the two
+// middlewares pins down what must NOT be cached or tagged.
+describe('transit cache middlewares on error responses', () => {
+    const errorApp = new Hono<Env>()
+    errorApp.use('*', async (c, next) => {
+        c.set('city', getCity('berlin')!)
+        await next()
+    })
+    errorApp.use('*', transitEdgeCacheMiddleware)
+    errorApp.use('*', transitCacheMiddleware)
+    errorApp.get('/v0/transit/lines', (c) => c.json({ error: 'boom' }, 500))
+    errorApp.get('/v0/transit/missing', (c) => c.json({ error: 'not found' }, 404))
+    errorApp.post('/v0/transit/lines', (c) => c.json({ ok: true }))
+
+    const errorRequest = async (url: string, method = 'GET') => {
+        warmedUrls.push(url)
+        const ctx = createExecutionContext()
+        const response = await errorApp.request(url, { method }, testEnv(), ctx)
+        await waitOnExecutionContext(ctx)
+        return response
+    }
+
+    it('a 5xx gets no Cache-Control/Cache-Tag and is not stored', async () => {
+        const url = `${BASE}/v0/transit/lines?t=err5xx`
+        const response = await errorRequest(url)
+
+        expect(response.status).toBe(500)
+        expect(response.headers.get('Cache-Control')).toBeNull()
+        expect(response.headers.get('Cache-Tag')).toBeNull()
+        expect(response.headers.get('X-Edge-Cache')).toBeNull()
+        expect(await cache.match(cityCacheKey(url, 'berlin'))).toBeUndefined()
+    })
+
+    it('a non-200 below 500 keeps its cache headers but is not stored at the edge', async () => {
+        const url = `${BASE}/v0/transit/missing?t=err404`
+        const response = await errorRequest(url)
+
+        expect(response.status).toBe(404)
+        expect(response.headers.get('Cache-Control')).toBe(TRANSIT_CACHE_CONTROL)
+        expect(response.headers.get('Cache-Tag')).toBe(transitCacheTag('berlin'))
+        expect(response.headers.get('X-Edge-Cache')).toBeNull()
+        expect(await cache.match(cityCacheKey(url, 'berlin'))).toBeUndefined()
+    })
+
+    it('non-GET responses get no cache headers', async () => {
+        const url = `${BASE}/v0/transit/lines?t=post`
+        const response = await errorRequest(url, 'POST')
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Cache-Control')).toBeNull()
+        expect(response.headers.get('Cache-Tag')).toBeNull()
+    })
+})

--- a/packages/api-worker/tests/postReport.test.ts
+++ b/packages/api-worker/tests/postReport.test.ts
@@ -1,11 +1,13 @@
-import { fetchMock } from 'cloudflare:test'
+import { createExecutionContext, fetchMock, waitOnExecutionContext } from 'cloudflare:test'
 import { and, desc, eq, sql } from 'drizzle-orm'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
+import { app } from '../src/index'
+import { referenceCacheKey } from '../src/modules/transit/reference-cache'
 import { Stations } from '../src/modules/transit/types'
 import { TransitNetworkDataService } from '../src/modules/transit/transit-network-data-service'
 import { db, lineStations, reports, stations } from './test-db'
-import { resetTestEnv, sendReportRequest, setTestEnv } from './test-utils'
+import { resetTestEnv, sendReportRequest, setTestEnv, testEnv } from './test-utils'
 
 const TELEGRAM_ORIGIN = 'https://telegram-worker.test'
 
@@ -109,6 +111,36 @@ describe('Telegram notification', () => {
         expect(response.headers.get('X-Telegram-Notification-Status')).toBeNull()
         // The forward was still attempted; only its failure is swallowed.
         expect(capturedRequests.length).toBe(1)
+    })
+
+    it('forwards in the background via waitUntil when an ExecutionContext is present', async () => {
+        const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
+
+        // A real ExecutionContext takes the waitUntil branch instead of awaiting inline; a
+        // failing forward must neither fail the response nor leak out of the background task.
+        shouldFail = true
+        const ctx = createExecutionContext()
+        const response = await app.request(
+            '/v0/reports',
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Password': testEnv().REPORT_PASSWORD ?? '' },
+                body: JSON.stringify({ stationId: station.id, source: 'web_app' }),
+            },
+            testEnv(),
+            ctx
+        )
+
+        expect(response.status).toBe(200)
+        await waitOnExecutionContext(ctx)
+        expect(capturedRequests.length).toBe(1)
+
+        // The real ExecutionContext also let cachedReference warm the shared reference cache;
+        // drop those entries so later suites keep reading straight from D1.
+        const cache = (caches as unknown as { default: Cache }).default
+        for (const key of ['stations', 'lines', 'segments']) {
+            await cache.delete(new Request(referenceCacheKey('berlin', key)))
+        }
     })
 
     it('does not send a Telegram notification if database insertion fails', async () => {

--- a/packages/api-worker/tests/reference-cache.test.ts
+++ b/packages/api-worker/tests/reference-cache.test.ts
@@ -1,0 +1,90 @@
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { cachedReference, referenceCacheKey } from '../src/modules/transit/reference-cache'
+import { cityCacheKey, TRANSIT_CACHE_CONTROL, transitCacheTag } from '../src/modules/transit/transit-cache-middleware'
+
+// The Workers pool provides a real caches.default (the DOM CacheStorage type lacks it).
+const cache = (
+    caches as unknown as {
+        default: {
+            match(request: Request): Promise<Response | undefined>
+            put(request: Request, response: Response): Promise<void>
+            delete(request: Request): Promise<boolean>
+        }
+    }
+).default
+
+// Storage is shared across suites (isolatedStorage: false); every key a test touches is
+// deleted again so no other suite reads this file's fabricated reference data.
+const usedKeys: Request[] = []
+
+const internalKey = (citySlug: string, key: string): Request => {
+    const request = new Request(referenceCacheKey(citySlug, key))
+    usedKeys.push(request)
+    return request
+}
+
+afterEach(async () => {
+    for (const key of usedKeys.splice(0)) {
+        await cache.delete(key)
+    }
+})
+
+const withCtx = async <T>(run: (ctx: ExecutionContext) => Promise<T>): Promise<T> => {
+    const ctx = createExecutionContext()
+    const result = await run(ctx)
+    await waitOnExecutionContext(ctx)
+    return result
+}
+
+describe('cachedReference (real Cache API)', () => {
+    it('invokes the loader once on a miss and serves the second call from the cache', async () => {
+        internalKey('berlin', 'spec-read-through')
+        const loader = vi.fn(async () => ({ answer: 42 }))
+
+        const first = await withCtx((ctx) => cachedReference('berlin', 'spec-read-through', loader, ctx))
+        const second = await withCtx((ctx) => cachedReference('berlin', 'spec-read-through', loader, ctx))
+
+        expect(loader).toHaveBeenCalledTimes(1)
+        expect(first).toEqual({ answer: 42 })
+        expect(second).toEqual({ answer: 42 })
+    })
+
+    it('stores the entry with the city Cache-Tag, so the tag purge clears this layer too', async () => {
+        const key = internalKey('berlin', 'spec-tag')
+        await withCtx((ctx) => cachedReference('berlin', 'spec-tag', async () => 'tagged', ctx))
+
+        const entry = await cache.match(key)
+        expect(entry).toBeDefined()
+        expect(entry!.headers.get('Cache-Tag')).toBe(transitCacheTag('berlin'))
+        expect(entry!.headers.get('Cache-Control')).toBe(TRANSIT_CACHE_CONTROL)
+    })
+
+    it('does not collide with the HTTP edge-cache keys for the same resource', async () => {
+        // A warm HTTP entry for /v0/transit/stations must not satisfy the internal
+        // "stations" lookup — the synthetic INTERNAL_ORIGIN keeps the namespaces apart.
+        const edgeKey = cityCacheKey('https://api.test/v0/transit/stations', 'berlin')
+        usedKeys.push(edgeKey)
+        await cache.put(edgeKey, new Response('"http-entry"', { headers: { 'Cache-Control': 'max-age=60' } }))
+
+        internalKey('berlin', 'stations')
+        const loader = vi.fn(async () => 'from-loader')
+        const value = await withCtx((ctx) => cachedReference('berlin', 'stations', loader, ctx))
+
+        expect(loader).toHaveBeenCalledTimes(1)
+        expect(value).toBe('from-loader')
+        // And the reference write must not clobber the HTTP entry either.
+        expect(await (await cache.match(edgeKey))!.text()).toBe('"http-entry"')
+    })
+
+    it('skips the cache write without an ExecutionContext, so the next call loads again', async () => {
+        internalKey('berlin', 'spec-no-ctx')
+        const loader = vi.fn(async () => 'uncached')
+
+        expect(await cachedReference('berlin', 'spec-no-ctx', loader, undefined)).toBe('uncached')
+        expect(await cachedReference('berlin', 'spec-no-ctx', loader, undefined)).toBe('uncached')
+
+        expect(loader).toHaveBeenCalledTimes(2)
+    })
+})

--- a/packages/telegram-worker/test/pipeline.test.ts
+++ b/packages/telegram-worker/test/pipeline.test.ts
@@ -70,6 +70,19 @@ describe('processMessage', () => {
         await processMessage('this is fine', testEnv)
     })
 
+    it('throws when the backend rejects the report, so the caller reports it', async () => {
+        interceptTransit()
+        interceptMistral('Rudow', null)
+        fetchMock
+            .get('https://backend.test')
+            .intercept({ path: '/v0/reports', method: 'POST' })
+            .reply(500, '{"error":"boom"}')
+
+        // A backend 5xx must reject (webhook routes it to reportError); swallowing it here
+        // would silently drop reports with no error-rate signal.
+        await expect(processMessage('U7 Rudow 2x BOS', testEnv)).rejects.toThrow()
+    })
+
     it('submits station-only with no lineId/directionId', async () => {
         interceptTransit()
         interceptMistral('Rudow', null)

--- a/packages/telegram-worker/test/webhook.test.ts
+++ b/packages/telegram-worker/test/webhook.test.ts
@@ -1,9 +1,13 @@
-import { env } from 'cloudflare:test'
+import { createExecutionContext, env, waitOnExecutionContext } from 'cloudflare:test'
 import { describe, expect, it, vi } from 'vitest'
 import { WEBHOOK_SECRET_HEADER, acceptUpdate, handleWebhook } from '../src/webhook'
 import { TelegramUpdate } from '../src/types'
 import type { Env } from '../src/types'
+import { reportError } from '../src/observability'
 import { ALLOWED_CHAT_ID } from './fixtures'
+
+// Spy seam for the privacy assertions below; the real implementation writes to Sentry.
+vi.mock('../src/observability', () => ({ reportError: vi.fn() }))
 
 function makeUpdate(opts: {
     text?: string
@@ -32,7 +36,7 @@ describe('acceptUpdate (filtering)', () => {
 
     it('accepts a photo caption', () => {
         expect(acceptUpdate(makeUpdate({ caption: 'U2 alex 2x BOS', hasPhoto: true }), ALLOWED_CHAT_ID)).toBe(
-            'U2 alex 2x BOS',
+            'U2 alex 2x BOS'
         )
     })
 
@@ -70,7 +74,12 @@ describe('handleWebhook', () => {
     it('rejects a wrong secret token with 401 and does not process', async () => {
         const process = vi.fn(async () => {})
         const { ctx, promises } = fakeCtx()
-        const res = await handleWebhook(webhookRequest(makeUpdate({ text: 'U2 alex' }), 'wrong'), env as unknown as Env, ctx, process)
+        const res = await handleWebhook(
+            webhookRequest(makeUpdate({ text: 'U2 alex' }), 'wrong'),
+            env as unknown as Env,
+            ctx,
+            process
+        )
         expect(res.status).toBe(401)
         expect(process).not.toHaveBeenCalled()
         expect(promises).toHaveLength(0)
@@ -79,7 +88,12 @@ describe('handleWebhook', () => {
     it('returns 200 and processes an accepted message in the background', async () => {
         const process = vi.fn(async () => {})
         const { ctx, promises } = fakeCtx()
-        const res = await handleWebhook(webhookRequest(makeUpdate({ text: 'U2 alex 2x BOS' })), env as unknown as Env, ctx, process)
+        const res = await handleWebhook(
+            webhookRequest(makeUpdate({ text: 'U2 alex 2x BOS' })),
+            env as unknown as Env,
+            ctx,
+            process
+        )
         expect(res.status).toBe(200)
         expect(process).toHaveBeenCalledExactlyOnceWith('U2 alex 2x BOS', expect.anything())
         expect(promises).toHaveLength(1)
@@ -93,11 +107,51 @@ describe('handleWebhook', () => {
             webhookRequest(makeUpdate({ text: 'U2 alex', chatId: -9999 })),
             env as unknown as Env,
             ctx,
-            process,
+            process
         )
         expect(res.status).toBe(200)
         expect(process).not.toHaveBeenCalled()
         expect(promises).toHaveLength(0)
+    })
+
+    it('runs the pipeline in the background of a real ExecutionContext', async () => {
+        const processed: string[] = []
+        const process = vi.fn(async (text: string) => void processed.push(text))
+        const ctx = createExecutionContext()
+
+        const res = await handleWebhook(
+            webhookRequest(makeUpdate({ text: 'U8 Hermannplatz' })),
+            env as unknown as Env,
+            ctx,
+            process
+        )
+        expect(res.status).toBe(200)
+
+        // waitOnExecutionContext resolves only after the waitUntil promise settles, proving
+        // the pipeline genuinely ran as background work of this request.
+        await waitOnExecutionContext(ctx)
+        expect(processed).toEqual(['U8 Hermannplatz'])
+    })
+
+    it('reports a background failure with only the message length, never the text', async () => {
+        vi.mocked(reportError).mockClear()
+        const text = 'U2 alex 2x BOS'
+        const process = vi.fn(async () => {
+            throw new Error('mistral timeout')
+        })
+        const ctx = createExecutionContext()
+
+        const res = await handleWebhook(webhookRequest(makeUpdate({ text })), env as unknown as Env, ctx, process)
+        // The failure stays in the background: Telegram still gets its 200 ack.
+        expect(res.status).toBe(200)
+        await waitOnExecutionContext(ctx)
+
+        expect(reportError).toHaveBeenCalledTimes(1)
+        const [, err, extra] = vi.mocked(reportError).mock.calls[0]!
+        expect((err as Error).message).toBe('mistral timeout')
+        // The privacy invariant: the extra payload carries the length and nothing else — the
+        // message text must never reach the (persisted) error report.
+        expect(extra).toEqual({ length: text.length })
     })
 
     it('acks malformed JSON with 200 and does not process', async () => {


### PR DESCRIPTION
Now that the api-worker suite runs on @cloudflare/vitest-pool-workers, cover
the runtime paths that were unreachable under bun test:

- edge-cache.test.ts: drive the real app with createExecutionContext /
  waitOnExecutionContext against a real caches.default — MISS then HIT,
  If-None-Match 304s (weak tags and *), origin-specific headers stripped
  from the stored entry with CORS re-derived per request, origin 304s not
  cached, purge (key delete) misses then repopulates, and stored entries
  carry the city Cache-Tag the production tag purge targets. A minimal app
  around the middlewares pins the 5xx/404/non-GET no-cache branches.
- reference-cache.test.ts: cachedReference loads once and serves from
  cache after, tags its entries for the same purge, keeps its internal
  key namespace apart from the HTTP edge keys, and skips the cache write
  without an ExecutionContext.
- postReport.test.ts: the telegram forward takes the waitUntil branch
  under a real ExecutionContext, and a failing forward still returns 200.
- telegram-worker webhook.test.ts: the pipeline runs as background work of
  a real ExecutionContext, and a thrown pipeline error reaches reportError
  with only the message length (privacy invariant), never the text.
- telegram-worker pipeline.test.ts: a backend 5xx on POST /v0/reports
  rejects so the webhook reports it instead of dropping silently.

Closes FRE-731

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NUzmb9f6o2h95tnbS9yTU2