### PR TITLE
test: cover threshold math, ETag lists, CORS rejection, and forwarding escaping (FRE-732)

### DIFF
--- a/packages/api-worker/src/common/normalize-transaction-name.ts
+++ b/packages/api-worker/src/common/normalize-transaction-name.ts
@@ -1,0 +1,6 @@
+// The @sentry/cloudflare HTTP instrumentation names transactions from the raw URL pathname.
+// Each station therefore turns GET /v0/reports/<stationId> into its own transaction (…/BAHU,
+// …/BOSB, …). Collapse that single trailing segment into the route pattern so Sentry tracks the
+// Per-station reads as one transaction, while leaving the list endpoint (GET /v0/reports) untouched.
+export const normalizeTransactionName = (name: string): string =>
+    name.replace(/^(\w+ \/v\d+\/reports)\/[^/]+$/, '$1/:stationId')

--- a/packages/api-worker/src/modules/reports/reports-service.ts
+++ b/packages/api-worker/src/modules/reports/reports-service.ts
@@ -63,6 +63,15 @@ const calculateWeekendAdjustment = (currentTime: DateTime, baseThreshold: number
     return truncatedBase * 0.5
 }
 
+// Returns the integer threshold that controls how many predicted/historic reports we should show.
+export const calculatePredictedReportsThreshold = (currentTime: DateTime): number => {
+    const base = calculateBasePredictedReportsThreshold(currentTime)
+    const adjustment = calculateWeekendAdjustment(currentTime, base)
+    const threshold = base - adjustment
+
+    return Math.trunc(clamp(threshold, MIN_PREDICTED_REPORTS_THRESHOLD, MAX_PREDICTED_REPORTS_THRESHOLD))
+}
+
 type TelegramNotificationPayload = {
     lineId: string | null
     stationId: StationId
@@ -128,7 +137,7 @@ export class ReportsService {
         const result = await this.getRealReports({ from, to, stationId })
 
         // Predict reports if we don't have enough, so that users always see at least some data
-        const predictedReportsThreshold = this.calculatePredictedReportsThreshold(currentTime)
+        const predictedReportsThreshold = calculatePredictedReportsThreshold(currentTime)
         if (result.length < predictedReportsThreshold) {
             const numberOfReportsToFetch = predictedReportsThreshold - result.length
             const reportedStationIds = new Set(result.map((r) => r.stationId as StationId))
@@ -165,15 +174,6 @@ export class ReportsService {
 
         const allStations = await this.transitNetworkDataService.getStations()
         return new Set((Object.keys(allStations) as StationId[]).filter((id) => !reportedStationIds.has(id)))
-    }
-
-    // Returns the integer threshold that controls how many predicted/historic reports we should show.
-    private calculatePredictedReportsThreshold(currentTime: DateTime): number {
-        const base = calculateBasePredictedReportsThreshold(currentTime)
-        const adjustment = calculateWeekendAdjustment(currentTime, base)
-        const threshold = base - adjustment
-
-        return Math.trunc(clamp(threshold, MIN_PREDICTED_REPORTS_THRESHOLD, MAX_PREDICTED_REPORTS_THRESHOLD))
     }
 
     // Recent reports used as the historic sample for prediction. Fetched separately

--- a/packages/api-worker/src/worker.ts
+++ b/packages/api-worker/src/worker.ts
@@ -2,6 +2,7 @@
 import { captureException, consoleLoggingIntegration, setTag, withSentry } from '@sentry/cloudflare'
 
 import { Bindings, setErrorReporter, setScopeTagger } from './app-env'
+import { normalizeTransactionName } from './common/normalize-transaction-name'
 
 import { app } from './index'
 
@@ -11,13 +12,6 @@ setErrorReporter((error, context) => captureException(error, context))
 
 // Same reason: let app-env tag the request scope (e.g. the resolved city) without importing the SDK.
 setScopeTagger((key, value) => setTag(key, value))
-
-// The @sentry/cloudflare HTTP instrumentation names transactions from the raw URL pathname.
-// Each station therefore turns GET /v0/reports/<stationId> into its own transaction (…/BAHU,
-// …/BOSB, …). Collapse that single trailing segment into the route pattern so Sentry tracks the
-// Per-station reads as one transaction, while leaving the list endpoint (GET /v0/reports) untouched.
-const normalizeTransactionName = (name: string): string =>
-    name.replace(/^(\w+ \/v\d+\/reports)\/[^/]+$/, '$1/:stationId')
 
 // Cloudflare Worker entry. The Hono app lives in index.ts so tests can run it without the Sentry SDK.
 export default withSentry(

--- a/packages/api-worker/tests/edge-cache.test.ts
+++ b/packages/api-worker/tests/edge-cache.test.ts
@@ -124,6 +124,12 @@ describe('transitEdgeCacheMiddleware (real Cache API)', () => {
         const star = await edgeRequest(url, { 'If-None-Match': '*' })
         expect(star.status).toBe(304)
 
+        // A comma list revalidates when any member matches, and misses when none do.
+        const listWithMatch = await edgeRequest(url, { 'If-None-Match': `"stale-one", W/${etag!}, "stale-two"` })
+        expect(listWithMatch.status).toBe(304)
+        const listWithoutMatch = await edgeRequest(url, { 'If-None-Match': '"stale-one", "stale-two"' })
+        expect(listWithoutMatch.status).toBe(200)
+
         // A stale tag (post-reseed ETag change) must get the full body again, not a 304.
         const stale = await edgeRequest(url, { 'If-None-Match': '"no-longer-current"' })
         expect(stale.status).toBe(200)

--- a/packages/api-worker/tests/generalAPI.test.ts
+++ b/packages/api-worker/tests/generalAPI.test.ts
@@ -97,6 +97,58 @@ describe('ETag 304 + CORS', () => {
     })
 })
 
+describe('CORS', () => {
+    const ALLOWED_ORIGIN = 'http://localhost:1871'
+    const DISALLOWED_ORIGIN = 'https://not-on-the-list.example'
+
+    it('does not echo a disallowed origin', async () => {
+        const response = await app.request(
+            '/v0/transit/stations',
+            { headers: { Origin: DISALLOWED_ORIGIN } },
+            testEnv()
+        )
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull()
+    })
+
+    it('grants a preflight from an allowed origin', async () => {
+        const response = await app.request(
+            '/v0/reports',
+            {
+                method: 'OPTIONS',
+                headers: {
+                    Origin: ALLOWED_ORIGIN,
+                    'Access-Control-Request-Method': 'POST',
+                    'Access-Control-Request-Headers': 'Content-Type',
+                },
+            },
+            testEnv()
+        )
+
+        expect(response.status).toBe(204)
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED_ORIGIN)
+        expect(response.headers.get('Access-Control-Allow-Methods')).toContain('POST')
+        expect(response.headers.get('Access-Control-Allow-Headers')).toContain('Content-Type')
+    })
+
+    it('does not grant a preflight from a disallowed origin', async () => {
+        const response = await app.request(
+            '/v0/reports',
+            {
+                method: 'OPTIONS',
+                headers: {
+                    Origin: DISALLOWED_ORIGIN,
+                    'Access-Control-Request-Method': 'POST',
+                },
+            },
+            testEnv()
+        )
+
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull()
+    })
+})
+
 describe('Transit cache headers', () => {
     it('sets Cache-Control and Vary on transit responses', async () => {
         const response = await app.request('/v0/transit/stations', undefined, testEnv())

--- a/packages/api-worker/tests/normalize-transaction-name.test.ts
+++ b/packages/api-worker/tests/normalize-transaction-name.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeTransactionName } from '../src/common/normalize-transaction-name'
+
+describe('normalizeTransactionName', () => {
+    it.each([
+        ['GET /v0/reports/BAHU', 'GET /v0/reports/:stationId'],
+        ['GET /v0/reports/U-hermannplatz', 'GET /v0/reports/:stationId'],
+        ['GET /v1/reports/BAHU', 'GET /v1/reports/:stationId'],
+    ])('collapses the station segment: %s → %s', (input, expected) => {
+        expect(normalizeTransactionName(input)).toBe(expected)
+    })
+
+    it.each([
+        ['the list route', 'GET /v0/reports'],
+        ['the list route with a trailing slash', 'GET /v0/reports/'],
+        ['POST to the list route', 'POST /v0/reports'],
+        ['other modules', 'GET /v0/transit/stations'],
+        ['nested paths below a station', 'GET /v0/reports/BAHU/extra'],
+        ['unversioned paths', 'GET /reports/BAHU'],
+    ])('leaves %s untouched', (_label, input) => {
+        expect(normalizeTransactionName(input)).toBe(input)
+    })
+})

--- a/packages/api-worker/tests/predicted-reports-threshold.test.ts
+++ b/packages/api-worker/tests/predicted-reports-threshold.test.ts
@@ -1,0 +1,55 @@
+import { DateTime } from 'luxon'
+import { describe, expect, it } from 'vitest'
+
+import { calculatePredictedReportsThreshold } from '../src/modules/reports/reports-service'
+
+// 2024-01-15 is a Monday, 2024-01-13 a Saturday, 2024-01-14 a Sunday.
+const monday = (hour: number, minute = 0) => DateTime.utc(2024, 1, 15, hour, minute)
+const saturday = (hour: number, minute = 0) => DateTime.utc(2024, 1, 13, hour, minute)
+const sunday = (hour: number, minute = 0) => DateTime.utc(2024, 1, 14, hour, minute)
+
+describe('calculatePredictedReportsThreshold', () => {
+    describe('weekday piecewise curve (boundaries)', () => {
+        it.each([
+            ['midnight', monday(0, 0), 1],
+            ['just before the morning ramp', monday(6, 59), 1],
+            ['start of the morning ramp (07:00)', monday(7, 0), 1],
+            ['middle of the morning ramp (08:00)', monday(8, 0), 4],
+            ['end of the morning ramp (08:59)', monday(8, 59), 6],
+            ['start of the daytime plateau (09:00)', monday(9, 0), 7],
+            ['daytime plateau (12:00)', monday(12, 0), 7],
+            ['just before the evening ramp (17:59)', monday(17, 59), 7],
+            ['start of the evening ramp (18:00)', monday(18, 0), 7],
+            ['middle of the evening ramp (19:30)', monday(19, 30), 4],
+            ['end of the evening ramp (20:59)', monday(20, 59), 1],
+            ['start of the night floor (21:00)', monday(21, 0), 1],
+            ['end of the day (23:59)', monday(23, 59), 1],
+        ])('returns %s → %i', (_label, time, expected) => {
+            expect(calculatePredictedReportsThreshold(time)).toBe(expected)
+        })
+    })
+
+    describe('Saturday: longer evening ramp (18:00–24:00) plus weekend adjustment', () => {
+        it.each([
+            ['night floor is clamped up to the minimum', saturday(2, 0), 1],
+            ['daytime plateau is halved by the weekend adjustment', saturday(12, 0), 3],
+            ['ramp start (18:00)', saturday(18, 0), 3],
+            // At 21:00 weekdays are already at the floor; the Saturday ramp is still descending.
+            ['still above the floor at 21:00', saturday(21, 0), 2],
+            ['ramp end stays clamped at the minimum (23:59)', saturday(23, 59), 1],
+        ])('%s → %i', (_label, time, expected) => {
+            expect(calculatePredictedReportsThreshold(time)).toBe(expected)
+        })
+    })
+
+    describe('Sunday: weekday-shaped curve with the weekend adjustment', () => {
+        it.each([
+            ['daytime plateau is halved', sunday(12, 0), 3],
+            // Sunday uses the short 18:00–21:00 ramp, not the Saturday one.
+            ['short evening ramp applies', sunday(19, 30), 2],
+            ['night floor is clamped up to the minimum', sunday(22, 0), 1],
+        ])('%s → %i', (_label, time, expected) => {
+            expect(calculatePredictedReportsThreshold(time)).toBe(expected)
+        })
+    })
+})

--- a/packages/telegram-worker/test/forwarding.test.ts
+++ b/packages/telegram-worker/test/forwarding.test.ts
@@ -96,6 +96,7 @@ describe('handleReportForward', () => {
 
     it.each([
         ['missing_station', { lineId: null, directionId: null }],
+        ['missing_direction_key', { lineId: null, stationId: 'x' }],
         ['empty_station_id', { lineId: null, stationId: '', directionId: null }],
         ['extra_key', { lineId: null, stationId: 'x', directionId: null, extra: 1 }],
         ['wrong_type_line', { lineId: 123, stationId: 'x', directionId: null }],
@@ -116,6 +117,39 @@ describe('handleReportForward', () => {
         expect(((await res.json()) as { error: string }).error).toBe('bad_request')
     })
 
+    it('returns 400 for an unknown lineId', async () => {
+        interceptTransit()
+        const res = await handleReportForward(
+            reportRequest({ lineId: 'NO_SUCH_LINE', stationId: picked.stationId, directionId: null }),
+            testEnv,
+        )
+        expect(res.status).toBe(400)
+        expect(((await res.json()) as { error: string }).error).toBe('bad_request')
+    })
+
+    it('returns 400 for an unknown directionId', async () => {
+        interceptTransit()
+        const res = await handleReportForward(
+            reportRequest({ lineId: picked.lineId, stationId: picked.stationId, directionId: 'DOES_NOT_EXIST' }),
+            testEnv,
+        )
+        expect(res.status).toBe(400)
+        expect(((await res.json()) as { error: string }).error).toBe('bad_request')
+    })
+
+    it('returns 400 when the line does not serve the direction', async () => {
+        interceptTransit()
+        // Both stations exist, but the direction sits on a different line than the reported one.
+        const line = index.variants.find((v) => v.id === picked.lineId)!
+        const foreignDirection = Object.keys(index.stations).find((id) => !line.stations.includes(id))
+        expect(foreignDirection).toBeDefined()
+        const res = await handleReportForward(
+            reportRequest({ lineId: picked.lineId, stationId: picked.stationId, directionId: foreignDirection }),
+            testEnv,
+        )
+        expect(res.status).toBe(400)
+    })
+
     it('returns 400 when the line does not serve the station', async () => {
         interceptTransit()
         const badLine = index.variants.find((v) => !v.stations.includes(picked.stationId))
@@ -125,6 +159,37 @@ describe('handleReportForward', () => {
             testEnv,
         )
         expect(res.status).toBe(400)
+    })
+
+    it('HTML-escapes station names so they cannot inject Telegram markup', async () => {
+        const rawStations = {
+            'U-evil': { name: `<script>alert('x') & "quotes"</script>`, lines: ['U1'] },
+            'U-end': { name: 'End > Start', lines: ['U1'] },
+        }
+        const rawLines = [{ id: 'U1-v', name: 'U1', isCircular: false, stations: ['U-evil', 'U-end'] }]
+        fetchMock
+            .get('https://backend.test')
+            .intercept({ path: '/v0/transit/stations', method: 'GET' })
+            .reply(200, JSON.stringify(rawStations), { headers: { 'content-type': 'application/json' } })
+        fetchMock
+            .get('https://backend.test')
+            .intercept({ path: '/v0/transit/lines', method: 'GET' })
+            .reply(200, JSON.stringify(rawLines), { headers: { 'content-type': 'application/json' } })
+        const capture: { body?: Record<string, unknown> } = {}
+        interceptTelegram(200, capture)
+
+        const res = await handleReportForward(
+            reportRequest({ stationId: 'U-evil', lineId: 'U1-v', directionId: 'U-end' }),
+            testEnv,
+        )
+
+        expect(res.status).toBe(200)
+        const text = capture.body!.text as string
+        // The message is sent with parse_mode HTML, so raw <, >, &, and quotes in
+        // station names would be interpreted as markup (or break parsing) by Telegram.
+        expect(text).toContain('&lt;script&gt;alert(&#x27;x&#x27;) &amp; &quot;quotes&quot;&lt;/script&gt;')
+        expect(text).not.toContain('<script>')
+        expect(text).toContain('End &gt; Start')
     })
 
     it('returns 502 when the Telegram send fails', async () => {


### PR DESCRIPTION
Fills the remaining test gaps from the worker-suite audit (spam.ts and the
threshold ramp integration tests already landed with the Vitest port):

- Export calculatePredictedReportsThreshold as a pure function and add
  table-driven boundary tests (07:00/09:00/18:00/21:00/midnight, the longer
  Saturday ramp, the weekend adjustment, and clamping at the floor).
- Extract normalizeTransactionName into its own module (worker.ts keeps the
  Sentry SDK out of the test bundle) and pin the station-segment collapsing
  against list routes, nested paths, and other modules.
- Cover comma-list If-None-Match revalidation at the edge cache (match among
  stale tags -> 304, no match -> 200).
- Add the CORS rejection path: disallowed origins get no ACAO, and OPTIONS
  preflight is exercised for both allowed and disallowed origins.
- Cover the remaining validateForwardedReport/validateTransitReferences
  paths (missing key, unknown lineId/directionId, direction not on the line)
  and assert Telegram-markup injection is HTML-escaped end to end.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y51Q4R6hRYXUWi2zg4u7aq