### PR TITLE
feat: track report rejections (too far / too soon) in analytics

### DIFF
--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -345,6 +345,7 @@ function SubmitFooter({ onSubmitted }: { onSubmitted: (result: SubmitReportRespo
     if (!stationId) return;
     const rejection = verify(stationId);
     if (rejection) {
+      track('report_rejected', { reason: rejection, stationId });
       toast.custom(
         () => (
           <ToastPill className="text-destructive flex w-fit items-center gap-2 text-sm font-semibold">

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -22,6 +22,10 @@ type AnalyticsEvents = {
     lineId: string | null;
     directionId: string | null;
   };
+  report_rejected: {
+    reason: 'too_soon' | 'too_far';
+    stationId: string;
+  };
   screenshot_taken: Record<string, never>;
   risk_layer_toggled: { to: SuperProperties['map_layer'] };
   contribute_modal_opened: { source: ContributeSource };


### PR DESCRIPTION
When the pre-submission verification blocks a report, capture a
report_rejected event with the rejection reason and station so we can
measure how often users are prevented from reporting.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019aJ4JCNTV9TLTEn2mBt5xN