### PR TITLE
feat: raise max report distance to 2 km

### DIFF
--- a/packages/frontend-next/src/components/report/useReportVerification.ts
+++ b/packages/frontend-next/src/components/report/useReportVerification.ts
@@ -4,7 +4,7 @@ import { distanceMeters } from '@/lib/geo';
 
 export type ReportRejection = 'too_soon' | 'too_far';
 
-const MAX_REPORT_DISTANCE_M = 1500;
+const MAX_REPORT_DISTANCE_M = 2000;
 const MIN_REPORT_INTERVAL_MS = 15 * 60 * 1000;
 const STORAGE_KEY = 'lastReportAt';
 


### PR DESCRIPTION
## Describe the issue:

Users have asked to be able to submit reports from further away. The report form's pre-submission verification currently rejects a report when the user is more than 1500 m from the selected station (`too_far`).

## Explain how you solved the issue:

Bumped `MAX_REPORT_DISTANCE_M` in `packages/frontend-next/src/components/report/useReportVerification.ts` from 1500 to 2000, so reports are allowed up to 2 km from the station.

## Additional notes or considerations:

The newly added `report_rejected` analytics event (tracked separately on `claude/report-rejection-tracking-0r7h1l`) will make it possible to measure how the `too_far` rejection rate changes after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aJ4JCNTV9TLTEn2mBt5xN

---
_Generated by [Claude Code](https://claude.ai/code/session_019aJ4JCNTV9TLTEn2mBt5xN)_