### PR TITLE
feat: cache the /transit/distance graph load through cachedReference

### DIFF
--- a/packages/api-worker/src/modules/transit/reference-cache.ts
+++ b/packages/api-worker/src/modules/transit/reference-cache.ts
@@ -17,7 +17,8 @@ export const referenceCacheKey = (citySlug: string, key: string): string => `${I
 export type CacheCtx = { waitUntil(promise: Promise<unknown>): void } | undefined
 
 /*
- * Read-through cache for static transit reference data (stations, lines, segments),
+ * Read-through cache for static transit reference data (stations, lines, segments,
+ * and the /distance graph inputs),
  * backed by the same Workers Cache API + `transit-network` Cache-Tag that
  * transitEdgeCacheMiddleware uses for the HTTP responses. Because the entry carries
  * that tag, the existing `db:purge-cache` tag purge invalidates it too — so a reseed

--- a/packages/api-worker/src/modules/transit/transit-network-data-service.ts
+++ b/packages/api-worker/src/modules/transit/transit-network-data-service.ts
@@ -8,6 +8,15 @@ import { buildGraph, findPathWithAStar, type Graph, type StationId } from './pat
 import { cachedReference, type CacheCtx } from './reference-cache'
 import type { Line, Lines, SegmentsFeatureCollection, Stations } from './types'
 
+// Raw table rows buildGraph consumes, cached as one JSON entry. All columns are
+// Plain strings/numbers/booleans, so the rows round-trip through the cache intact;
+// LineStations keeps its (lineId, order) ordering as a JSON array.
+type GraphInputs = {
+    stations: (typeof stations.$inferSelect)[]
+    lines: (typeof lines.$inferSelect)[]
+    lineStations: (typeof lineStations.$inferSelect)[]
+}
+
 export class TransitNetworkDataService {
     constructor(
         private db: DbConnection,
@@ -161,6 +170,13 @@ export class TransitNetworkDataService {
     }
 
     private async loadGraph(): Promise<Graph> {
+        // Cache the raw rows rather than the built Graph — Graph holds Maps, which
+        // Don't survive the JSON round-trip; rebuilding from rows is cheap in-process.
+        const inputs = await cachedReference(this.citySlug, 'graph-inputs', () => this.loadGraphInputs(), this.cacheCtx)
+        return buildGraph(inputs.stations, inputs.lines, inputs.lineStations)
+    }
+
+    private async loadGraphInputs(): Promise<GraphInputs> {
         // The three reads are independent, so issue them concurrently rather than as
         // Three back-to-back D1 round-trips (Sentry "consecutive DB queries").
         const [allStations, allLineStations, allLines] = await Promise.all([
@@ -169,6 +185,6 @@ export class TransitNetworkDataService {
             this.db.select().from(lines),
         ])
 
-        return buildGraph(allStations, allLines, allLineStations)
+        return { stations: allStations, lines: allLines, lineStations: allLineStations }
     }
 }

--- a/packages/api-worker/tests/graph-cache.test.ts
+++ b/packages/api-worker/tests/graph-cache.test.ts
@@ -1,0 +1,153 @@
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { asc, eq, inArray } from 'drizzle-orm'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import { app } from '../src/index'
+import { referenceCacheKey } from '../src/modules/transit/reference-cache'
+import { TRANSIT_CACHE_CONTROL, transitCacheTag } from '../src/modules/transit/transit-cache-middleware'
+import { db, lines, lineStations, stations } from './test-db'
+import { appRequestWithRedirect, testEnv } from './test-utils'
+
+type DistanceResponse = {
+    distance: number
+}
+
+type ErrorResponse = {
+    details: {
+        internal_code: string
+    }
+}
+
+// The Workers pool provides a real caches.default (the DOM CacheStorage type lacks it).
+const cache = (
+    caches as unknown as {
+        default: {
+            match(request: Request): Promise<Response | undefined>
+            put(request: Request, response: Response): Promise<void>
+            delete(request: Request): Promise<boolean>
+        }
+    }
+).default
+
+const graphKey = (): Request => new Request(referenceCacheKey('berlin', 'graph-inputs'))
+
+const TEST_STATION_IDS = ['GRAPH_A', 'GRAPH_B'] as const
+const TEST_LINE_ID = 'GRAPH_L1'
+
+// Two adjacent stations on one seeded line — the warm-up request that populates the cache.
+let fromStationId: string
+let toStationId: string
+
+// Real request through the whole app with a real ExecutionContext, so cachedReference's
+// waitUntil(cache.put) runs and is awaited before the test goes on.
+const distanceRequest = async (from: string, to: string) => {
+    const ctx = createExecutionContext()
+    const params = new URLSearchParams({ from, to })
+    const response = await app.request(
+        `https://api.test/v0/transit/distance?${params.toString()}`,
+        undefined,
+        testEnv(),
+        ctx
+    )
+    await waitOnExecutionContext(ctx)
+    return response
+}
+
+// Stations that exist in D1 but not in a previously warmed graph entry — the observable
+// that tells a cache hit (404, D1 not re-read) apart from a fresh load (200).
+const insertStationsUnknownToTheCachedGraph = async () => {
+    await db.insert(stations).values([
+        { id: 'GRAPH_A', name: 'Graph A', lat: 52.5, lng: 13.4 },
+        { id: 'GRAPH_B', name: 'Graph B', lat: 52.51, lng: 13.41 },
+    ])
+    await db.insert(lines).values({ id: TEST_LINE_ID, name: 'Graph Line 1', type: 'subway', isCircular: false })
+    await db.insert(lineStations).values([
+        { lineId: TEST_LINE_ID, stationId: 'GRAPH_A', order: 0 },
+        { lineId: TEST_LINE_ID, stationId: 'GRAPH_B', order: 1 },
+    ])
+}
+
+describe('GET /v0/transit/distance graph caching (real Cache API)', () => {
+    beforeAll(async () => {
+        const rows = await db
+            .select({
+                lineId: lineStations.lineId,
+                stationId: lineStations.stationId,
+            })
+            .from(lineStations)
+            .orderBy(asc(lineStations.lineId), asc(lineStations.order))
+
+        for (let i = 0; i < rows.length - 1; i++) {
+            if (rows[i].lineId === rows[i + 1].lineId) {
+                fromStationId = rows[i].stationId
+                toStationId = rows[i + 1].stationId
+                return
+            }
+        }
+
+        throw new Error('Expected seeded transit data to contain two consecutive stations on one line')
+    })
+
+    // Storage is shared across suites (isolatedStorage: false); drop the warmed graph entry
+    // and the fabricated topology so no other suite reads this file's state.
+    afterEach(async () => {
+        await cache.delete(graphKey())
+        await db.delete(lines).where(eq(lines.id, TEST_LINE_ID))
+        await db.delete(stations).where(inArray(stations.id, [...TEST_STATION_IDS]))
+    })
+
+    it('warms a graph-inputs entry with the city Cache-Tag while the response itself stays no-store', async () => {
+        const response = await distanceRequest(fromStationId, toStationId)
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Cache-Control')).toBe('no-store')
+
+        const entry = await cache.match(graphKey())
+        expect(entry).toBeDefined()
+        expect(entry!.headers.get('Cache-Tag')).toBe(transitCacheTag('berlin'))
+        expect(entry!.headers.get('Cache-Control')).toBe(TRANSIT_CACHE_CONTROL)
+    })
+
+    it('serves later requests from the cached graph without re-reading D1', async () => {
+        const warm = await distanceRequest(fromStationId, toStationId)
+        expect(warm.status).toBe(200)
+        const warmBody = (await warm.json()) as DistanceResponse
+
+        await insertStationsUnknownToTheCachedGraph()
+
+        // The new stations are in D1 but not in the cached graph: a 404 proves the graph
+        // was rebuilt from the cache entry, not from a fresh table scan.
+        const staleRead = await distanceRequest('GRAPH_A', 'GRAPH_B')
+        expect(staleRead.status).toBe(404)
+        const staleBody = (await staleRead.json()) as ErrorResponse
+        expect(staleBody.details.internal_code).toBe('STATION_NOT_FOUND')
+
+        // And the cached JSON round-trips into a working graph for the seeded stations.
+        const cachedHit = await distanceRequest(fromStationId, toStationId)
+        expect(cachedHit.status).toBe(200)
+        expect(((await cachedHit.json()) as DistanceResponse).distance).toBe(warmBody.distance)
+    })
+
+    it('reads fresh data from D1 after a purge and re-warms the entry', async () => {
+        await distanceRequest(fromStationId, toStationId)
+        await insertStationsUnknownToTheCachedGraph()
+
+        // Local analogue of the production reseed tag purge (the Cloudflare API call itself
+        // is covered in city-cache.test.ts): drop the entry, the next request must miss.
+        expect(await cache.delete(graphKey())).toBe(true)
+
+        const afterPurge = await distanceRequest('GRAPH_A', 'GRAPH_B')
+        expect(afterPurge.status).toBe(200)
+        expect(((await afterPurge.json()) as DistanceResponse).distance).toBe(1)
+
+        expect(await cache.match(graphKey())).toBeDefined()
+    })
+
+    it('skips the cache write without an ExecutionContext, matching the Bun/seed-CLI fallback', async () => {
+        const params = new URLSearchParams({ from: fromStationId, to: toStationId })
+        const response = await appRequestWithRedirect(`/transit/distance?${params.toString()}`)
+
+        expect(response.status).toBe(200)
+        expect(await cache.match(graphKey())).toBeUndefined()
+    })
+})

--- a/packages/api-worker/tests/graph-cache.test.ts
+++ b/packages/api-worker/tests/graph-cache.test.ts
@@ -1,11 +1,11 @@
 import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
-import { asc, eq, inArray } from 'drizzle-orm'
+import { asc } from 'drizzle-orm'
 import { afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import { app } from '../src/index'
 import { referenceCacheKey } from '../src/modules/transit/reference-cache'
 import { TRANSIT_CACHE_CONTROL, transitCacheTag } from '../src/modules/transit/transit-cache-middleware'
-import { db, lines, lineStations, stations } from './test-db'
+import { db, lineStations } from './test-db'
 import { appRequestWithRedirect, testEnv } from './test-utils'
 
 type DistanceResponse = {
@@ -31,9 +31,6 @@ const cache = (
 
 const graphKey = (): Request => new Request(referenceCacheKey('berlin', 'graph-inputs'))
 
-const TEST_STATION_IDS = ['GRAPH_A', 'GRAPH_B'] as const
-const TEST_LINE_ID = 'GRAPH_L1'
-
 // Two adjacent stations on one seeded line — the warm-up request that populates the cache.
 let fromStationId: string
 let toStationId: string
@@ -53,18 +50,32 @@ const distanceRequest = async (from: string, to: string) => {
     return response
 }
 
-// Stations that exist in D1 but not in a previously warmed graph entry — the observable
-// that tells a cache hit (404, D1 not re-read) apart from a fresh load (200).
-const insertStationsUnknownToTheCachedGraph = async () => {
-    await db.insert(stations).values([
-        { id: 'GRAPH_A', name: 'Graph A', lat: 52.5, lng: 13.4 },
-        { id: 'GRAPH_B', name: 'Graph B', lat: 52.51, lng: 13.41 },
-    ])
-    await db.insert(lines).values({ id: TEST_LINE_ID, name: 'Graph Line 1', type: 'subway', isCircular: false })
-    await db.insert(lineStations).values([
-        { lineId: TEST_LINE_ID, stationId: 'GRAPH_A', order: 0 },
-        { lineId: TEST_LINE_ID, stationId: 'GRAPH_B', order: 1 },
-    ])
+// A fabricated graph-inputs entry whose stations exist nowhere in D1, written through the
+// same Cache API the service reads. Answering a distance between them is only possible
+// from this entry, which makes cache hits observable without any manual DB writes; the
+// body mirrors the GraphInputs row shape the service stores.
+const putSyntheticGraphEntry = async () => {
+    const inputs = {
+        stations: [
+            { id: 'FAKE_A', name: 'Fake A', lat: 52.5, lng: 13.4 },
+            { id: 'FAKE_B', name: 'Fake B', lat: 52.51, lng: 13.41 },
+        ],
+        lines: [{ id: 'FAKE_L1', name: 'Fake Line 1', type: 'subway', isCircular: false, color: '#000000' }],
+        lineStations: [
+            { lineId: 'FAKE_L1', stationId: 'FAKE_A', order: 0 },
+            { lineId: 'FAKE_L1', stationId: 'FAKE_B', order: 1 },
+        ],
+    }
+    await cache.put(
+        graphKey(),
+        new Response(JSON.stringify(inputs), {
+            headers: {
+                'Content-Type': 'application/json',
+                'Cache-Control': TRANSIT_CACHE_CONTROL,
+                'Cache-Tag': transitCacheTag('berlin'),
+            },
+        })
+    )
 }
 
 describe('GET /v0/transit/distance graph caching (real Cache API)', () => {
@@ -89,11 +100,9 @@ describe('GET /v0/transit/distance graph caching (real Cache API)', () => {
     })
 
     // Storage is shared across suites (isolatedStorage: false); drop the warmed graph entry
-    // and the fabricated topology so no other suite reads this file's state.
+    // so no other suite reads this file's cache state.
     afterEach(async () => {
         await cache.delete(graphKey())
-        await db.delete(lines).where(eq(lines.id, TEST_LINE_ID))
-        await db.delete(stations).where(inArray(stations.id, [...TEST_STATION_IDS]))
     })
 
     it('warms a graph-inputs entry with the city Cache-Tag while the response itself stays no-store', async () => {
@@ -108,39 +117,39 @@ describe('GET /v0/transit/distance graph caching (real Cache API)', () => {
         expect(entry!.headers.get('Cache-Control')).toBe(TRANSIT_CACHE_CONTROL)
     })
 
-    it('serves later requests from the cached graph without re-reading D1', async () => {
-        const warm = await distanceRequest(fromStationId, toStationId)
-        expect(warm.status).toBe(200)
-        const warmBody = (await warm.json()) as DistanceResponse
+    it('serves requests from the cached graph without re-reading D1', async () => {
+        await putSyntheticGraphEntry()
 
-        await insertStationsUnknownToTheCachedGraph()
-
-        // The new stations are in D1 but not in the cached graph: a 404 proves the graph
-        // was rebuilt from the cache entry, not from a fresh table scan.
-        const staleRead = await distanceRequest('GRAPH_A', 'GRAPH_B')
-        expect(staleRead.status).toBe(404)
-        const staleBody = (await staleRead.json()) as ErrorResponse
-        expect(staleBody.details.internal_code).toBe('STATION_NOT_FOUND')
-
-        // And the cached JSON round-trips into a working graph for the seeded stations.
-        const cachedHit = await distanceRequest(fromStationId, toStationId)
+        // The fabricated stations exist only in the cache entry: a 200 proves the graph
+        // was rebuilt from the cached JSON, not from a fresh D1 table scan.
+        const cachedHit = await distanceRequest('FAKE_A', 'FAKE_B')
         expect(cachedHit.status).toBe(200)
-        expect(((await cachedHit.json()) as DistanceResponse).distance).toBe(warmBody.distance)
+        expect(((await cachedHit.json()) as DistanceResponse).distance).toBe(1)
+
+        // And the seeded stations, present in D1 but absent from the cached graph, are
+        // not found — D1 was never consulted.
+        const seededMiss = await distanceRequest(fromStationId, toStationId)
+        expect(seededMiss.status).toBe(404)
+        expect(((await seededMiss.json()) as ErrorResponse).details.internal_code).toBe('STATION_NOT_FOUND')
     })
 
     it('reads fresh data from D1 after a purge and re-warms the entry', async () => {
-        await distanceRequest(fromStationId, toStationId)
-        await insertStationsUnknownToTheCachedGraph()
+        await putSyntheticGraphEntry()
+        expect((await distanceRequest('FAKE_A', 'FAKE_B')).status).toBe(200)
 
         // Local analogue of the production reseed tag purge (the Cloudflare API call itself
         // is covered in city-cache.test.ts): drop the entry, the next request must miss.
         expect(await cache.delete(graphKey())).toBe(true)
 
-        const afterPurge = await distanceRequest('GRAPH_A', 'GRAPH_B')
-        expect(afterPurge.status).toBe(200)
-        expect(((await afterPurge.json()) as DistanceResponse).distance).toBe(1)
+        const afterPurge = await distanceRequest('FAKE_A', 'FAKE_B')
+        expect(afterPurge.status).toBe(404)
+        expect(((await afterPurge.json()) as ErrorResponse).details.internal_code).toBe('STATION_NOT_FOUND')
 
+        // The miss re-read D1 and re-warmed the entry with the real seeded topology.
         expect(await cache.match(graphKey())).toBeDefined()
+        const seededHit = await distanceRequest(fromStationId, toStationId)
+        expect(seededHit.status).toBe(200)
+        expect(((await seededHit.json()) as DistanceResponse).distance).toBe(1)
     })
 
     it('skips the cache write without an ExecutionContext, matching the Bun/seed-CLI fallback', async () => {


### PR DESCRIPTION
GET /v0/transit/distance was the only transit path scanning the full
stations, line_stations, and lines tables in D1 on every request. Wrap
loadGraph's three table reads in cachedReference under a city-scoped
graph-inputs key, so D1 is only read on a per-colo cache miss or after
the reseed tag purge — the entry carries the same transit-network-<city>
Cache-Tag the existing db:purge-cache flow invalidates.

The raw rows are cached (not the built Graph, whose Maps don't survive
JSON) with line_stations kept in (lineId, order) order; buildGraph runs
in-process per request. The HTTP response stays no-store. Under Bun
tests and the Node seed CLI the Cache API is absent and cachedReference
falls through to the loader, unchanged.

Closes FRE-742

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B7bYZmCkWzdJEzPoF9FeZq