### PR TITLE
feat: progressively disclose secondary transit lines by zoom

### DIFF
--- a/packages/frontend-next/src/api/transit.ts
+++ b/packages/frontend-next/src/api/transit.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import type { Feature, FeatureCollection, LineString, Point } from 'geojson';
+import type { Feature, FeatureCollection, LineString } from 'geojson';
 
 import { currentCitySlug } from '@/lib/city';
 import { distanceMeters } from '@/lib/geo';
@@ -57,22 +57,6 @@ export type SegmentProperties = {
 
 export type Segment = Feature<LineString, SegmentProperties>;
 export type Segments = FeatureCollection<LineString, SegmentProperties>;
-
-export type StationPointProps = { id: string; name: string };
-
-export function stationsToGeoJSON(stations: Stations): FeatureCollection<Point, StationPointProps> {
-  return {
-    type: 'FeatureCollection',
-    features: Object.values(stations).map((station) => ({
-      type: 'Feature',
-      geometry: {
-        type: 'Point',
-        coordinates: [station.coordinates.longitude, station.coordinates.latitude],
-      },
-      properties: { id: station.id, name: station.name },
-    })),
-  };
-}
 
 export function resolveStationLineNames(
   lineIds: Station['lines'],

--- a/packages/frontend-next/src/components/map/LineLayer.tsx
+++ b/packages/frontend-next/src/components/map/LineLayer.tsx
@@ -1,11 +1,10 @@
 import { Layer, Source } from 'react-map-gl/maplibre';
 
-import { useSegments } from '@/api/transit';
-
 import { STATIONS_BASE_LAYER_ID } from './StationsLayer';
+import { LINE_OPACITY, LINE_WIDTH, useTypedSegments } from './line-style';
 
 export function LineLayer() {
-  const { data: segments } = useSegments();
+  const segments = useTypedSegments();
 
   if (!segments) return null;
 
@@ -15,9 +14,11 @@ export function LineLayer() {
         id="segments-line"
         type="line"
         beforeId={STATIONS_BASE_LAYER_ID}
+        layout={{ 'line-join': 'round', 'line-cap': 'round' }}
         paint={{
           'line-color': ['get', 'color'],
-          'line-width': 3,
+          'line-width': LINE_WIDTH,
+          'line-opacity': LINE_OPACITY,
         }}
       />
     </Source>

--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -3,8 +3,8 @@ import './Map.css';
 
 import maplibregl, { type StyleSpecification } from 'maplibre-gl';
 import { Protocol } from 'pmtiles';
-import { useEffect, useState } from 'react';
-import { Map as MapGL } from 'react-map-gl/maplibre';
+import { useEffect, useRef, useState } from 'react';
+import { Map as MapGL, type ViewStateChangeEvent } from 'react-map-gl/maplibre';
 
 // Register the `pmtiles://` protocol so MapLibre can range-read the static PMTiles basemap archive
 // directly from R2 (see packages/tile-server). This runs once when the lazy map chunk loads, before
@@ -15,9 +15,11 @@ maplibregl.addProtocol('pmtiles', pmtilesProtocol.tile);
 
 import { useRisk } from '@/api/risk';
 import { useSegments } from '@/api/transit';
+import { track } from '@/lib/analytics';
 import { currentCity } from '@/lib/city';
 
 import { LineLayer } from './LineLayer';
+import { SECONDARY_REVEAL_ZOOM } from './line-style';
 import { MapCameraController } from './MapCameraController';
 import { ReportsLayer } from './ReportsLayer';
 import { RiskLayer } from './RiskLayer';
@@ -50,6 +52,16 @@ export function MapView() {
   const { selectedStation, handleMapClick } = useStationSelection();
   const { visible: riskVisible } = useRiskLayer();
   const [baseMapReady, setBaseMapReady] = useState(false);
+
+  // Fire once per session the first time the user zooms in far enough to reveal the secondary
+  // (tram/bus) tier. The map is persistent, so this ref spans the whole session; sessions that
+  // never fire it never surfaced those lines (see the discoverability analysis).
+  const secondaryRevealedRef = useRef(false);
+  const trackSecondaryReveal = (e: ViewStateChangeEvent) => {
+    if (secondaryRevealedRef.current || e.viewState.zoom < SECONDARY_REVEAL_ZOOM) return;
+    secondaryRevealedRef.current = true;
+    track('secondary_lines_revealed', { zoom: Math.round(e.viewState.zoom * 10) / 10 });
+  };
 
   // On web the style is just the URL (MapLibre fetches it, and the SW + immutable HTTP cache handle
   // offline). The Capacitor build has no service worker, so it resolves the style + a locally-cached
@@ -97,6 +109,7 @@ export function MapView() {
         attributionControl={{ compact: true }}
         interactiveLayerIds={[REPORTS_HIT_LAYER_ID, STATIONS_LAYER_ID]}
         onClick={handleMapClick}
+        onZoomEnd={trackSecondaryReveal}
         // Let the base map render its first frame before we add the GeoJSON sources and the
         // report markers, so that overlay setup doesn't compete with the heaviest part of map
         // init. The map is persistent, so this fires once per session.

--- a/packages/frontend-next/src/components/map/RiskLayer.tsx
+++ b/packages/frontend-next/src/components/map/RiskLayer.tsx
@@ -4,7 +4,12 @@ import { Layer, Source } from 'react-map-gl/maplibre';
 import { useRisk } from '@/api/risk';
 
 import { STATIONS_BASE_LAYER_ID } from './StationsLayer';
-import { LINE_OPACITY, LINE_WIDTH, type TypedSegmentProperties, useTypedSegments } from './line-style';
+import {
+  LINE_OPACITY,
+  LINE_WIDTH,
+  type TypedSegmentProperties,
+  useTypedSegments,
+} from './line-style';
 
 // Neutral green for segments without elevated risk. The backend
 // only returns risky (non-green) segments, so everything else falls back to this.

--- a/packages/frontend-next/src/components/map/RiskLayer.tsx
+++ b/packages/frontend-next/src/components/map/RiskLayer.tsx
@@ -2,18 +2,18 @@ import type { FeatureCollection, LineString } from 'geojson';
 import { Layer, Source } from 'react-map-gl/maplibre';
 
 import { useRisk } from '@/api/risk';
-import { type SegmentProperties, useSegments } from '@/api/transit';
 
 import { STATIONS_BASE_LAYER_ID } from './StationsLayer';
+import { LINE_OPACITY, LINE_WIDTH, type TypedSegmentProperties, useTypedSegments } from './line-style';
 
 // Neutral green for segments without elevated risk. The backend
 // only returns risky (non-green) segments, so everything else falls back to this.
 const NEUTRAL_GREEN = '#13C184';
 
-type RiskSegmentProperties = SegmentProperties & { line_color: string };
+type RiskSegmentProperties = TypedSegmentProperties & { line_color: string };
 
 export function RiskLayer() {
-  const { data: segments } = useSegments();
+  const segments = useTypedSegments();
   const { data: risk } = useRisk();
 
   if (!segments) return null;
@@ -39,7 +39,8 @@ export function RiskLayer() {
         layout={{ 'line-join': 'round', 'line-cap': 'round' }}
         paint={{
           'line-color': ['get', 'line_color'],
-          'line-width': 3,
+          'line-width': LINE_WIDTH,
+          'line-opacity': LINE_OPACITY,
         }}
       />
     </Source>

--- a/packages/frontend-next/src/components/map/StationsLayer.tsx
+++ b/packages/frontend-next/src/components/map/StationsLayer.tsx
@@ -1,6 +1,9 @@
+import type { ExpressionSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { Layer, Source } from 'react-map-gl/maplibre';
 
-import { type Station, stationsToGeoJSON, useStations } from '@/api/transit';
+import { type Station } from '@/api/transit';
+
+import { stationHitRadius, stationOpacity, useTrunkStationsGeoJSON } from './line-style';
 
 // Bottom-most (visible) station layer. Line layers insert `beforeId` this so they always render
 // beneath the station dots, regardless of mount order when toggling between line/risk layers.
@@ -12,27 +15,33 @@ type StationsLayerProps = {
 };
 
 export function StationsLayer({ selectedStation }: StationsLayerProps) {
-  const { data: stations } = useStations();
+  const stations = useTrunkStationsGeoJSON();
 
   if (!stations) return null;
 
+  const selectedId = selectedStation?.id ?? '';
+  const isSelected: ExpressionSpecification = ['==', ['get', 'id'], selectedId];
+  const opacity = stationOpacity(selectedId);
+
   return (
-    <Source id="stations" type="geojson" data={stationsToGeoJSON(stations)}>
+    <Source id="stations" type="geojson" data={stations}>
       <Layer
         id={STATIONS_BASE_LAYER_ID}
         type="circle"
         paint={{
-          'circle-radius': ['case', ['==', ['get', 'id'], selectedStation?.id ?? ''], 5, 2],
+          'circle-radius': ['case', isSelected, 5, 2],
           'circle-color': '#ffffff',
           'circle-stroke-color': '#000000',
           'circle-stroke-width': 1,
+          'circle-opacity': opacity,
+          'circle-stroke-opacity': opacity,
         }}
       />
       <Layer
         id={STATIONS_LAYER_ID}
         type="circle"
         paint={{
-          'circle-radius': 12,
+          'circle-radius': stationHitRadius(selectedId),
           'circle-color': '#000000',
           'circle-opacity': 0,
         }}

--- a/packages/frontend-next/src/components/map/line-style.ts
+++ b/packages/frontend-next/src/components/map/line-style.ts
@@ -112,7 +112,8 @@ export function useTrunkStationsGeoJSON(): FeatureCollection<Point, StationPoint
   if (!stations) return undefined;
 
   const trunkLineIds = new Set<string>();
-  if (lines) for (const line of lines) if (!secondaryTypes.has(line.type)) trunkLineIds.add(line.id);
+  if (lines)
+    for (const line of lines) if (!secondaryTypes.has(line.type)) trunkLineIds.add(line.id);
   const linesLoaded = Boolean(lines);
 
   return {

--- a/packages/frontend-next/src/components/map/line-style.ts
+++ b/packages/frontend-next/src/components/map/line-style.ts
@@ -1,0 +1,213 @@
+import type {
+  DataDrivenPropertyValueSpecification,
+  ExpressionSpecification,
+} from '@maplibre/maplibre-gl-style-spec';
+import type { FeatureCollection, LineString, Point } from 'geojson';
+
+import { HOUR_MS, useReports } from '@/api/reports';
+import {
+  LINE_TYPE_PRIORITY,
+  type SegmentProperties,
+  useLines,
+  useSegments,
+  useStations,
+} from '@/api/transit';
+import { currentCity } from '@/lib/city';
+
+// A dense multi-modal network is unreadable if every line draws at full width/opacity at every
+// zoom. Rapid transit (the "trunk") stays visible; street-level surface modes (tram, bus, …) form a
+// "secondary" tier drawn faintly at the metro-area overview (a "we cover this" hint) and revealed
+// at full strength on a small zoom-in. The split is derived per city from LINE_TYPE_PRIORITY (see
+// useSecondaryTypes), so it adapts to whichever modes a city has.
+
+// Where rapid transit ends and surface modes begin. Anchored to tram so a lower-ranked mode (bus)
+// joins the surface tier automatically.
+const SURFACE_MIN_PRIORITY = LINE_TYPE_PRIORITY.tram;
+
+// Per-segment tier flags read by the paint expressions below. `reported` (an active report on the
+// line) forces it visible and heavier so a report marker never floats over a hidden line.
+export type TypedSegmentProperties = SegmentProperties & {
+  secondary: boolean;
+  reported: boolean;
+};
+export type TypedSegments = FeatureCollection<LineString, TypedSegmentProperties>;
+
+/**
+ * The surface-mode types to hide at overview zoom for the current city. With rapid transit present,
+ * every surface mode is secondary; an all-surface city (e.g. tram+bus) keeps its top mode as trunk.
+ * Single-mode cities and types absent from the priority map hide nothing.
+ */
+function useSecondaryTypes(): Set<string> {
+  const { data: lines } = useLines();
+  const secondary = new Set<string>();
+  if (!lines) return secondary;
+
+  const priorities = LINE_TYPE_PRIORITY as Record<string, number | undefined>;
+  const priorityByType = new Map<string, number>();
+  for (const line of lines) {
+    const priority = priorities[line.type];
+    if (priority !== undefined) priorityByType.set(line.type, priority);
+  }
+  if (priorityByType.size < 2) return secondary;
+
+  const surface = [...priorityByType].filter(([, priority]) => priority >= SURFACE_MIN_PRIORITY);
+  const hasRapidTransit = [...priorityByType.values()].some((p) => p < SURFACE_MIN_PRIORITY);
+  // -Infinity ⇒ all surface modes hide; else the top surface mode stays trunk.
+  const trunkAnchor = hasRapidTransit ? -Infinity : Math.min(...surface.map(([, p]) => p));
+  for (const [type, priority] of surface) {
+    if (priority > trunkAnchor) secondary.add(type);
+  }
+  return secondary;
+}
+
+/** Line and station ids with an active report, from the same last-hour window as the markers. */
+function useReportedIds(): { lines: Set<string>; stations: Set<string> } {
+  const { data: reports } = useReports(HOUR_MS);
+  const lines = new Set<string>();
+  const stations = new Set<string>();
+  if (reports)
+    for (const report of reports) {
+      stations.add(report.stationId);
+      if (report.lineId) lines.add(report.lineId);
+    }
+  return { lines, stations };
+}
+
+/** Segments tagged with their tier flags for the line layers; `undefined` until segments load. */
+export function useTypedSegments(): TypedSegments | undefined {
+  const { data: segments } = useSegments();
+  const { data: lines } = useLines();
+  const secondaryTypes = useSecondaryTypes();
+  const reported = useReportedIds();
+
+  if (!segments) return undefined;
+
+  const typeById = new Map<string, string>();
+  if (lines) for (const line of lines) typeById.set(line.id, line.type);
+
+  return {
+    ...segments,
+    features: segments.features.map((feature) => ({
+      ...feature,
+      properties: {
+        ...feature.properties,
+        secondary: secondaryTypes.has(typeById.get(feature.properties.line) ?? ''),
+        reported: reported.lines.has(feature.properties.line),
+      },
+    })),
+  };
+}
+
+// Per-station flags for the fade: `trunk` = serves a non-secondary line; `reported` = has a report.
+// Either keeps the dot, and its tap target, visible.
+export type StationPointProps = { id: string; name: string; trunk: boolean; reported: boolean };
+
+/** Station points tagged for the fade; `undefined` until stations load. */
+export function useTrunkStationsGeoJSON(): FeatureCollection<Point, StationPointProps> | undefined {
+  const { data: stations } = useStations();
+  const { data: lines } = useLines();
+  const secondaryTypes = useSecondaryTypes();
+  const reported = useReportedIds();
+
+  if (!stations) return undefined;
+
+  const trunkLineIds = new Set<string>();
+  if (lines) for (const line of lines) if (!secondaryTypes.has(line.type)) trunkLineIds.add(line.id);
+  const linesLoaded = Boolean(lines);
+
+  return {
+    type: 'FeatureCollection',
+    features: Object.values(stations).map((station) => ({
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [station.coordinates.longitude, station.coordinates.latitude],
+      },
+      properties: {
+        id: station.id,
+        name: station.name,
+        trunk: linesLoaded ? station.lines.some((id) => trunkLineIds.has(id)) : true,
+        reported: reported.stations.has(station.id),
+      },
+    })),
+  };
+}
+
+// The secondary tier is drawn faintly (SECONDARY_MIN_OPACITY) from the city's overview zoom and
+// ramps to full strength one-and-a-half levels in, so a small zoom-in surfaces trams/buses — the
+// discoverability lever. Anchored to the initial zoom so the faint hint shows on first paint in any
+// city. Stations reveal on the same ramp (but from hidden, since faint dots would just clutter).
+const SECONDARY_FADE_START = currentCity.map.zoom;
+const SECONDARY_FADE_END = SECONDARY_FADE_START + 1.5;
+
+// Faint overview opacity for the secondary tier — enough to hint coverage, not enough to compete
+// with the trunk network. A teaser that invites zooming; full legibility is at _END. Tune here.
+const SECONDARY_MIN_OPACITY = 0.2;
+
+// Zoom at which the secondary tier is fully shown — the point a user has "discovered" it. Exported
+// so discovery analytics track the same threshold the rendering uses.
+export const SECONDARY_REVEAL_ZOOM = SECONDARY_FADE_END;
+
+// `zoom` must be the top-level input to `interpolate`, so the trunk/selected/reported override
+// lives in the per-stop value rather than wrapping the interpolate in a `case`.
+export function stationOpacity(selectedId: string): ExpressionSpecification {
+  return [
+    'interpolate',
+    ['linear'],
+    ['zoom'],
+    SECONDARY_FADE_START,
+    [
+      'case',
+      ['==', ['get', 'id'], selectedId],
+      1,
+      ['any', ['get', 'trunk'], ['get', 'reported']],
+      1,
+      0,
+    ],
+    SECONDARY_FADE_END,
+    1,
+  ];
+}
+
+// Tap target tracks the fade, so a tap on the empty overview never selects an invisible station.
+export function stationHitRadius(selectedId: string): ExpressionSpecification {
+  return [
+    'interpolate',
+    ['linear'],
+    ['zoom'],
+    SECONDARY_FADE_START,
+    [
+      'case',
+      ['==', ['get', 'id'], selectedId],
+      12,
+      ['any', ['get', 'trunk'], ['get', 'reported']],
+      12,
+      0,
+    ],
+    SECONDARY_FADE_END,
+    12,
+  ];
+}
+
+export const LINE_OPACITY: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['linear'],
+  ['zoom'],
+  SECONDARY_FADE_START,
+  ['case', ['get', 'reported'], 1, ['case', ['get', 'secondary'], SECONDARY_MIN_OPACITY, 1]],
+  SECONDARY_FADE_END,
+  ['case', ['get', 'reported'], 1, ['case', ['get', 'secondary'], 0.85, 1]],
+];
+
+// Trunk (and reported) lines draw heavier than secondary lines, and everything thickens with zoom.
+export const LINE_WIDTH: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['linear'],
+  ['zoom'],
+  10,
+  ['case', ['any', ['get', 'reported'], ['!', ['get', 'secondary']]], 1.4, 0.6],
+  13,
+  ['case', ['any', ['get', 'reported'], ['!', ['get', 'secondary']]], 2.8, 1.4],
+  16,
+  ['case', ['any', ['get', 'reported'], ['!', ['get', 'secondary']]], 5, 3],
+];

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -39,6 +39,10 @@ type AnalyticsEvents = {
     trigger: LocationRequestTrigger;
     reason: 'denied' | 'unavailable' | 'timeout';
   };
+  // Fires once per session the first time the map is zoomed in far enough to reveal the secondary
+  // (tram/bus) tier. Sessions that never fire it never discovered those lines exist — the
+  // denominator being map pageviews. `zoom` is where the reveal happened.
+  secondary_lines_revealed: { zoom: number };
   station_selected: { source: 'map' | 'search' };
   report_marker_selected: { report_age_minutes: number };
   reports_overview_opened: { report_count: number };


### PR DESCRIPTION
## What this does

Introduces a zoom-based **level-of-detail (progressive disclosure)** for the map's transit lines:

- **Rapid transit (U-Bahn / S-Bahn) is the always-visible "trunk"** network.
- **Street-level modes (tram, and later bus) are a "secondary" tier** — drawn *faintly* at the metro-area overview (a "we cover this" hint) and revealed at full, accessible strength on a small zoom-in.
- A line — and its station — with an **active report** is force-shown at any zoom, so a report marker never floats over a hidden line.
- A once-per-session **`secondary_lines_revealed`** analytics event lets us measure whether users ever discover the secondary tier.

All of the tier logic lives in one new file, `components/map/line-style.ts`, shared by the line view, the risk view, and the stations layer.

## Why — the problem

As we expand the network (and to other cities), the map gets overloaded: Berlin alone has 9 U-Bahn + 17 S-Bahn + **29 same-coloured tram lines**. At the city-overview zoom, the tram web buries the rapid-transit network in an unreadable tangle. The goal was to declutter the overview **without** making tram/bus coverage undiscoverable.

## Evidence behind the decision

**Analytics (PostHog + the reports D1 database):**

- **Half the network is "secondary":** 329 of 639 Berlin stations (51%) are tram-only.
- **There is real, recurring interest in those stations:** ~14.6% of deliberate station lookups (`/station/:id`) are for tram-only stations — ~1,140 distinct users/month.
- **Discovery is visual, not search-driven:** 86% of station selections come from tapping the map vs. 14% from search. So "you can always search for it" does **not** rescue discoverability — most users explore by looking.
- **The interest is NOT report-driven** (this was the key check). Correlating tram-station views against the full report history: only ~10% (same-station) to ~23% (any serving line) of tram-station views coincide with an active report, and a 24h-shifted placebo already explains ~12 of those points by chance. Net: **~90% of tram-station interest is exploratory, not triggered by a live report.** → The report force-reveal is worth keeping, but it only addresses a minority of the discoverability gap.

**UX research (NN/g, transit-map cartography, Google/Apple/Transit apps):** zoom-based LOD is the accepted, mainstream pattern for dense maps (Google Maps hides tram/bus stops until you zoom in; Transit app does zoom-contextual rendering). The recognised risk is exactly the discoverability one — hidden content needs a *visible cue that it exists* (NN/g: "Recognition rather than Recall", "Visibility of System Status"). Search alone is explicitly "not enough."

## How it works (and why this shape)

- **City- and mode-agnostic split.** The trunk/secondary boundary is derived from the existing `LINE_TYPE_PRIORITY` ranking, not hardcoded per type. Surface modes (tram and anything ranked below it, e.g. bus) are the secondary tier when rapid transit is present; an all-surface city (e.g. tram + bus) keeps its top mode as the trunk anchor; single-mode cities hide nothing. Adding `bus` is a one-line change to `LineType` + `LINE_TYPE_PRIORITY` — the rendering adapts automatically.
- **Faint hint at the overview, full reveal on zoom.** The secondary tier renders at 0.2 opacity from the city's initial zoom and ramps to full strength ~1.5 zoom levels in. The fade anchors to `currentCity.map.zoom` so the hint is correct in any city.
- **Report force-reveal.** Segments/stations whose line currently carries a report are shown at full strength (and heavier weight) regardless of zoom — directly fixes the "report marker with no line under it" case.
- **Stations reveal with their lines**, but from hidden (not faint) — 300+ faint dots at the overview would just re-clutter. Their tap targets track the reveal, so a tap on the empty overview never selects an invisible station.

## Accessibility trade-off (deliberate, on the record)

The 0.2 faint hint at the overview measures only ~1.0–1.4:1 contrast on the dark basemap (verified analytically + under a simulated cheap/glare screen). It is therefore **a teaser that invites zooming, not legible content** — full, accessible legibility is one small zoom in. We chose this over a fully-hidden tier to preserve the "we cover this" signal, and the analytics below will tell us whether the teaser actually converts. `SECONDARY_MIN_OPACITY` and the fade span are single-number tunables at the top of `line-style.ts` if we want to dial the hint up/down.

## Measuring whether it works

`secondary_lines_revealed` fires **once per session** the first time the map is zoomed past the full-reveal threshold (the exported `SECONDARY_REVEAL_ZOOM`, so analytics and rendering never drift). A PostHog funnel (`$pageview → secondary_lines_revealed`) on the **Map Interactions** dashboard reads the discovery rate. The actionable cohort: users who engage (station/report events) but never fire the reveal event — engaged users who never discovered the secondary network.

## Explicitly rejected (and why)

- **A layer legend / mode toggle:** the risk-layer toggle is barely used, so a new control would likely be ignored too — and it clutters the UI. NN/g's own caveat is that a control behind a button relies on users choosing to open it.
- **A one-time tooltip / zoom hint:** relies on recall; research ranks it weakest.
- **A fully-hidden secondary tier:** accessible, but drops the coverage signal entirely.

## Follow-ups

- Add `lineId` / line `type` to `station_selected` so we can measure interest in a *specific* hidden line (today we can only see whether the tier was revealed at all).
- Revisit the faint hint's opacity once the discovery funnel has data.
