### PR TITLE
feat: share one anonymous PostHog identity across freifahren.org subdomains

### DIFF
--- a/packages/frontend-next/src/lib/posthog-client.ts
+++ b/packages/frontend-next/src/lib/posthog-client.ts
@@ -4,11 +4,11 @@ import type { PostHog } from 'posthog-js';
 import { currentCitySlug } from './city';
 import { optionalEnv } from './utils';
 
-// In the native WKWebView (capacitor://localhost) cookies are unreliable, so persistent capture uses
-// localStorage only; the web keeps the cookie too. Consent ('denied' -> memory) still applies on top.
-export const PERSISTENT_PERSISTENCE = Capacitor.isNativePlatform()
-  ? 'localStorage'
-  : 'localStorage+cookie';
+// Web uses a cookie, not localStorage: localStorage is per-origin, so a visitor crossing city
+// subdomains would land on empty storage and be minted a new anonymous id. The cookie is shared
+// across subdomains (see cross_subdomain_cookie), so the id survives the switch. Native keeps
+// localStorage because cookies are unreliable in the WKWebView (capacitor://localhost).
+export const PERSISTENT_PERSISTENCE = Capacitor.isNativePlatform() ? 'localStorage' : 'cookie';
 
 // posthog-js is lazy-loaded after first paint to keep it out of the eager bundle. Calls made before
 // it finishes loading are buffered here and flushed in order, so startup events aren't lost.
@@ -73,6 +73,9 @@ export function loadPostHog(): Promise<void> {
       // users stay un-retained by design, and respect_dnt keeps DNT users out entirely.
       person_profiles: 'always',
       persistence: PERSISTENT_PERSISTENCE,
+      // Explicit so the cross-subdomain intent can't be silently flipped to per-host. posthog-js
+      // also derives this for registrable domains; it stays host-only on single-label hosts.
+      cross_subdomain_cookie: true,
       autocapture: false,
       capture_performance: false,
       disable_session_recording: true,


### PR DESCRIPTION
Closes FRE-711.

## Problem
PostHog web persistence was `localStorage+cookie`, and localStorage is per-origin. A visitor crossing city subdomains (`berlin.` ↔ `leipzig.` ↔ `app.freifahren.org`) lands on empty localStorage and is minted a **fresh anonymous id**, double-counting one person as many — on top of the already-broken lifecycle/retention. This has to land **before** the city switcher (FRE-712) ships, otherwise every switch fragments identity.

## Change
- Web persistence → `cookie` (was `localStorage+cookie`). The id now lives only in a cookie scoped to the registrable domain, so it is shared across subdomains and there is no per-origin store to override it.
- Set `cross_subdomain_cookie: true` explicitly. posthog-js already derives this for registrable domains; making it explicit keeps the cross-subdomain intent from being silently flipped to per-host.
- Native is unchanged (stays `localStorage` — cookies are unreliable in the WKWebView).

`PERSISTENT_PERSISTENCE` is the single source of truth (consent.ts restores it after undecided/granted), so the consent flow follows automatically. `api_host`/the `/relay` proxy are untouched.

## Verification (end-to-end, local)
Ran the built client with a throwaway PostHog key against two subdomains of one registrable domain (`berlin.fftest.test` / `leipzig.fftest.test` via `/etc/hosts`):
- **Cross-subdomain identity holds:** `leipzig.` reads the exact same `distinct_id` the cookie was minted with on `berlin.` — a host-only cookie would never cross, so the `.fftest.test` domain scoping is confirmed by behavior.
- **No fragmenting store:** persistent localStorage keys for PostHog are empty (`[]`); the id is entirely cookie-based.
- **Reload-stable:** same `distinct_id` after reload.
- **Cookie size sane:** the `ph_*_posthog` cookie is ~750 bytes, well under the 4 KB per-cookie limit.