### PR TITLE
ci: redeploy registry-consuming workers on packages/cities changes

### DIFF
--- a/.github/workflows/api-worker-deploy.yml
+++ b/.github/workflows/api-worker-deploy.yml
@@ -5,6 +5,8 @@ on:
         branches: [main]
         paths:
             - 'packages/api-worker/**'
+            # Bundled at runtime, so a registry-only change must redeploy this worker.
+            - 'packages/cities/**'
             - '.github/workflows/api-worker-deploy.yml'
 
 concurrency:

--- a/.github/workflows/frontend-next-deploy.yml
+++ b/.github/workflows/frontend-next-deploy.yml
@@ -5,6 +5,8 @@ on:
         branches: [main]
         paths:
             - 'packages/frontend-next/**'
+            # Bundled into the client, so a registry-only change must redeploy.
+            - 'packages/cities/**'
             - '.github/workflows/frontend-next-deploy.yml'
     workflow_dispatch: {}
 

--- a/.github/workflows/telegram-worker-deploy.yml
+++ b/.github/workflows/telegram-worker-deploy.yml
@@ -5,6 +5,8 @@ on:
         branches: [main]
         paths:
             - 'packages/telegram-worker/**'
+            # Bundled at runtime, so a registry-only change must redeploy this worker.
+            - 'packages/cities/**'
             - '.github/workflows/telegram-worker-deploy.yml'
     workflow_dispatch: {}
 

--- a/.github/workflows/tile-server-deploy.yml
+++ b/.github/workflows/tile-server-deploy.yml
@@ -5,6 +5,8 @@ on:
         branches: [main]
         paths:
             - 'packages/tile-server/**'
+            # `generate` builds tiles per registry city, so a registry-only change must rebuild.
+            - 'packages/cities/**'
             - '.github/workflows/tile-server-deploy.yml'
     workflow_dispatch: {}
 


### PR DESCRIPTION
Closes FRE-729.

## Problem
Each Cloudflare worker's deploy workflow is path-filtered to its **own** package. The shared `@freifahren/cities` registry is bundled by several workers but is in **none** of their deploy path filters. A change touching only `packages/cities/**` (e.g. the Leipzig registry entry in FRE-715) would silently **not** redeploy those workers — they'd keep serving the old registry until an unrelated change to their own package fired a deploy.

This has to be in place **before** the first cities-only change merges.

## Change
Add `packages/cities/**` to the `on.push.paths` filter of every workflow whose worker bundles the registry:

| Workflow | Why it consumes the registry |
|---|---|
| `api-worker-deploy.yml` | bundled at runtime (`app-env.ts`, `transit-network-data-service.ts`, seed) |
| `telegram-worker-deploy.yml` | bundled at runtime (`src/config.ts`) |
| `frontend-next-deploy.yml` | bundled into the client (`src/lib/city.ts`) |
| `tile-server-deploy.yml` | `bun run generate` builds tiles per registry city (`scripts/generate.ts`) |

**Excluded** (verified they do not import `@freifahren/cities`): `warehouse-export` (the issue's conditional consumer — it doesn't) and `capgo-worker`.

## Verification
- Grepped every package for `@freifahren/cities` to confirm the exact consumer set above (excluding `dist/`/`node_modules`).
- Parsed all four edited workflows with a YAML parser: each is valid and its `push.paths` array now contains `packages/cities/**` alongside its existing own-package and self filters.

Note: CI (PR) workflows run on `pull_request` and aren't path-filtered this way, so this is a deploy-trigger fix only — no test-coverage impact.