### PR TITLE
feat: add berlin.freifahren.org and a settings city switcher

### DIFF
--- a/packages/api-worker/wrangler.jsonc
+++ b/packages/api-worker/wrangler.jsonc
@@ -16,7 +16,7 @@
     ],
     "vars": {
         "NODE_ENV": "production",
-        "CORS_ORIGINS": "https://freifahren.org,https://app.freifahren.org,https://www.freifahren.org,http://localhost:1871,http://192.168.178.65:1871,capacitor://localhost",
+        "CORS_ORIGINS": "https://freifahren.org,https://app.freifahren.org,https://www.freifahren.org,https://berlin.freifahren.org,http://localhost:1871,http://192.168.178.65:1871,capacitor://localhost",
         "TELEGRAM_WORKER_URL": "https://telegram-worker.freifahren.workers.dev",
         "SENTRY_DSN": "https://8f49e71a73d689efdcaabfd8794457b6@o4508609338867712.ingest.de.sentry.io/4511638467051600",
     },

--- a/packages/frontend-next/src/components/map/CitySwitcher.i18n.ts
+++ b/packages/frontend-next/src/components/map/CitySwitcher.i18n.ts
@@ -1,0 +1,13 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'citySwitcher';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  city: 'City',
+  label: 'Switch city',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  city: 'Stadt',
+  label: 'Stadt wechseln',
+});

--- a/packages/frontend-next/src/components/map/CitySwitcher.tsx
+++ b/packages/frontend-next/src/components/map/CitySwitcher.tsx
@@ -1,0 +1,74 @@
+import { ChevronDown, MapPin } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { CITIES } from '@freifahren/cities';
+
+import { currentCity } from '@/lib/city';
+import { FEATURE_FLAGS, useFeatureFlag } from '@/lib/feature-flags';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+import { NAMESPACE } from './CitySwitcher.i18n';
+
+const cities = Object.values(CITIES);
+
+// Switching city means switching hostname: one bundle serves every subdomain and resolves the city
+// from the hostname at boot (see lib/city.ts). Swap the leftmost label for the target subdomain and
+// keep the rest (app.freifahren.org -> berlin.freifahren.org). On a single-label host (localhost)
+// there is nothing to swap, so the app stays put — expected, since only one city resolves there.
+function urlForSubdomain(subdomain: string): string {
+  const { protocol, hostname, port, pathname, search } = window.location;
+  const labels = hostname.split('.');
+  const host = labels.length < 2 ? hostname : [subdomain, ...labels.slice(1)].join('.');
+  return `${protocol}//${host}${port ? `:${port}` : ''}${pathname}${search}`;
+}
+
+// A row in the settings card (matches the Contact/Feedback rows): the current city on the right,
+// tapping it opens a menu to switch. Lives in settings rather than on the map because switching is
+// rare — but the row makes it discoverable that more than one city exists.
+export function CitySwitcher() {
+  const enabled = useFeatureFlag(FEATURE_FLAGS.citySwitcher);
+  const { t } = useTranslation(NAMESPACE);
+
+  // Built but not launched: hidden until PostHog turns the flag on. With only one city there is
+  // nothing to switch to or discover, so the row stays hidden until a second city ships.
+  if (!enabled || cities.length < 2) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label={t('label')}
+        className="hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm transition-colors outline-none"
+      >
+        <MapPin className="text-muted-foreground size-4" />
+        <span>{t('city')}</span>
+        <span className="text-muted-foreground ml-auto flex items-center gap-1">
+          {currentCity.displayName}
+          <ChevronDown className="size-4" />
+        </span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={currentCity.slug}
+          onValueChange={(slug) => {
+            if (slug !== currentCity.slug) {
+              const city = cities.find((c) => c.slug === slug);
+              if (city) window.location.assign(urlForSubdomain(city.subdomain));
+            }
+          }}
+        >
+          {cities.map((city) => (
+            <DropdownMenuRadioItem key={city.slug} value={city.slug}>
+              {city.displayName}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/frontend-next/src/components/map/SettingsCard.tsx
+++ b/packages/frontend-next/src/components/map/SettingsCard.tsx
@@ -13,6 +13,7 @@ import { openLegalDisclaimer } from '@/lib/legal-disclaimer';
 import { Route as ImpressumRoute } from '@/routes/impressum';
 import { Route as PrivacyRoute } from '@/routes/privacy';
 
+import { CitySwitcher } from './CitySwitcher';
 import { DetailCard } from './DetailCard';
 import { NAMESPACE } from './SettingsButton.i18n';
 import { SocialLinks } from './SocialLinks';
@@ -60,6 +61,7 @@ export function SettingsCard({ onClose }: SettingsCardProps) {
   return (
     <DetailCard title={t('title')} closeLabel={t('close')} onClose={onClose}>
       <div className="flex flex-col px-2">
+        <CitySwitcher />
         <a
           href={`${WEBSITE_URL}/contact`}
           className="hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm transition-colors outline-none"

--- a/packages/frontend-next/src/components/ui/dropdown-menu.tsx
+++ b/packages/frontend-next/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { Check } from 'lucide-react';
+import * as React from 'react';
+import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function DropdownMenu(props: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuTrigger(props: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 6,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground animate-in fade-in zoom-in-95 z-50 min-w-[9rem] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-hidden rounded-lg p-1 shadow-[0_6px_16px_rgba(0,0,0,0.28)] duration-150',
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item>) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2.5 py-2 text-sm font-semibold outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuRadioGroup(
+  props: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>,
+) {
+  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        'focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-2 pr-2.5 pl-8 text-sm font-semibold outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2.5 flex size-4 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label>) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      className={cn('text-muted-foreground px-2.5 py-1.5 text-xs font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+};

--- a/packages/frontend-next/src/lib/feature-flags.ts
+++ b/packages/frontend-next/src/lib/feature-flags.ts
@@ -1,0 +1,59 @@
+import { useSyncExternalStore } from 'react';
+
+import { enqueuePostHog } from '@/lib/posthog-client';
+
+// PostHog feature flags read through the same lazy-loaded client as analytics, so components never
+// touch the SDK directly. Flags gate UI that ships in the bundle but isn't launched yet; the value
+// is false until the SDK loads and PostHog resolves flags, and false forever when analytics is
+// disabled (no key, or a 'denied'/DNT session that never initializes the SDK). Fail-closed: a
+// gated feature stays hidden unless PostHog affirmatively turns it on.
+export const FEATURE_FLAGS = {
+  citySwitcher: 'city-switcher',
+} as const;
+
+type FlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];
+
+const values = new Map<FlagKey, boolean>();
+const listeners = new Set<() => void>();
+let subscribed = false;
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+// Wire up to PostHog once, on first subscription. onFeatureFlags fires whenever flags (re)load —
+// after the SDK import resolves, after a reload, and after a local override in the toolbar — so the
+// store tracks every change. Buffered until the SDK is ready; dropped if analytics is disabled.
+function ensureSubscribed(): void {
+  if (subscribed) return;
+  subscribed = true;
+  enqueuePostHog((posthog) => {
+    const sync = () => {
+      let changed = false;
+      for (const key of Object.values(FEATURE_FLAGS)) {
+        const next = posthog.isFeatureEnabled(key) ?? false;
+        if (values.get(key) !== next) {
+          values.set(key, next);
+          changed = true;
+        }
+      }
+      if (changed) notify();
+    };
+    posthog.onFeatureFlags(sync);
+    sync();
+  });
+}
+
+function subscribe(listener: () => void): () => void {
+  ensureSubscribed();
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useFeatureFlag(flag: FlagKey): boolean {
+  // In dev every flag reads on, so gated work is visible locally without touching PostHog. In
+  // prod the value comes from the resolved flag (false until PostHog turns it on).
+  return useSyncExternalStore(subscribe, () =>
+    import.meta.env.DEV ? true : (values.get(flag) ?? false),
+  );
+}

--- a/packages/frontend-next/wrangler.jsonc
+++ b/packages/frontend-next/wrangler.jsonc
@@ -9,5 +9,11 @@
     // Without this the SPA fallback swallows /relay/* before the proxy Worker runs.
     "run_worker_first": ["/relay/*"],
   },
-  "routes": [{ "pattern": "app.freifahren.org", "custom_domain": true }],
+  // app.freifahren.org stays a Berlin alias (PWA install + Capacitor origin + App Store deep-link
+  // target); berlin.freifahren.org is the canonical per-city host. Both serve the same bundle,
+  // which resolves the city from the hostname at runtime.
+  "routes": [
+    { "pattern": "app.freifahren.org", "custom_domain": true },
+    { "pattern": "berlin.freifahren.org", "custom_domain": true },
+  ],
 }


### PR DESCRIPTION
Closes FRE-712. Rollout step 4 of the Multi-city expansion — Berlin-only, proving the multi-host machinery.

## Changes
- **`packages/frontend-next/wrangler.jsonc`** — add the `berlin.freifahren.org` custom-domain route alongside `app.freifahren.org`, which stays the Berlin alias (PWA install + Capacitor origin + App Store deep-link target). Both serve the same bundle, which resolves the city from the hostname at runtime.
- **`packages/api-worker/wrangler.jsonc`** — add `https://berlin.freifahren.org` to the exact-match `CORS_ORIGINS` allowlist.
- **City switcher in Settings** — a row in the settings card (`📍 City … Berlin ⌄`), matching the Contact/Feedback rows. Switching is rare, so it lives out of the map chrome but stays discoverable. Navigates to the target subdomain by swapping the hostname's leftmost label.
- **`src/components/ui/dropdown-menu.tsx`** (new) — shadcn dropdown-menu wrapping the already-installed `radix-ui`, following the repo's component idiom.
- **`src/lib/feature-flags.ts`** (new) — a PostHog feature-flag facade + `useFeatureFlag` hook wired through the existing lazy-loaded client. Fail-closed (false until PostHog turns a flag on); **every flag reads on in dev** so gated work is visible locally. The switcher is gated behind the client-side `city-switcher` flag and additionally only renders when more than one city exists — so it stays hidden until a second city ships.

## Infra config (registered out-of-band, documented here per the issue)
- **Cloudflare:** Workers custom domain `berlin.freifahren.org` → `frontend` worker in zone `freifahren.org` (managed DNS + TLS). Verified live: HTTP 200, valid cert, resolves to Berlin. Also listed in `wrangler.jsonc` so future deploys keep it.
- **PostHog:** feature flag `city-switcher` (client-side, tag `multi-city`) created at **0% rollout** — shipped gated off. Bump the rollout to launch.

## Notes
- `leipzig.freifahren.org` was intentionally **not** added to CORS — the next city isn't decided yet.
- Each subdomain gets its own service-worker registration/precache (expected; no action needed).
- Mobile (Capacitor) uses a persisted city preference instead of the hostname; a native onboarding/switch flow is deferred to a follow-up (FRE-721).

## Verification
- Full deploy gate green: `format:check`, `lint` (0 errors), and `build` (tsc + vite) all pass.
- Browser-driven: flag off → switcher hidden; flag on (local override, no prod change) → Settings shows the City row and the dropdown lists the cities with the active one checked. Confirmed the production flag stays at 0% afterward.