### PR TITLE
ci: record GitHub deployments for each worker deploy

### DIFF
--- a/.github/workflows/api-worker-deploy.yml
+++ b/.github/workflows/api-worker-deploy.yml
@@ -14,6 +14,10 @@ concurrency:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        # Records a GitHub deployment for this worker so it shows in the repo's Deployments tab.
+        environment:
+            name: api-worker
+            url: https://api.freifahren.org
         permissions:
             contents: read
         defaults:

--- a/.github/workflows/capgo-worker-deploy.yml
+++ b/.github/workflows/capgo-worker-deploy.yml
@@ -16,6 +16,10 @@ concurrency:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        # Records a GitHub deployment for this worker so it shows in the repo's Deployments tab.
+        environment:
+            name: capgo-worker
+            url: https://updates.freifahren.org
         permissions:
             contents: read
         defaults:

--- a/.github/workflows/frontend-next-deploy.yml
+++ b/.github/workflows/frontend-next-deploy.yml
@@ -16,6 +16,10 @@ concurrency:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        # Records a GitHub deployment for this worker so it shows in the repo's Deployments tab.
+        environment:
+            name: frontend
+            url: https://app.freifahren.org
         permissions:
             contents: read
         defaults:

--- a/.github/workflows/telegram-worker-deploy.yml
+++ b/.github/workflows/telegram-worker-deploy.yml
@@ -19,6 +19,10 @@ jobs:
         # (`wrangler secret put MISTRAL_API_KEY` etc.) and fill TELEGRAM_REPORT_CHAT_ID in
         # wrangler.jsonc.
         runs-on: ubuntu-latest
+        # Records a GitHub deployment for this worker so it shows in the repo's Deployments tab.
+        environment:
+            name: telegram-worker
+            url: https://telegram-worker.freifahren.workers.dev
         permissions:
             contents: read
         defaults:

--- a/.github/workflows/tile-server-deploy.yml
+++ b/.github/workflows/tile-server-deploy.yml
@@ -21,6 +21,10 @@ jobs:
         # this workflow never runs against an unconfigured edge and never affects existing users.
         if: ${{ vars.TILES_BASE_URL != '' }}
         runs-on: ubuntu-latest
+        # Records a GitHub deployment for the basemap so it shows in the repo's Deployments tab.
+        environment:
+            name: tile-server
+            url: ${{ vars.TILES_BASE_URL }}
         permissions:
             contents: read
         defaults:

--- a/.github/workflows/warehouse-export-deploy.yml
+++ b/.github/workflows/warehouse-export-deploy.yml
@@ -16,6 +16,10 @@ concurrency:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        # Records a GitHub deployment for this worker so it shows in the repo's Deployments tab.
+        # No url: warehouse-export has no public HTTP endpoint (it's a scheduled export worker).
+        environment:
+            name: warehouse-export
         permissions:
             contents: read
         defaults:


### PR DESCRIPTION
## Problem
`wrangler deploy` doesn't create GitHub deployment records, so our Cloudflare Workers deploys never show up in the repo's **Deployments** tab. The stale `Production` / `Preview` entries there (last updated ~2 years ago) are leftovers from an old Pages/Vercel git integration, not our current Actions pipeline.

## Change
Add a GitHub Actions `environment:` to each deploy job. GitHub then auto-records a deployment tied to the commit — with `in_progress → success/failure` status and a clickable live URL — no extra tooling, token, or permissions needed.

One environment per worker (rather than a shared `production`) so the tab shows each service's own latest deploy instead of six interleaved:

| Workflow | Environment | URL |
|---|---|---|
| `frontend-next-deploy.yml` | `frontend` | https://app.freifahren.org |
| `api-worker-deploy.yml` | `api-worker` | https://api.freifahren.org |
| `telegram-worker-deploy.yml` | `telegram-worker` | https://telegram-worker.freifahren.workers.dev |
| `tile-server-deploy.yml` | `tile-server` | `${{ vars.TILES_BASE_URL }}` |
| `warehouse-export-deploy.yml` | `warehouse-export` | — (no public endpoint) |
| `capgo-worker-deploy.yml` | `capgo-worker` | https://updates.freifahren.org |

## Notes
- **Free** on this public repo; the `environment:` key annotates the existing job and adds no jobs/minutes. Environment protection rules (reviewers, wait timers) are available too if ever wanted, also free on public repos.
- Deploy status tracks the whole job (which is essentially just the deploy step), not the wrangler step alone.
- The stale `Production`/`Preview` environments can be removed under Settings → Environments; the new named environments appear regardless.
- All six workflows validated as parseable YAML with the environment attached to their `deploy` job.