### PR TITLE
fix: harden frontend runtime recovery

### DIFF
--- a/packages/frontend-next/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/frontend-next/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,24 @@
   "originHash" : "bb13ae3a8636030d88b23ddf136a6b9d91d49d1d38cde9872d3eb17d4c70aeb6",
   "pins" : [
     {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
+        "version" : "5.12.0"
+      }
+    },
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
+      }
+    },
+    {
       "identity" : "capacitor-swift-pm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
@@ -26,6 +44,24 @@
       "state" : {
         "revision" : "2c420d31d0c31b525fa9e7c552ef0fc9d924befc",
         "version" : "9.17.1"
+      }
+    },
+    {
+      "identity" : "version",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mrackwitz/Version.git",
+      "state" : {
+        "revision" : "fd4b0eb5756aa7f1c33977fb626cf37d2140a3a0",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/packages/frontend-next/ios/App/CapApp-SPM/Package.swift
+++ b/packages/frontend-next/ios/App/CapApp-SPM/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .package(name: "CapacitorKeyboard", path: "../../../node_modules/@capacitor/keyboard"),
         .package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen"),
         .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar"),
+        .package(name: "CapgoCapacitorUpdater", path: "../../../node_modules/@capgo/capacitor-updater"),
         .package(name: "SentryCapacitor", path: "../../../node_modules/@sentry/capacitor")
     ],
     targets: [
@@ -32,6 +33,7 @@ let package = Package(
                 .product(name: "CapacitorKeyboard", package: "CapacitorKeyboard"),
                 .product(name: "CapacitorSplashScreen", package: "CapacitorSplashScreen"),
                 .product(name: "CapacitorStatusBar", package: "CapacitorStatusBar"),
+                .product(name: "CapgoCapacitorUpdater", package: "CapgoCapacitorUpdater"),
                 .product(name: "SentryCapacitor", package: "SentryCapacitor")
             ]
         )

--- a/packages/frontend-next/src/components/map/PersistentMapView.tsx
+++ b/packages/frontend-next/src/components/map/PersistentMapView.tsx
@@ -2,13 +2,23 @@ import { useRouterState } from '@tanstack/react-router';
 import { lazy, Suspense, useState } from 'react';
 
 import { cn } from '@/lib/utils';
+import { notifyNativeAppReady } from '@/lib/native';
 
 // Load the map + maplibre-gl in parallel only once the map first mounts, keeping the
 // heavy bundle out of the shell and off map-less routes (/report, /privacy, /impressum).
+const stalledMapImport = new Promise<never>(() => {});
 const importMap = () =>
-  Promise.all([import('@/components/map/Map'), import('maplibre-gl')]).then(([m]) => ({
-    default: m.MapView,
-  }));
+  Promise.all([import('@/components/map/Map'), import('maplibre-gl')]).then(
+    ([mapModule, maplibreModule]) => {
+      // Vite resolves a failed preload with undefined when vite:preloadError is prevented. Keep the
+      // Suspense boundary pending while the page reloads instead of replacing the whole app with
+      // the router error screen. Native deliberately remains unconfirmed so Capgo rolls it back.
+      if (!mapModule || !maplibreModule) return stalledMapImport;
+
+      void notifyNativeAppReady();
+      return { default: mapModule.MapView };
+    },
+  );
 
 const MapView = lazy(importMap);
 

--- a/packages/frontend-next/src/components/report/useReportVerification.ts
+++ b/packages/frontend-next/src/components/report/useReportVerification.ts
@@ -1,6 +1,7 @@
 import { useStations } from '@/api/transit';
 import { useGeolocation } from '@/contexts/Geolocation.context';
 import { distanceMeters } from '@/lib/geo';
+import { safeLocalStorage } from '@/lib/safe-storage';
 
 export type ReportRejection = 'too_soon' | 'too_far';
 
@@ -9,21 +10,13 @@ const MIN_REPORT_INTERVAL_MS = 15 * 60 * 1000;
 const STORAGE_KEY = 'lastReportAt';
 
 function readLastReportAt(): number | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    const value = raw ? Number(raw) : NaN;
-    return Number.isFinite(value) ? value : null;
-  } catch {
-    return null;
-  }
+  const raw = safeLocalStorage.getItem(STORAGE_KEY);
+  const value = raw ? Number(raw) : NaN;
+  return Number.isFinite(value) ? value : null;
 }
 
 function writeLastReportAt(timestamp: number): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, String(timestamp));
-  } catch {
-    // Private mode / storage unavailable: skip.
-  }
+  safeLocalStorage.setItem(STORAGE_KEY, String(timestamp));
 }
 
 /**

--- a/packages/frontend-next/src/hooks/useRiskLayer.ts
+++ b/packages/frontend-next/src/hooks/useRiskLayer.ts
@@ -1,6 +1,7 @@
 import { useEffect, useSyncExternalStore } from 'react';
 
 import { setSuperProperties, track } from '@/lib/analytics';
+import { safeLocalStorage } from '@/lib/safe-storage';
 
 // Which transit layer the map shows: risk-colored segments ('RISK') or plain line colors
 // ('LINES'). Shared between the toggle button (mounted in the map route) and the layer (nested
@@ -13,11 +14,7 @@ const STORAGE_KEY = 'defaultLayer';
 const DEFAULT_LAYER: Layer = 'RISK';
 
 function readInitial(): Layer {
-  try {
-    return localStorage.getItem(STORAGE_KEY) === 'LINES' ? 'LINES' : 'RISK';
-  } catch {
-    return DEFAULT_LAYER;
-  }
+  return safeLocalStorage.getItem(STORAGE_KEY) === 'LINES' ? 'LINES' : DEFAULT_LAYER;
 }
 
 let layer = readInitial();
@@ -26,11 +23,7 @@ const listeners = new Set<() => void>();
 function setLayer(next: Layer) {
   if (next === layer) return;
   layer = next;
-  try {
-    localStorage.setItem(STORAGE_KEY, next);
-  } catch {
-    // Ignore storage failures (e.g. private mode); state still works for the session.
-  }
+  safeLocalStorage.setItem(STORAGE_KEY, next);
   track('risk_layer_toggled', { to: next });
   setSuperProperties({ map_layer: next });
   for (const listener of listeners) listener();

--- a/packages/frontend-next/src/lib/app-banner.ts
+++ b/packages/frontend-next/src/lib/app-banner.ts
@@ -1,6 +1,8 @@
 import { Capacitor } from '@capacitor/core';
 import { useSyncExternalStore } from 'react';
 
+import { safeLocalStorage } from '@/lib/safe-storage';
+
 // Numeric App Store ID (not the bundle id). Keep in sync with the apple-itunes-app tag in index.html.
 export const APP_STORE_ID = '6738277309';
 
@@ -32,11 +34,7 @@ const eligible =
   !detectIosSafari(navigator.userAgent);
 
 function readDismissed(): boolean {
-  try {
-    return localStorage.getItem(STORAGE_KEY) === '1';
-  } catch {
-    return false;
-  }
+  return safeLocalStorage.getItem(STORAGE_KEY) === '1';
 }
 
 let dismissed = readDismissed();
@@ -53,11 +51,7 @@ function shouldShow(): boolean {
 
 export function dismissAppBanner(): void {
   dismissed = true;
-  try {
-    localStorage.setItem(STORAGE_KEY, '1');
-  } catch {
-    // In-memory flag still hides it for this session.
-  }
+  safeLocalStorage.setItem(STORAGE_KEY, '1');
   for (const listener of listeners) listener();
 }
 

--- a/packages/frontend-next/src/lib/city.ts
+++ b/packages/frontend-next/src/lib/city.ts
@@ -1,6 +1,8 @@
 import { Capacitor } from '@capacitor/core';
 import { CITIES, DEFAULT_CITY_SLUG, getCity, type CityConfig } from '@freifahren/cities';
 
+import { safeLocalStorage } from '@/lib/safe-storage';
+
 // Runtime city resolution. One build serves every city; the active city is resolved at boot
 // from a source that depends on the platform, then held for the session. The registry
 // (packages/cities) is small static data bundled into the client.
@@ -15,12 +17,8 @@ const defaultCity = (): CityConfig => getCity(DEFAULT_CITY_SLUG) as CityConfig;
 // select a city. Resolve from a persisted preference instead (localStorage is synchronous and
 // available in the WebView). The switcher UI that writes it ships in FRE-721.
 const resolveNativeCity = (): CityConfig => {
-  try {
-    const stored = localStorage.getItem(NATIVE_CITY_PREFERENCE_KEY);
-    return (stored ? getCity(stored) : undefined) ?? defaultCity();
-  } catch {
-    return defaultCity();
-  }
+  const stored = safeLocalStorage.getItem(NATIVE_CITY_PREFERENCE_KEY);
+  return (stored ? getCity(stored) : undefined) ?? defaultCity();
 };
 
 // Web: the subdomain selects the city (berlin.freifahren.org -> berlin). Unknown hosts

--- a/packages/frontend-next/src/lib/consent.ts
+++ b/packages/frontend-next/src/lib/consent.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from 'react';
 
 import { enqueuePostHog, PERSISTENT_PERSISTENCE } from '@/lib/posthog-client';
+import { safeLocalStorage } from '@/lib/safe-storage';
 
 // Capture is ON by default (see main.tsx). The banner asks for cookie consent specifically; either
 // choice keeps analytics running, but at different privacy levels:
@@ -21,7 +22,7 @@ type StoredConsent = { choice: ConsentChoice; decidedAt: number };
 
 function read(): StoredConsent | null {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
     if (
@@ -38,7 +39,7 @@ function read(): StoredConsent | null {
     }
     return null;
   } catch {
-    // Private mode / disabled storage / legacy value: treat as undecided.
+    // Malformed or legacy values are treated as undecided.
     return null;
   }
 }
@@ -101,14 +102,10 @@ function applyToPostHog(value: ConsentChoice | null): void {
 export function setConsent(value: ConsentChoice): void {
   const now = new Date();
   decidedAt = now.getTime();
-  try {
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({ choice: value, decidedAt: now.toISOString() }),
-    );
-  } catch {
-    // Ignore storage failures; the in-memory choice still applies for this session.
-  }
+  safeLocalStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ choice: value, decidedAt: now.toISOString() }),
+  );
   choice = value;
   reviewOpen = false;
   applyToPostHog(value);

--- a/packages/frontend-next/src/lib/contribute-modal.ts
+++ b/packages/frontend-next/src/lib/contribute-modal.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from 'react';
 
 import { track } from '@/lib/analytics';
+import { safeLocalStorage } from '@/lib/safe-storage';
 
 // "Don't show again" preference. Reuse the old frontend's key so users who already
 // dismissed the modal there are not nagged again after the rewrite ships.
@@ -43,20 +44,11 @@ export function useContributeModalOpen(): boolean {
 }
 
 export function isContributeDismissed(): boolean {
-  try {
-    return localStorage.getItem(DISMISSED_KEY) === 'true';
-  } catch {
-    // Private mode / disabled storage: treat as not dismissed so the modal can still appear.
-    return false;
-  }
+  return safeLocalStorage.getItem(DISMISSED_KEY) === 'true';
 }
 
 export function dismissContributeForever(): void {
   track('contribute_dismissed', { source });
-  try {
-    localStorage.setItem(DISMISSED_KEY, 'true');
-  } catch {
-    // Ignore storage failures; closing the modal below still suppresses it for this session.
-  }
+  safeLocalStorage.setItem(DISMISSED_KEY, 'true');
   closeContributeModal();
 }

--- a/packages/frontend-next/src/lib/legal-disclaimer.ts
+++ b/packages/frontend-next/src/lib/legal-disclaimer.ts
@@ -1,5 +1,7 @@
 import { useSyncExternalStore } from 'react';
 
+import { safeLocalStorage } from '@/lib/safe-storage';
+
 // Acceptance is re-asked every six months. localStorage has no native expiry, so
 // we store the acceptance timestamp and compare against this window on read.
 // (Note: on Safari/iOS, ITP may purge script-writable storage after ~7 days of
@@ -10,16 +12,11 @@ const STORAGE_KEY = 'legalDisclaimerAcceptedAt';
 const SIX_MONTHS_MS = 1000 * 60 * 60 * 24 * 182;
 
 function isWithinWindow(now: number): boolean {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw === null) return false;
-    const acceptedAt = new Date(raw).getTime();
-    if (Number.isNaN(acceptedAt)) return false;
-    return now - acceptedAt < SIX_MONTHS_MS;
-  } catch {
-    // Private mode / disabled storage: treat as not accepted so the gate still works.
-    return false;
-  }
+  const raw = safeLocalStorage.getItem(STORAGE_KEY);
+  if (raw === null) return false;
+  const acceptedAt = new Date(raw).getTime();
+  if (Number.isNaN(acceptedAt)) return false;
+  return now - acceptedAt < SIX_MONTHS_MS;
 }
 
 let accepted = isWithinWindow(Date.now());
@@ -33,11 +30,7 @@ function notify(): void {
 }
 
 function acceptDisclaimer(): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, new Date().toISOString());
-  } catch {
-    // Ignore storage failures; the session-level state below still suppresses the gate.
-  }
+  safeLocalStorage.setItem(STORAGE_KEY, new Date().toISOString());
   accepted = true;
   notify();
 }

--- a/packages/frontend-next/src/lib/native.ts
+++ b/packages/frontend-next/src/lib/native.ts
@@ -12,17 +12,6 @@ export async function initNativePlatform(): Promise<void> {
   if (!Capacitor.isNativePlatform()) return;
 
   try {
-    // Capgo OTA: signal that this bundle booted cleanly. If notifyAppReady() isn't called within
-    // appReadyTimeout the updater treats the bundle as broken and rolls back to the previous one on
-    // the next launch — that auto-rollback is our safety net for a bad bundle. The download/install
-    // itself is handled by autoUpdate (see capacitor.config.ts).
-    const { CapacitorUpdater } = await import('@capgo/capacitor-updater');
-    await CapacitorUpdater.notifyAppReady();
-  } catch {
-    /* ignore */
-  }
-
-  try {
     // The app has no multi-field forms, so the keyboard accessory bar (the "‹ › Done" toolbar) only
     // reads as a stray dialog.
     const { Keyboard } = await import('@capacitor/keyboard');
@@ -53,4 +42,16 @@ export async function initNativePlatform(): Promise<void> {
   // AppDelegate bridges iOS's userDidTakeScreenshot notification to this window event. The current
   // route rides along automatically as posthog-js's `$pathname`.
   window.addEventListener('screenshotTaken', () => track('screenshot_taken', {}));
+}
+
+let appReadyPromise: Promise<void> | null = null;
+
+/** Confirm an OTA bundle only after the initial route's critical JavaScript loaded successfully. */
+export function notifyNativeAppReady(): Promise<void> {
+  if (!Capacitor.isNativePlatform()) return Promise.resolve();
+  appReadyPromise ??= import('@capgo/capacitor-updater')
+    .then(({ CapacitorUpdater }) => CapacitorUpdater.notifyAppReady())
+    .then(() => undefined)
+    .catch(() => {});
+  return appReadyPromise;
 }

--- a/packages/frontend-next/src/lib/offline-basemap.ts
+++ b/packages/frontend-next/src/lib/offline-basemap.ts
@@ -12,13 +12,13 @@ const store = createStore('freifahren-basemap', 'cache');
 const STYLE_KEY = 'style';
 const ARCHIVE_PREFIX = 'archive:';
 
-/** A pmtiles Source backed by the whole archive held in memory, for offline range reads. */
-class BufferSource implements Source {
-  private readonly buffer: ArrayBuffer;
+/** A pmtiles Source that reads only the requested range from the persisted archive. */
+class BlobSource implements Source {
+  private readonly blob: Blob;
   private readonly key: string;
 
-  constructor(buffer: ArrayBuffer, key: string) {
-    this.buffer = buffer;
+  constructor(blob: Blob, key: string) {
+    this.blob = blob;
     this.key = key;
   }
 
@@ -27,7 +27,7 @@ class BufferSource implements Source {
   }
 
   async getBytes(offset: number, length: number): Promise<RangeResponse> {
-    return { data: this.buffer.slice(offset, offset + length) };
+    return { data: await this.blob.slice(offset, offset + length).arrayBuffer() };
   }
 }
 
@@ -102,7 +102,7 @@ export async function prepareOfflineBasemap(
   const cached = await get<Blob>(key, store);
   if (cached) {
     if (fresh) await set(STYLE_KEY, fresh, store);
-    protocol.add(new PMTiles(new BufferSource(await cached.arrayBuffer(), archiveUrl)));
+    protocol.add(new PMTiles(new BlobSource(cached, archiveUrl)));
   } else if (fresh && navigator.onLine) {
     // New deploy: its archive isn't downloaded yet. Persist the style only *after* its archive lands,
     // and prune older archives only then — so the persisted style always has a matching archive and an

--- a/packages/frontend-next/src/lib/safe-storage.ts
+++ b/packages/frontend-next/src/lib/safe-storage.ts
@@ -1,0 +1,36 @@
+export type SafeStorage = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => boolean;
+  removeItem: (key: string) => boolean;
+};
+
+function createSafeStorage(resolve: () => Storage): SafeStorage {
+  return {
+    getItem(key) {
+      try {
+        return resolve().getItem(key);
+      } catch {
+        return null;
+      }
+    },
+    setItem(key, value) {
+      try {
+        resolve().setItem(key, value);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    removeItem(key) {
+      try {
+        resolve().removeItem(key);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+export const safeLocalStorage = createSafeStorage(() => localStorage);
+export const safeSessionStorage = createSafeStorage(() => sessionStorage);

--- a/packages/frontend-next/src/lib/viewed-reports.ts
+++ b/packages/frontend-next/src/lib/viewed-reports.ts
@@ -1,5 +1,7 @@
 import { useSyncExternalStore } from 'react';
 
+import { safeSessionStorage } from '@/lib/safe-storage';
+
 // Reports the user has already looked at (by opening the report detail or the reports overview)
 // stop pulsing on the map and on the overview button. Tracked by the app-wide
 // `${stationId}-${timestamp}` report key and persisted in sessionStorage so the state survives
@@ -14,7 +16,7 @@ function reportKey(stationId: string, timestamp: string): string {
 
 function readInitial(): Set<string> {
   try {
-    const raw = sessionStorage.getItem(STORAGE_KEY);
+    const raw = safeSessionStorage.getItem(STORAGE_KEY);
     if (!raw) return new Set();
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return new Set();
@@ -41,11 +43,7 @@ export function markReportViewed(stationId: string, timestamp: string): void {
   const key = reportKey(stationId, timestamp);
   if (viewed.has(key)) return;
   viewed = new Set(viewed).add(key);
-  try {
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify([...viewed]));
-  } catch {
-    // Storage unavailable: keep the in-memory state so it still works for this session.
-  }
+  safeSessionStorage.setItem(STORAGE_KEY, JSON.stringify([...viewed]));
   for (const listener of listeners) listener();
 }
 

--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -10,6 +10,7 @@ import { syncConsentToPostHog } from './lib/consent';
 import { loadPostHog } from './lib/posthog-client';
 import { initErrorMonitoring } from './lib/error-monitoring';
 import { initNativePlatform } from './lib/native';
+import { safeSessionStorage } from './lib/safe-storage';
 import './lib/i18n';
 import { routeTree } from './routeTree.gen';
 import './index.css';
@@ -37,11 +38,12 @@ if (!__CAPACITOR__ && 'serviceWorker' in navigator) {
 // fetch the fresh shell. Skip when offline — a reload can't fetch a new chunk and the SW already
 // serves the precached shell, so it'd only wipe UI state. The timestamp bounds repeated reloads.
 window.addEventListener('vite:preloadError', (event) => {
+  // Prevent Vite from rethrowing the underlying import failure whether recovery is possible or not.
+  event.preventDefault();
   if (!navigator.onLine) return;
   const KEY = 'vite:preloadError:lastReload';
-  if (Date.now() - Number(sessionStorage.getItem(KEY) ?? 0) < 10_000) return;
-  sessionStorage.setItem(KEY, String(Date.now()));
-  event.preventDefault();
+  if (Date.now() - Number(safeSessionStorage.getItem(KEY) ?? 0) < 10_000) return;
+  if (!safeSessionStorage.setItem(KEY, String(Date.now()))) return;
   window.location.reload();
 });
 

--- a/packages/frontend-next/src/routes/__root.tsx
+++ b/packages/frontend-next/src/routes/__root.tsx
@@ -1,4 +1,5 @@
-import { createRootRoute, Outlet } from '@tanstack/react-router';
+import { createRootRoute, Outlet, useRouterState } from '@tanstack/react-router';
+import { useEffect } from 'react';
 
 import { AppBanner } from '@/components/AppBanner';
 import { ConsentBanner } from '@/components/ConsentBanner';
@@ -8,6 +9,19 @@ import { LegalDisclaimer } from '@/components/LegalDisclaimer';
 import { PersistentMapView } from '@/components/map/PersistentMapView';
 import { ScreenshotBranding } from '@/components/ScreenshotBranding';
 import { GeolocationProvider } from '@/contexts/GeolocationProvider';
+import { notifyNativeAppReady } from '@/lib/native';
+
+function NativeAppReady() {
+  const onMapRoute = useRouterState({
+    select: (state) => state.matches.some((match) => match.routeId.startsWith('/_map')),
+  });
+
+  useEffect(() => {
+    if (!onMapRoute) void notifyNativeAppReady();
+  }, [onMapRoute]);
+
+  return null;
+}
 
 export const Route = createRootRoute({
   // Root is never the active leaf, so the disclaimer never reads this value;
@@ -15,6 +29,7 @@ export const Route = createRootRoute({
   staticData: { legalDisclaimer: false },
   component: () => (
     <GeolocationProvider>
+      <NativeAppReady />
       <PersistentMapView />
       <AppBanner />
       <Outlet />


### PR DESCRIPTION
## What changed

- centralize guarded `localStorage` and `sessionStorage` access in a shared safe-storage adapter and migrate all frontend callers
- prevent Vite preload failures from being rethrown, while keeping the bounded online reload recovery
- keep a prevented/failed map import inside its Suspense boundary so the rest of the app stays usable
- confirm Capgo OTA bundles only after the initial route's critical JavaScript has loaded, so corrupt bundles can roll back
- restore the Capgo updater in the checked-in Swift package manifest and lock its transitive packages
- read cached PMTiles data by requested Blob ranges instead of materializing the full ~25 MB archive into one ArrayBuffer at startup

## Why

This addresses the actionable production Sentry clusters:

- [WEB-APP-T](https://freifahren-web.sentry.io/issues/132269458/): restricted storage access threw inside the preload recovery handler
- [WEB-APP-4](https://freifahren-web.sentry.io/issues/127908175/) and [WEB-APP-6](https://freifahren-web.sentry.io/issues/128015904/): CSS and dynamic map chunks failed to preload
- [WEB-APP-X](https://freifahren-web.sentry.io/issues/132904860/): a native bundle raised repeated `Unexpected EOF` errors but was marked ready before its critical map chunk loaded
- [WEB-APP-P](https://freifahren-web.sentry.io/issues/131087273/) plus related native hang groups: offline basemap startup eagerly copied the complete archive into memory before serving any tile range

## Impact

Restricted browser contexts no longer crash on storage access, transient chunk failures are contained without reload loops or a global error screen, broken native OTA bundles retain rollback protection, and native map startup avoids a large eager allocation/copy.

## Validation

- `bun run format:check`
- `bun run lint` (passes with the two existing TanStack Virtual/React Compiler warnings)
- `bun run build`
- `CAPACITOR=true bun run build`
- `bun run build:ios`
- Xcode simulator build succeeds with Capgo linked into the native dependency graph
- iPhone 17 Pro / iOS 26.5 simulator install and launch succeeds; the map shell and live report data render and no hang/exception/plugin-not-implemented log appears
- cached-basemap relaunch exercised a persisted 26 MB WebKit/IndexedDB store; the map became interactive without an app-hang event
- local browser happy path: map and controls render, storage-backed legal confirmation works, no browser warnings/errors
- denied-storage fault injection: all safe-storage reads return `null` and writes fail closed without throwing
- missing Map CSS fault injection: no uncaught runtime error
- missing MapLibre JavaScript fault injection: app shell remains usable, no browser warnings/errors, restoring the chunk restores the map