### PR TITLE
feat: provision Leipzig D1 migration fan-out

### DIFF
--- a/.github/workflows/api-worker-deploy.yml
+++ b/.github/workflows/api-worker-deploy.yml
@@ -14,8 +14,54 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
+    migrate:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        defaults:
+            run:
+                working-directory: packages/api-worker
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Set up Bun
+              uses: oven-sh/setup-bun@v1
+              with:
+                  bun-version: latest
+
+            - name: Install dependencies
+              run: bun install --frozen-lockfile
+
+            - name: Apply migrations and verify city databases are in sync
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+              run: |
+                  latest_migration=''
+                  while IFS= read -r binding; do
+                    echo "Applying migrations to $binding"
+                    bunx wrangler d1 migrations apply "$binding" --remote
+
+                    applied=$(bunx wrangler d1 execute "$binding" --remote --json \
+                      --command 'SELECT name FROM d1_migrations ORDER BY id DESC LIMIT 1' \
+                      | bun -e 'const result = await Bun.stdin.json(); const name = result[0]?.results?.[0]?.name; if (typeof name !== "string") process.exit(1); console.log(name)')
+
+                    if [ -z "$applied" ]; then
+                      echo "No applied migration found for $binding" >&2
+                      exit 1
+                    fi
+
+                    echo "$binding is at $applied"
+                    if [ -n "$latest_migration" ] && [ "$applied" != "$latest_migration" ]; then
+                      echo "Migration drift detected: $binding is at $applied, expected $latest_migration" >&2
+                      exit 1
+                    fi
+                    latest_migration="$applied"
+                  done < <(bun -e 'import { CITY_DATABASES } from "../../packages/cities/src/index.ts"; for (const { dbBinding } of Object.values(CITY_DATABASES)) console.log(dbBinding)')
+
     deploy:
-        needs: seed
+        needs: [migrate, seed]
         runs-on: ubuntu-latest
         # Records a GitHub deployment for this worker so it shows in the repo's Deployments tab.
         environment:
@@ -100,7 +146,7 @@ jobs:
     # additive and idempotent, so reports stay intact and re-running is a no-op if unchanged.
     # Each matrix leg touches only that city's isolated DB. Preconditions: the city's D1 binding exists.
     seed:
-        needs: plan
+        needs: [migrate, plan]
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -13,6 +13,7 @@ import { TransitNetworkDataService } from './modules/transit/transit-network-dat
 export type Bindings = {
     // Cloudflare D1 binding. Present on Workers and, in tests, provided by the Miniflare pool.
     DB?: D1Database
+    DB_LEIPZIG?: D1Database
     CORS_ORIGINS?: string
     NODE_ENV?: string
     TELEGRAM_WORKER_URL?: string
@@ -110,9 +111,8 @@ const resolveCity = (c: Context<Env>): CityConfig => {
     return city
 }
 
-// Look up a city's D1 binding by name on the Worker env. Dynamic by design: today
-// Every city resolves to the single `DB` binding, but this is the switch that will
-// Fan out to per-city bindings (DB_LEIPZIG, …) once they exist.
+// Looks up a city's D1 binding by name on the Worker env. Dynamic by design.
+// Each city can use its isolated database.
 const cityDbBinding = (env: Bindings, dbBinding: string): D1Database | undefined =>
     (env as unknown as Record<string, D1Database | undefined>)[dbBinding]
 

--- a/packages/api-worker/tests/seed.test.ts
+++ b/packages/api-worker/tests/seed.test.ts
@@ -7,6 +7,7 @@ import { seedBaseData } from '../src/db/seed/seed'
 import { sendReportRequest } from './test-utils'
 
 const temporaryStationId = 'test-orphan'
+const reSeedTimeout = 20_000
 
 describe('seedBaseData', () => {
     beforeEach(async () => {
@@ -19,64 +20,72 @@ describe('seedBaseData', () => {
         await db.delete(stations).where(eq(stations.id, temporaryStationId))
     })
 
-    it('preserves existing reports across a re-seed', async () => {
-        const [station] = await db.select({ id: lineStations.stationId }).from(lineStations).limit(1)
-        if (!station) throw new Error('expected at least one seeded station to exist')
+    it(
+        'preserves existing reports across a re-seed',
+        async () => {
+            const [station] = await db.select({ id: lineStations.stationId }).from(lineStations).limit(1)
+            if (!station) throw new Error('expected at least one seeded station to exist')
 
-        const response = await sendReportRequest({ stationId: station.id, lineId: null, directionId: null })
-        expect(response.status).toBe(200)
-        const inserted = (await response.json()) as { reportId: number }
+            const response = await sendReportRequest({ stationId: station.id, lineId: null, directionId: null })
+            expect(response.status).toBe(200)
+            const inserted = (await response.json()) as { reportId: number }
 
-        await seedBaseData(db)
+            await seedBaseData(db)
 
-        const after = await db.select({ reportId: reports.reportId }).from(reports)
-        expect(after).toEqual([{ reportId: inserted.reportId }])
-    })
+            const after = await db.select({ reportId: reports.reportId }).from(reports)
+            expect(after).toEqual([{ reportId: inserted.reportId }])
+        },
+        reSeedTimeout
+    )
 
     // The seed loads reference data additively and never removes a station a report points at,
     // so a re-seed can't orphan a report. Prune only drops line-less stations with no reports.
-    it('does not prune a report-referenced station that lost its line associations', async () => {
-        const [lineStation] = await db
-            .select({ lineId: lineStations.lineId, lat: stations.lat, lng: stations.lng })
-            .from(lineStations)
-            .innerJoin(stations, eq(stations.id, lineStations.stationId))
-            .limit(1)
-        if (!lineStation) throw new Error('expected seeded line station to exist')
+    it(
+        'does not prune a report-referenced station that lost its line associations',
+        async () => {
+            const [lineStation] = await db
+                .select({ lineId: lineStations.lineId, lat: stations.lat, lng: stations.lng })
+                .from(lineStations)
+                .innerJoin(stations, eq(stations.id, lineStations.stationId))
+                .limit(1)
+            if (!lineStation) throw new Error('expected seeded line station to exist')
 
-        await db.insert(stations).values({
-            id: temporaryStationId,
-            name: 'Report-referenced test station',
-            lat: lineStation.lat,
-            lng: lineStation.lng,
-        })
-        await db.insert(lineStations).values({
-            lineId: lineStation.lineId,
-            stationId: temporaryStationId,
-            order: 10_000,
-        })
+            await db.insert(stations).values({
+                id: temporaryStationId,
+                name: 'Report-referenced test station',
+                lat: lineStation.lat,
+                lng: lineStation.lng,
+            })
+            await db.insert(lineStations).values({
+                lineId: lineStation.lineId,
+                stationId: temporaryStationId,
+                order: 10_000,
+            })
 
-        const response = await sendReportRequest(
-            { stationId: temporaryStationId, lineId: lineStation.lineId, directionId: null },
-            createApp()
-        )
-        expect(response.status).toBe(200)
-        const inserted = (await response.json()) as { reportId: number }
+            const response = await sendReportRequest(
+                { stationId: temporaryStationId, lineId: lineStation.lineId, directionId: null },
+                createApp()
+            )
+            expect(response.status).toBe(200)
+            const inserted = (await response.json()) as { reportId: number }
 
-        // Drop its only line association so it becomes line-less before the re-seed.
-        await db.delete(lineStations).where(eq(lineStations.stationId, temporaryStationId))
+            // Drop its only line association so it becomes line-less before the re-seed.
+            await db.delete(lineStations).where(eq(lineStations.stationId, temporaryStationId))
 
-        await seedBaseData(db)
+            await seedBaseData(db)
 
-        const reportsAfter = await db
-            .select({ reportId: reports.reportId })
-            .from(reports)
-            .where(eq(reports.reportId, inserted.reportId))
-        expect(reportsAfter).toEqual([{ reportId: inserted.reportId }])
+            const reportsAfter = await db
+                .select({ reportId: reports.reportId })
+                .from(reports)
+                .where(eq(reports.reportId, inserted.reportId))
+            expect(reportsAfter).toEqual([{ reportId: inserted.reportId }])
 
-        const stationAfter = await db
-            .select({ id: stations.id })
-            .from(stations)
-            .where(eq(stations.id, temporaryStationId))
-        expect(stationAfter).toEqual([{ id: temporaryStationId }])
-    })
+            const stationAfter = await db
+                .select({ id: stations.id })
+                .from(stations)
+                .where(eq(stations.id, temporaryStationId))
+            expect(stationAfter).toEqual([{ id: temporaryStationId }])
+        },
+        reSeedTimeout
+    )
 })

--- a/packages/api-worker/wrangler.jsonc
+++ b/packages/api-worker/wrangler.jsonc
@@ -8,12 +8,23 @@
         "enabled": true,
     },
     "workers_dev": true,
-    "routes": [{ "pattern": "api.freifahren.org/*", "zone_name": "freifahren.org" }],
+    "routes": [
+        {
+            "pattern": "api.freifahren.org/*",
+            "zone_name": "freifahren.org",
+        },
+    ],
     "d1_databases": [
         {
             "binding": "DB",
             "database_name": "api-worker-db-eu",
             "database_id": "f8e11f14-15a5-42a8-8eba-5ab513175890",
+            "migrations_dir": "drizzle",
+        },
+        {
+            "binding": "DB_LEIPZIG",
+            "database_name": "api-worker-db-leipzig",
+            "database_id": "e590b909-ce9e-4b32-8761-8e86f2e036d3",
             "migrations_dir": "drizzle",
         },
     ],

--- a/packages/cities/src/berlin.ts
+++ b/packages/cities/src/berlin.ts
@@ -1,4 +1,5 @@
 import type { CityConfig } from './types'
+import { CITY_DATABASES } from './databases'
 
 // Few-shot examples appended to the Telegram extraction prompt. Tuned to teach
 // disambiguation the model gets wrong: slang names, direction-vs-station,
@@ -53,8 +54,8 @@ export const BERLIN: CityConfig = {
     displayName: 'Berlin',
     // D1 databases can't be renamed and we don't migrate data, so Berlin keeps
     // the existing database and its `DB` binding.
-    dbName: 'api-worker-db-eu',
-    dbBinding: 'DB',
+    dbName: CITY_DATABASES.berlin.dbName,
+    dbBinding: CITY_DATABASES.berlin.dbBinding,
     lang: 'de',
     map: {
         center: [13.388, 52.5162],

--- a/packages/cities/src/databases.ts
+++ b/packages/cities/src/databases.ts
@@ -1,0 +1,14 @@
+import type { CityDatabaseConfig } from './types'
+
+// This registry tracks provisioned city databases independently from city content.
+// A city can receive its isolated D1 schema before its transit configuration is ready.
+export const CITY_DATABASES = {
+    berlin: {
+        dbName: 'api-worker-db-eu',
+        dbBinding: 'DB',
+    },
+    leipzig: {
+        dbName: 'api-worker-db-leipzig',
+        dbBinding: 'DB_LEIPZIG',
+    },
+} as const satisfies Record<string, CityDatabaseConfig>

--- a/packages/cities/src/index.ts
+++ b/packages/cities/src/index.ts
@@ -1,8 +1,10 @@
 import { BERLIN } from './berlin'
+import { CITY_DATABASES } from './databases'
 import type { CityConfig } from './types'
 
 export * from './types'
 export { BERLIN }
+export { CITY_DATABASES }
 
 /**
  * The city registry: the single source of truth for everything that differs

--- a/packages/cities/src/types.ts
+++ b/packages/cities/src/types.ts
@@ -112,21 +112,13 @@ export interface CityMap {
  * from the hostname (or an explicit `?city=` param on the API); this registry is
  * the single source of truth for everything that differs between cities.
  */
-export interface CityConfig {
+export interface CityConfig extends CityDatabaseConfig {
     /** Stable identifier used as the registry key and the API `?city=` value. */
     slug: string
     /** Subdomain the city is served from (`<subdomain>.freifahren.org`). */
     subdomain: string
     /** Human-readable name shown in the UI. */
     displayName: string
-    /**
-     * D1 database name. Berlin keeps the existing `api-worker-db-eu` — D1
-     * databases can't be renamed and we don't migrate data. New cities follow
-     * `api-worker-db-<slug>`.
-     */
-    dbName: string
-    /** Static Worker binding name for this city's D1 database. */
-    dbBinding: string
     /** BCP-47 language tag for the city's primary language. */
     lang: string
     map: CityMap
@@ -135,4 +127,12 @@ export interface CityConfig {
     seed: CitySeedConfig
     telegram: CityTelegramProfile
     community: CityCommunity
+}
+
+/** The D1 resources provisioned for each city. */
+export interface CityDatabaseConfig {
+    /** D1 database name. */
+    dbName: string
+    /** Static Worker binding name for this city's D1 database. */
+    dbBinding: string
 }


### PR DESCRIPTION
## Summary

Provisions the isolated Leipzig D1 database and makes API deployment keep every city database on the same shared Drizzle schema.

Closes #765
Linear: [FRE-714](https://linear.app/freifahren/issue/FRE-714/create-leipzig-d1-eu-jurisdiction-db-leipzig-binding-migration-fan-out)

## Infrastructure contract

| City | D1 database | Worker binding |
| --- | --- | --- |
| Berlin | `api-worker-db-eu` | `DB` |
| Leipzig | `api-worker-db-leipzig` | `DB_LEIPZIG` |

The Leipzig database was created in the Freifahren Cloudflare account with D1 jurisdiction `eu`. Its immutable database ID is recorded in `packages/api-worker/wrangler.jsonc`; it shares the same `drizzle/` migration directory as Berlin.

`packages/cities/src/databases.ts` is the registry of provisioned city databases. It is intentionally separate from runtime city configuration: Leipzig can receive schema migrations before FRE-715 introduces Leipzig transit data and makes it selectable by requests or the seed matrix.

## Deployment behavior

Before the Worker is seeded or deployed, the new `migrate` job:

1. Reads every binding from `CITY_DATABASES`.
2. Runs `wrangler d1 migrations apply <binding> --remote` for each.
3. Queries each database's `d1_migrations` ledger for its newest migration.
4. Fails loudly if any database has no applied migration or differs from the others.

The seed job now waits for this migration job, avoiding concurrent migration attempts. The deployment waits for both jobs.

The seed CLI still applies migrations defensively before it builds/loads reference data. That is harmless and idempotent, but a city-aware shared migration helper is tracked separately in [FRE-743](https://linear.app/freifahren/issue/FRE-743/make-d1-migration-commands-city-aware).

## Validation

- `wrangler deploy --dry-run` confirmed both `DB` and `DB_LEIPZIG` bindings are valid.
- Confirmed remote Leipzig D1 connectivity with a read-only query.
- Confirmed the database reports `jurisdiction: eu`.

@codex review