### PR TITLE
feat: add frontend preview deployments per PR

### DIFF
--- a/.github/workflows/frontend-preview.yml
+++ b/.github/workflows/frontend-preview.yml
@@ -53,7 +53,6 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
-            issues: write
             pull-requests: write
         defaults:
             run:
@@ -92,28 +91,34 @@ jobs:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-            - name: Comment preview link on pull request
+            - name: Add preview link to the pull request description
               uses: actions/github-script@v7
               env:
                   PREVIEW_URL: ${{ steps.deploy.outputs.url }}
               with:
                   script: |
-                      const marker = '<!-- frontend-preview -->'
-                      const body = `${marker}\n🚀 Frontend preview: [Open preview](${process.env.PREVIEW_URL})\n\nThis preview uses the production API.`
+                      // A marked block appended to the PR body (not a separate comment) so the link
+                      // lives in the description. The markers let us update it in place on every push
+                      // and leave the author's own description untouched.
+                      const startMarker = '<!-- frontend-preview:start -->'
+                      const endMarker = '<!-- frontend-preview:end -->'
+                      const block = [
+                        startMarker,
+                        `🚀 **Frontend preview:** [Open preview](${process.env.PREVIEW_URL})`,
+                        '',
+                        '_This preview uses the production API._',
+                        endMarker,
+                      ].join('\n')
                       const { owner, repo } = context.repo
-                      const issue_number = context.issue.number
-                      const comments = await github.paginate(github.rest.issues.listComments, {
-                        owner,
-                        repo,
-                        issue_number,
-                      })
-                      const existing = comments.find(
-                        (comment) => comment.user.type === 'Bot' && comment.body?.includes(marker)
-                      )
-                      if (existing) {
-                        await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
-                      } else {
-                        await github.rest.issues.createComment({ owner, repo, issue_number, body })
+                      const pull_number = context.issue.number
+                      const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number })
+                      const body = pr.body ?? ''
+                      const region = new RegExp(`${startMarker}[\\s\\S]*?${endMarker}`)
+                      const nextBody = region.test(body)
+                        ? body.replace(region, block)
+                        : `${body.trimEnd()}${body.trim() ? '\n\n' : ''}${block}\n`
+                      if (nextBody !== body) {
+                        await github.rest.pulls.update({ owner, repo, pull_number, body: nextBody })
                       }
 
     cleanup:
@@ -126,6 +131,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+            pull-requests: write
         defaults:
             run:
                 working-directory: packages/frontend-next
@@ -162,3 +168,21 @@ jobs:
               env:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+            - name: Remove preview link from the pull request description
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      // The Worker is gone, so drop the preview block from the description to avoid
+                      // leaving a dead "Open preview" link on the closed PR. No-op if it isn't there.
+                      const startMarker = '<!-- frontend-preview:start -->'
+                      const endMarker = '<!-- frontend-preview:end -->'
+                      const { owner, repo } = context.repo
+                      const pull_number = context.issue.number
+                      const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number })
+                      const body = pr.body ?? ''
+                      const region = new RegExp(`\\n*${startMarker}[\\s\\S]*?${endMarker}\\n*`)
+                      const nextBody = body.replace(region, '\n')
+                      if (nextBody !== body) {
+                        await github.rest.pulls.update({ owner, repo, pull_number, body: nextBody.trimEnd() })
+                      }

--- a/.github/workflows/frontend-preview.yml
+++ b/.github/workflows/frontend-preview.yml
@@ -1,21 +1,54 @@
 name: Frontend preview
 
+# No `paths:` filter here on purpose: it would also gate the `closed` event, so a PR that deployed
+# a preview and then moved its frontend/cities changes out of the diff before closing would never
+# trigger cleanup, leaving the `frontend-pr-<n>` Worker (and its cost) behind. The path check lives
+# on the `changes` job below instead, which only gates deployment.
 on:
     pull_request:
         types: [opened, reopened, synchronize, closed]
-        paths:
-            - 'packages/frontend-next/**'
-            - 'packages/cities/**'
-            - '.github/workflows/frontend-preview.yml'
 
 concurrency:
     group: frontend-preview-${{ github.event.pull_request.number }}
     cancel-in-progress: false
 
 jobs:
+    # Deployment path check (see the note on `on:` above). Runs only for non-close events; the
+    # deploy job consumes its output so previews are still limited to frontend/cities changes.
+    changes:
+        if: github.event.action != 'closed'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: read
+        outputs:
+            frontend: ${{ steps.filter.outputs.frontend }}
+        steps:
+            - name: Detect frontend changes
+              id: filter
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const { owner, repo } = context.repo
+                      const files = await github.paginate(github.rest.pulls.listFiles, {
+                        owner,
+                        repo,
+                        pull_number: context.issue.number,
+                        per_page: 100,
+                      })
+                      const patterns = [
+                        /^packages\/frontend-next\//,
+                        /^packages\/cities\//,
+                        /^\.github\/workflows\/frontend-preview\.yml$/,
+                      ]
+                      const changed = files.some((file) => patterns.some((pattern) => pattern.test(file.filename)))
+                      core.setOutput('frontend', changed ? 'true' : 'false')
+
     deploy:
+        needs: changes
         if: >-
             github.event.action != 'closed' &&
+            needs.changes.outputs.frontend == 'true' &&
             github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest
         permissions:
@@ -84,6 +117,9 @@ jobs:
                       }
 
     cleanup:
+        # Runs for every closed PR from this repo (no path gate) so a preview can never outlive its
+        # PR, even if the frontend changes were reverted before closing. The delete is idempotent:
+        # a PR that never deployed a preview is a no-op rather than a failure.
         if: >-
             github.event.action == 'closed' &&
             github.event.pull_request.head.repo.full_name == github.repository
@@ -98,8 +134,31 @@ jobs:
             - name: Check out code
               uses: actions/checkout@v4
 
+            - name: Set up Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
             - name: Delete preview worker
-              run: bunx wrangler@latest delete --name "frontend-pr-${{ github.event.pull_request.number }}" --force
+              run: |
+                  set -uo pipefail
+                  worker_name="frontend-pr-${{ github.event.pull_request.number }}"
+                  output=$(bunx wrangler@latest delete --name "$worker_name" --force 2>&1)
+                  status=$?
+                  echo "$output"
+                  if [ "$status" -eq 0 ]; then
+                    echo "Deleted preview worker $worker_name."
+                    exit 0
+                  fi
+                  # A PR that never deployed a preview (or was already cleaned up) has no Worker to
+                  # delete — Cloudflare returns script_not_found (code 10007). That is expected, not a
+                  # failure. Any other error (auth, network) must fail loudly so a real leak is noticed.
+                  if echo "$output" | grep -qiE 'code: *10007|script_not_found|workers\.api\.error\.not_found'; then
+                    echo "No preview worker named $worker_name exists; nothing to clean up."
+                    exit 0
+                  fi
+                  echo "Failed to delete preview worker $worker_name (exit $status)." >&2
+                  exit "$status"
               env:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/frontend-preview.yml
+++ b/.github/workflows/frontend-preview.yml
@@ -53,6 +53,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+            issues: write
             pull-requests: write
         defaults:
             run:
@@ -91,34 +92,28 @@ jobs:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-            - name: Add preview link to the pull request description
+            - name: Comment preview link on pull request
               uses: actions/github-script@v7
               env:
                   PREVIEW_URL: ${{ steps.deploy.outputs.url }}
               with:
                   script: |
-                      // A marked block appended to the PR body (not a separate comment) so the link
-                      // lives in the description. The markers let us update it in place on every push
-                      // and leave the author's own description untouched.
-                      const startMarker = '<!-- frontend-preview:start -->'
-                      const endMarker = '<!-- frontend-preview:end -->'
-                      const block = [
-                        startMarker,
-                        `🚀 **Frontend preview:** [Open preview](${process.env.PREVIEW_URL})`,
-                        '',
-                        '_This preview uses the production API._',
-                        endMarker,
-                      ].join('\n')
+                      const marker = '<!-- frontend-preview -->'
+                      const body = `${marker}\n🚀 Frontend preview: [Open preview](${process.env.PREVIEW_URL})\n\nThis preview uses the production API.`
                       const { owner, repo } = context.repo
-                      const pull_number = context.issue.number
-                      const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number })
-                      const body = pr.body ?? ''
-                      const region = new RegExp(`${startMarker}[\\s\\S]*?${endMarker}`)
-                      const nextBody = region.test(body)
-                        ? body.replace(region, block)
-                        : `${body.trimEnd()}${body.trim() ? '\n\n' : ''}${block}\n`
-                      if (nextBody !== body) {
-                        await github.rest.pulls.update({ owner, repo, pull_number, body: nextBody })
+                      const issue_number = context.issue.number
+                      const comments = await github.paginate(github.rest.issues.listComments, {
+                        owner,
+                        repo,
+                        issue_number,
+                      })
+                      const existing = comments.find(
+                        (comment) => comment.user.type === 'Bot' && comment.body?.includes(marker)
+                      )
+                      if (existing) {
+                        await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+                      } else {
+                        await github.rest.issues.createComment({ owner, repo, issue_number, body })
                       }
 
     cleanup:
@@ -131,7 +126,6 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
-            pull-requests: write
         defaults:
             run:
                 working-directory: packages/frontend-next
@@ -168,21 +162,3 @@ jobs:
               env:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-            - name: Remove preview link from the pull request description
-              uses: actions/github-script@v7
-              with:
-                  script: |
-                      // The Worker is gone, so drop the preview block from the description to avoid
-                      // leaving a dead "Open preview" link on the closed PR. No-op if it isn't there.
-                      const startMarker = '<!-- frontend-preview:start -->'
-                      const endMarker = '<!-- frontend-preview:end -->'
-                      const { owner, repo } = context.repo
-                      const pull_number = context.issue.number
-                      const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number })
-                      const body = pr.body ?? ''
-                      const region = new RegExp(`\\n*${startMarker}[\\s\\S]*?${endMarker}\\n*`)
-                      const nextBody = body.replace(region, '\n')
-                      if (nextBody !== body) {
-                        await github.rest.pulls.update({ owner, repo, pull_number, body: nextBody.trimEnd() })
-                      }

--- a/.github/workflows/frontend-preview.yml
+++ b/.github/workflows/frontend-preview.yml
@@ -21,6 +21,7 @@ jobs:
         permissions:
             contents: read
             issues: write
+            pull-requests: write
         defaults:
             run:
                 working-directory: packages/frontend-next

--- a/.github/workflows/frontend-preview.yml
+++ b/.github/workflows/frontend-preview.yml
@@ -1,0 +1,104 @@
+name: Frontend preview
+
+on:
+    pull_request:
+        types: [opened, reopened, synchronize, closed]
+        paths:
+            - 'packages/frontend-next/**'
+            - 'packages/cities/**'
+            - '.github/workflows/frontend-preview.yml'
+
+concurrency:
+    group: frontend-preview-${{ github.event.pull_request.number }}
+    cancel-in-progress: false
+
+jobs:
+    deploy:
+        if: >-
+            github.event.action != 'closed' &&
+            github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            issues: write
+        defaults:
+            run:
+                working-directory: packages/frontend-next
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Set up Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install dependencies
+              run: bun install --frozen-lockfile
+
+            - name: Build preview against the production API
+              run: bun run build
+              env:
+                  VITE_API_URL: https://api.freifahren.org
+
+            - name: Deploy preview worker
+              id: deploy
+              run: |
+                  set -euo pipefail
+                  worker_name="frontend-pr-${{ github.event.pull_request.number }}"
+                  bunx wrangler@latest deploy --config wrangler.preview.jsonc --name "$worker_name"
+                  subdomain=$(curl --fail --silent --show-error \
+                    --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+                    "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/subdomain" \
+                    | jq --exit-status --raw-output '.result.subdomain')
+                  url="https://${worker_name}.${subdomain}.workers.dev"
+                  echo "url=$url" >> "$GITHUB_OUTPUT"
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+            - name: Comment preview link on pull request
+              uses: actions/github-script@v7
+              env:
+                  PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+              with:
+                  script: |
+                      const marker = '<!-- frontend-preview -->'
+                      const body = `${marker}\n🚀 Frontend preview: [Open preview](${process.env.PREVIEW_URL})\n\nThis preview uses the production API.`
+                      const { owner, repo } = context.repo
+                      const issue_number = context.issue.number
+                      const comments = await github.paginate(github.rest.issues.listComments, {
+                        owner,
+                        repo,
+                        issue_number,
+                      })
+                      const existing = comments.find(
+                        (comment) => comment.user.type === 'Bot' && comment.body?.includes(marker)
+                      )
+                      if (existing) {
+                        await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+                      } else {
+                        await github.rest.issues.createComment({ owner, repo, issue_number, body })
+                      }
+
+    cleanup:
+        if: >-
+            github.event.action == 'closed' &&
+            github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        defaults:
+            run:
+                working-directory: packages/frontend-next
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Delete preview worker
+              run: bunx wrangler@latest delete --name "frontend-pr-${{ github.event.pull_request.number }}" --force
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -15,6 +15,10 @@ export type Bindings = {
     DB?: D1Database
     DB_LEIPZIG?: D1Database
     CORS_ORIGINS?: string
+    // This repo's Cloudflare account subdomain (e.g. `freifahren` for `*.freifahren.workers.dev`).
+    // Scopes the frontend preview CORS allowance to our own account so another tenant can't claim
+    // The `frontend-pr-<n>` name pattern and gain production API access. Unset => no previews.
+    PREVIEW_WORKERS_SUBDOMAIN?: string
     NODE_ENV?: string
     TELEGRAM_WORKER_URL?: string
     REPORT_PASSWORD?: string
@@ -30,12 +34,25 @@ export type AppConfig = {
     corsOrigins: string[]
     telegramWorkerUrl?: string
     reportPassword?: string
+    // See PREVIEW_WORKERS_SUBDOMAIN on Bindings. Undefined disables preview-origin CORS entirely.
+    previewWorkersSubdomain?: string
 }
 
-const previewOriginPattern = /^https:\/\/frontend-pr-\d+\.[a-z0-9-]+\.workers\.dev$/
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
-export const isAllowedCorsOrigin = (origin: string, corsOrigins: string[]) =>
-    corsOrigins.includes(origin) || previewOriginPattern.test(origin)
+// Frontend previews are deployed as `frontend-pr-<n>.<our-subdomain>.workers.dev`. Pinning the
+// Subdomain (rather than accepting any `*.workers.dev` tenant) keeps a Worker in someone else's
+// Cloudflare account from claiming the same name pattern and being granted production API CORS.
+const buildPreviewOriginPattern = (subdomain: string) =>
+    new RegExp(`^https:\\/\\/frontend-pr-\\d+\\.${escapeRegExp(subdomain)}\\.workers\\.dev$`)
+
+export const isAllowedCorsOrigin = (origin: string, config: AppConfig) => {
+    if (config.corsOrigins.includes(origin)) {
+        return true
+    }
+    const { previewWorkersSubdomain } = config
+    return previewWorkersSubdomain !== undefined && buildPreviewOriginPattern(previewWorkersSubdomain).test(origin)
+}
 
 export type Services = {
     reportsService: ReportsService
@@ -71,6 +88,7 @@ export const resolveConfig = (env: Bindings): AppConfig => {
         corsOrigins,
         telegramWorkerUrl: env.TELEGRAM_WORKER_URL,
         reportPassword: env.REPORT_PASSWORD,
+        previewWorkersSubdomain: env.PREVIEW_WORKERS_SUBDOMAIN,
     }
 }
 

--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -32,6 +32,11 @@ export type AppConfig = {
     reportPassword?: string
 }
 
+const previewOriginPattern = /^https:\/\/frontend-pr-\d+\.[a-z0-9-]+\.workers\.dev$/
+
+export const isAllowedCorsOrigin = (origin: string, corsOrigins: string[]) =>
+    corsOrigins.includes(origin) || previewOriginPattern.test(origin)
+
 export type Services = {
     reportsService: ReportsService
     riskService: RiskService

--- a/packages/api-worker/src/index.ts
+++ b/packages/api-worker/src/index.ts
@@ -3,7 +3,7 @@ import { cors } from 'hono/cors'
 import { etag, RETAINED_304_HEADERS } from 'hono/etag'
 import { requestId } from 'hono/request-id'
 
-import { Env, registerContext } from './app-env'
+import { Env, isAllowedCorsOrigin, registerContext } from './app-env'
 import { handleError } from './common/error-handler'
 import { registerVersionedRoutes } from './common/router'
 import { getReports, getReportsByStation, postReport } from './modules/reports/'
@@ -42,7 +42,7 @@ export const createApp = () => {
         cors({
             origin: (origin, c) => {
                 const allowed = (c as Context<Env>).get('config').corsOrigins
-                return allowed.includes(origin) ? origin : null
+                return isAllowedCorsOrigin(origin, allowed) ? origin : null
             },
             allowHeaders: ['Accept', 'Content-Type', 'If-Modified-Since', 'If-None-Match', 'ff-platform'],
             allowMethods: ['GET', 'POST', 'OPTIONS'],

--- a/packages/api-worker/src/index.ts
+++ b/packages/api-worker/src/index.ts
@@ -41,8 +41,8 @@ export const createApp = () => {
         '*',
         cors({
             origin: (origin, c) => {
-                const allowed = (c as Context<Env>).get('config').corsOrigins
-                return isAllowedCorsOrigin(origin, allowed) ? origin : null
+                const config = (c as Context<Env>).get('config')
+                return isAllowedCorsOrigin(origin, config) ? origin : null
             },
             allowHeaders: ['Accept', 'Content-Type', 'If-Modified-Since', 'If-None-Match', 'ff-platform'],
             allowMethods: ['GET', 'POST', 'OPTIONS'],

--- a/packages/api-worker/tests/generalAPI.test.ts
+++ b/packages/api-worker/tests/generalAPI.test.ts
@@ -102,6 +102,9 @@ describe('CORS', () => {
     const PREVIEW_ORIGIN = 'https://frontend-pr-744.freifahren.workers.dev'
     const DISALLOWED_ORIGIN = 'https://not-on-the-list.example'
     const MALFORMED_PREVIEW_ORIGIN = 'https://frontend-pr-not-a-number.freifahren.workers.dev'
+    // Same name pattern, but a foreign Cloudflare account subdomain — must be rejected so another
+    // tenant can't impersonate our previews and gain production API CORS access.
+    const FOREIGN_PREVIEW_ORIGIN = 'https://frontend-pr-744.someone-else.workers.dev'
 
     it('does not echo a disallowed origin', async () => {
         const response = await app.request(
@@ -143,17 +146,20 @@ describe('CORS', () => {
         expect(response.headers.get('Access-Control-Allow-Origin')).toBe(PREVIEW_ORIGIN)
     })
 
-    it.each([DISALLOWED_ORIGIN, MALFORMED_PREVIEW_ORIGIN])('does not grant a preflight from %s', async (origin) => {
-        const response = await appRequestWithRedirect('/reports', {
-            method: 'OPTIONS',
-            headers: {
-                Origin: origin,
-                'Access-Control-Request-Method': 'POST',
-            },
-        })
+    it.each([DISALLOWED_ORIGIN, MALFORMED_PREVIEW_ORIGIN, FOREIGN_PREVIEW_ORIGIN])(
+        'does not grant a preflight from %s',
+        async (origin) => {
+            const response = await appRequestWithRedirect('/reports', {
+                method: 'OPTIONS',
+                headers: {
+                    Origin: origin,
+                    'Access-Control-Request-Method': 'POST',
+                },
+            })
 
-        expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull()
-    })
+            expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull()
+        }
+    )
 })
 
 describe('Transit cache headers', () => {

--- a/packages/api-worker/tests/generalAPI.test.ts
+++ b/packages/api-worker/tests/generalAPI.test.ts
@@ -99,7 +99,9 @@ describe('ETag 304 + CORS', () => {
 
 describe('CORS', () => {
     const ALLOWED_ORIGIN = 'http://localhost:1871'
+    const PREVIEW_ORIGIN = 'https://frontend-pr-744.freifahren.workers.dev'
     const DISALLOWED_ORIGIN = 'https://not-on-the-list.example'
+    const MALFORMED_PREVIEW_ORIGIN = 'https://frontend-pr-not-a-number.freifahren.workers.dev'
 
     it('does not echo a disallowed origin', async () => {
         const response = await app.request(
@@ -113,18 +115,14 @@ describe('CORS', () => {
     })
 
     it('grants a preflight from an allowed origin', async () => {
-        const response = await app.request(
-            '/v0/reports',
-            {
-                method: 'OPTIONS',
-                headers: {
-                    Origin: ALLOWED_ORIGIN,
-                    'Access-Control-Request-Method': 'POST',
-                    'Access-Control-Request-Headers': 'Content-Type',
-                },
+        const response = await appRequestWithRedirect('/reports', {
+            method: 'OPTIONS',
+            headers: {
+                Origin: ALLOWED_ORIGIN,
+                'Access-Control-Request-Method': 'POST',
+                'Access-Control-Request-Headers': 'Content-Type',
             },
-            testEnv()
-        )
+        })
 
         expect(response.status).toBe(204)
         expect(response.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED_ORIGIN)
@@ -132,18 +130,27 @@ describe('CORS', () => {
         expect(response.headers.get('Access-Control-Allow-Headers')).toContain('Content-Type')
     })
 
-    it('does not grant a preflight from a disallowed origin', async () => {
-        const response = await app.request(
-            '/v0/reports',
-            {
-                method: 'OPTIONS',
-                headers: {
-                    Origin: DISALLOWED_ORIGIN,
-                    'Access-Control-Request-Method': 'POST',
-                },
+    it('grants a preflight from a frontend preview origin', async () => {
+        const response = await appRequestWithRedirect('/reports', {
+            method: 'OPTIONS',
+            headers: {
+                Origin: PREVIEW_ORIGIN,
+                'Access-Control-Request-Method': 'POST',
             },
-            testEnv()
-        )
+        })
+
+        expect(response.status).toBe(204)
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBe(PREVIEW_ORIGIN)
+    })
+
+    it.each([DISALLOWED_ORIGIN, MALFORMED_PREVIEW_ORIGIN])('does not grant a preflight from %s', async (origin) => {
+        const response = await appRequestWithRedirect('/reports', {
+            method: 'OPTIONS',
+            headers: {
+                Origin: origin,
+                'Access-Control-Request-Method': 'POST',
+            },
+        })
 
         expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull()
     })

--- a/packages/api-worker/tests/generalAPI.test.ts
+++ b/packages/api-worker/tests/generalAPI.test.ts
@@ -102,9 +102,6 @@ describe('CORS', () => {
     const PREVIEW_ORIGIN = 'https://frontend-pr-744.freifahren.workers.dev'
     const DISALLOWED_ORIGIN = 'https://not-on-the-list.example'
     const MALFORMED_PREVIEW_ORIGIN = 'https://frontend-pr-not-a-number.freifahren.workers.dev'
-    // Same name pattern, but a foreign Cloudflare account subdomain — must be rejected so another
-    // tenant can't impersonate our previews and gain production API CORS access.
-    const FOREIGN_PREVIEW_ORIGIN = 'https://frontend-pr-744.someone-else.workers.dev'
 
     it('does not echo a disallowed origin', async () => {
         const response = await app.request(
@@ -146,20 +143,17 @@ describe('CORS', () => {
         expect(response.headers.get('Access-Control-Allow-Origin')).toBe(PREVIEW_ORIGIN)
     })
 
-    it.each([DISALLOWED_ORIGIN, MALFORMED_PREVIEW_ORIGIN, FOREIGN_PREVIEW_ORIGIN])(
-        'does not grant a preflight from %s',
-        async (origin) => {
-            const response = await appRequestWithRedirect('/reports', {
-                method: 'OPTIONS',
-                headers: {
-                    Origin: origin,
-                    'Access-Control-Request-Method': 'POST',
-                },
-            })
+    it.each([DISALLOWED_ORIGIN, MALFORMED_PREVIEW_ORIGIN])('does not grant a preflight from %s', async (origin) => {
+        const response = await appRequestWithRedirect('/reports', {
+            method: 'OPTIONS',
+            headers: {
+                Origin: origin,
+                'Access-Control-Request-Method': 'POST',
+            },
+        })
 
-            expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull()
-        }
-    )
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull()
+    })
 })
 
 describe('Transit cache headers', () => {

--- a/packages/api-worker/tests/test-utils.ts
+++ b/packages/api-worker/tests/test-utils.ts
@@ -22,6 +22,7 @@ export const resetTestEnv = () => {
 export const testEnv = (): Bindings => ({
     DB: workerEnv.DB,
     CORS_ORIGINS: overrides.CORS_ORIGINS ?? workerEnv.CORS_ORIGINS,
+    PREVIEW_WORKERS_SUBDOMAIN: overrides.PREVIEW_WORKERS_SUBDOMAIN ?? workerEnv.PREVIEW_WORKERS_SUBDOMAIN,
     NODE_ENV: overrides.NODE_ENV ?? workerEnv.NODE_ENV,
     TELEGRAM_WORKER_URL: overrides.TELEGRAM_WORKER_URL ?? workerEnv.TELEGRAM_WORKER_URL,
     REPORT_PASSWORD: overrides.REPORT_PASSWORD ?? workerEnv.REPORT_PASSWORD,

--- a/packages/api-worker/vitest.config.ts
+++ b/packages/api-worker/vitest.config.ts
@@ -33,6 +33,7 @@ export default defineWorkersConfig(async () => {
                             TEST_MIGRATIONS: migrations,
                             CORS_ORIGINS:
                                 'http://localhost,http://localhost:1871,http://127.0.0.1:1871,capacitor://localhost',
+                            PREVIEW_WORKERS_SUBDOMAIN: 'freifahren',
                             NODE_ENV: 'development',
                             REPORT_PASSWORD: 'password',
                             TELEGRAM_WORKER_URL: 'https://telegram-worker.test',

--- a/packages/api-worker/wrangler.jsonc
+++ b/packages/api-worker/wrangler.jsonc
@@ -31,6 +31,8 @@
     "vars": {
         "NODE_ENV": "production",
         "CORS_ORIGINS": "https://freifahren.org,https://app.freifahren.org,https://www.freifahren.org,https://berlin.freifahren.org,https://leipzig.freifahren.org,http://localhost:1871,http://leipzig.localhost:1871,http://192.168.178.65:1871,capacitor://localhost",
+        // Scopes frontend preview CORS to `frontend-pr-<n>.freifahren.workers.dev` (our account only).
+        "PREVIEW_WORKERS_SUBDOMAIN": "freifahren",
         "TELEGRAM_WORKER_URL": "https://telegram-worker.freifahren.workers.dev",
         "SENTRY_DSN": "https://8f49e71a73d689efdcaabfd8794457b6@o4508609338867712.ingest.de.sentry.io/4511638467051600",
     },

--- a/packages/frontend-next/wrangler.preview.jsonc
+++ b/packages/frontend-next/wrangler.preview.jsonc
@@ -1,0 +1,13 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "frontend-pr-preview",
+  "compatibility_date": "2026-05-31",
+  "main": "./worker/index.ts",
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/relay/*"],
+  },
+  "workers_dev": true,
+}


### PR DESCRIPTION
## Summary

- deploy a route-free `frontend-pr-<number>` Worker for same-repository frontend PRs and post/update its `workers.dev` link
- delete that Worker when the PR closes
- allow numbered frontend preview origins through API CORS

Preview frontends deliberately use the production API.

## Validation

- `packages/frontend-next`: format check, lint, production-API build, and `wrangler deploy --dry-run`
- `packages/api-worker`: format check, lint, and focused CORS integration tests (18 passing)
- Full API suite: 141 passing; 3 existing time-based prediction-threshold failures in `tests/getReports.test.ts`

<!-- frontend-preview:start -->
🚀 **Frontend preview:** [Open preview](https://frontend-pr-822.freifahren.workers.dev)

_This preview uses the production API._
<!-- frontend-preview:end -->
