### PR TITLE
feat: build Leipzig basemap tiles

### DIFF
--- a/packages/cities/src/leipzig.ts
+++ b/packages/cities/src/leipzig.ts
@@ -35,6 +35,7 @@ export const LEIPZIG: CityConfig = {
     },
     tiles: {
         osmUrl: 'https://download.geofabrik.de/europe/germany/sachsen-latest.osm.pbf',
+        clipToMapBounds: true,
     },
     seed: {
         adminLevel: '^6$',

--- a/packages/cities/src/types.ts
+++ b/packages/cities/src/types.ts
@@ -98,6 +98,8 @@ export interface CityCommunity {
 export interface CityTiles {
     /** Geofabrik OSM extract the basemap is built from. */
     osmUrl: string
+    /** Crop this regional extract to `map.bounds` before generating the archive. */
+    clipToMapBounds?: boolean
 }
 
 /** Map defaults for the city's basemap. */
@@ -106,7 +108,7 @@ export interface CityMap {
     center: LngLat
     /** Initial zoom level. */
     zoom: number
-    /** Metro-area extent. Not yet consumed by the frontend; recorded for camera/bounds work. */
+    /** Metro-area extent. Used for optional tile cropping. */
     bounds: BBox
     /** URL of the MapLibre style JSON served by the tile-server. */
     styleUrl: string

--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -29,7 +29,9 @@ import { REPORTS_HIT_LAYER_ID } from '../../hooks/useReportsLayer';
 import { useRiskLayer } from '../../hooks/useRiskLayer';
 import { useStationSelection } from '../../hooks/useStationSelection';
 
-const MAP_STYLE_URL = currentCity.map.styleUrl;
+const MAP_STYLE_URL = import.meta.env.VITE_TILES_BASE_URL
+  ? `${import.meta.env.VITE_TILES_BASE_URL}/styles/${currentCity.slug}.json`
+  : currentCity.map.styleUrl;
 
 const INITIAL_VIEW = {
   longitude: currentCity.map.center[0],

--- a/packages/tile-server/README.md
+++ b/packages/tile-server/README.md
@@ -16,6 +16,8 @@ city in it (each carries a `tiles` block with its Geofabrik `osmUrl`). There is 
 - `tilemaker/` — Tilemaker config + Lua that map OSM into the basemap layers (city-agnostic).
 - `source/freifahren-style.json` — the source MapLibre style (the only committed `source/` file).
 - `scripts/generate.ts` — download extract → tilemaker → `dist/<city>.pmtiles` + `dist/styles/<city>.json`.
+  Leipzig opts into a crop to its configured `map.bounds` before tile generation, keeping its archive
+  focused on the city rather than all of Saxony.
 - `styles/rewrite-style.ts` — points the style at a city's archive (pure function used by `generate.ts`).
 - `styles/serve.ts` — a range-capable static server for local `dist/`.
 - `fonts/` — TTF the glyph PBFs would be generated from (unused until the style gets text layers).
@@ -36,7 +38,7 @@ bun run serve        # serve dist/ with range + CORS on http://localhost:3000
 Then point the frontend at the local style:
 
 ```env
-VITE_MAP_STYLE_URL=http://localhost:3000/styles/berlin.json
+VITE_TILES_BASE_URL=http://localhost:3000
 ```
 
 `generate` downloads each city's OSM extract into `source/` on first run (cached afterwards). Locally

--- a/packages/tile-server/scripts/generate.ts
+++ b/packages/tile-server/scripts/generate.ts
@@ -10,7 +10,7 @@
 //   CITY              limit to one city (by slug); default: all buildable cities
 //   TILES_BASE_URL    style host; default http://localhost:3000 (the deploy sets the R2 domain)
 //   TILES_VERSION     immutable path segment, i.e. the git sha (deploy only); default none (flat path)
-import { mkdir } from 'node:fs/promises'
+import { mkdir, rename, unlink } from 'node:fs/promises'
 import { basename, resolve } from 'node:path'
 
 import { CITIES } from '@freifahren/cities'
@@ -23,6 +23,7 @@ const DIST = resolve(PKG, 'dist')
 const SOURCE = resolve(PKG, 'source')
 const STYLE_SRC = resolve(SOURCE, 'freifahren-style.json')
 const BASE_CONFIG = resolve(PKG, 'tilemaker/config-freifahren.json')
+const OSMIUM_IMAGE = 'mschilde/osmium-tool@sha256:0495d0356b688e642b74b8cb64f140f7315e3bf2e4682701131b3bad30597285'
 
 const baseUrl = process.env.TILES_BASE_URL ?? 'http://localhost:3000'
 const version = process.env.TILES_VERSION ?? ''
@@ -58,22 +59,52 @@ const baseConfig = (await Bun.file(BASE_CONFIG).json()) as TilemakerConfig
 
 for (const city of selected) {
   // 1. OSM extract — download once if not already present locally.
-  const pbf = resolve(SOURCE, basename(new URL(city.tiles.osmUrl).pathname))
-  if (!(await Bun.file(pbf).exists())) {
+  const sourcePbf = resolve(SOURCE, basename(new URL(city.tiles.osmUrl).pathname))
+  if (!(await Bun.file(sourcePbf).exists())) {
+    const partialSourcePbf = `${sourcePbf}.part`
+    await unlink(partialSourcePbf).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    })
     console.log(`↓ ${city.slug}: ${city.tiles.osmUrl}`)
-    // curl, not fetch + Bun.write: streaming the ~100 MB extract through Bun.write stalled on CI
-    // (the whole deploy hung). curl streams straight to disk and retries. --remove-on-error so an
-    // interrupted transfer can't leave a truncated file the exists() check above would later reuse.
-    const dl = Bun.spawn(['curl', '-fSL', '--retry', '3', '--remove-on-error', '-o', pbf, city.tiles.osmUrl], {
+    // A .part file is only renamed after curl succeeds, so an interrupted download cannot be
+    // mistaken for a cached source extract on the next build.
+    const dl = Bun.spawn(['curl', '-fSL', '--retry', '3', '--remove-on-error', '-o', partialSourcePbf, city.tiles.osmUrl], {
       stdout: 'inherit',
       stderr: 'inherit',
     })
     if ((await dl.exited) !== 0) throw new Error(`OSM download failed for ${city.slug}`)
+    await rename(partialSourcePbf, sourcePbf)
   }
 
-  // 2. Per-city tilemaker config: base tuning + this city's identity, written into dist/
-  // (inside the /work mount) so tilemaker can read it. The archive's suggested view is
-  // the city's map center + zoom — one source, no drift.
+  const pbf = city.tiles.clipToMapBounds ? resolve(SOURCE, `${city.slug}.osm.pbf`) : sourcePbf
+  if (city.tiles.clipToMapBounds) {
+    console.log(`✂ ${city.slug}: crop to map bounds`)
+    const crop = Bun.spawn(
+      [
+        'docker',
+        'run',
+        '--rm',
+        '-v',
+        `${REPO}:/work`,
+        '-w',
+        '/work',
+        OSMIUM_IMAGE,
+        'osmium',
+        'extract',
+        '--strategy=complete_ways',
+        `--bbox=${city.map.bounds.join(',')}`,
+        '--set-bounds',
+        '--overwrite',
+        '--output',
+        inContainer(pbf),
+        inContainer(sourcePbf),
+      ],
+      { stdout: 'inherit', stderr: 'inherit' },
+    )
+    if ((await crop.exited) !== 0) throw new Error(`OSM crop failed for ${city.slug}`)
+  }
+
+  // 2. Per-city tilemaker config: base tuning + this city's identity, written into dist/.
   const config = structuredClone(baseConfig)
   config.settings.name = `FreiFahren ${city.displayName} vector tiles`
   config.settings.description = `OSM-derived vector tiles for the FreiFahren ${city.displayName} basemap.`
@@ -110,6 +141,5 @@ for (const city of selected) {
   const style = (await Bun.file(STYLE_SRC).json()) as Style
   const rewritten = rewritePmtilesStyle(style, { city: city.slug, baseUrl, version })
   await Bun.write(resolve(DIST, 'styles', `${city.slug}.json`), `${JSON.stringify(rewritten, null, 2)}\n`)
-
   console.log(`✓ ${city.slug}: dist/${city.slug}.pmtiles + dist/styles/${city.slug}.json`)
 }


### PR DESCRIPTION
## Summary

Adds a Leipzig-specific basemap build alongside the existing Berlin archive.

Leipzig is sourced from Geofabrik's Saxony extract, then cropped to the Leipzig bounds before Tilemaker runs. The pipeline publishes the usual `leipzig.pmtiles` archive and `styles/leipzig.json` style, preserving the existing per-city R2 layout and immutable versioned archive URLs.

## Why

Building directly from the Saxony extract included far more data than the Leipzig map needs. The new registry flag keeps Leipzig's archive focused on its configured city extent while leaving Berlin's existing archive and behavior unchanged.

The crop is registry-driven rather than hard-coded: a city can opt in with `tiles.clipToMapBounds`, and the pipeline uses that city's `map.bounds`.

## Local development

Set:

```env
VITE_TILES_BASE_URL=http://localhost:3000
```

The frontend then resolves its city style from the local range-capable tile server, so `leipzig.localhost` uses the locally generated Leipzig PMTiles archive.

## Validation

- `bunx tsc --noEmit -p packages/cities/tsconfig.json`
- `cd packages/tile-server && bun run typecheck`
- `cd packages/tile-server && CITY=leipzig bun run generate`
- Verified `Range: bytes=0-1023` returns `206 Partial Content` for `leipzig.pmtiles`
- `cd packages/frontend-next && bun run build`

The resulting local Leipzig archive is 8.25 MB.

## Follow-up

[FRE-746](https://linear.app/freifahren/issue/FRE-746/serve-a-shared-germany-wide-basemap-with-city-camera-bounds) documents the separate future option of a Germany-wide online basemap with city camera bounds. It is intentionally out of scope for this PR.