### PR TITLE
feat: launch leipzig.freifahren.org

### DIFF
--- a/packages/frontend-next/index.html
+++ b/packages/frontend-next/index.html
@@ -36,6 +36,7 @@
       content="Sieh Ticketkontrollen auf der Karte und melde neue Kontrollen in Echtzeit."
     />
     <meta property="og:image" content="https://app.freifahren.org/og-image.jpg" />
+    <link rel="canonical" href="https://app.freifahren.org/" />
     <meta
       name="description"
       content="Freifahren ist eine Webapp, die es Nutzern ermöglicht Ticketkontrollen zu melden und sich vor Kontrollen zu warnen."

--- a/packages/frontend-next/public/robots.txt
+++ b/packages/frontend-next/public/robots.txt
@@ -1,4 +1,4 @@
-# app.freifahren.org is the web app, not our content surface. Disallow crawling
-# so it does not cannibalize freifahren.org in search results.
+# The city hosts are interactive web apps, not our content surface. Disallow crawling
+# so they do not cannibalize freifahren.org in search results.
 User-agent: *
 Disallow: /

--- a/packages/frontend-next/worker/index.ts
+++ b/packages/frontend-next/worker/index.ts
@@ -3,6 +3,32 @@ const API_HOST = 'eu.i.posthog.com';
 const ASSET_HOST = 'eu-assets.i.posthog.com';
 const PREFIX = '/relay';
 
+function withHostMetadata(response: Response, origin: string, method: string): Response {
+  if (method !== 'GET' || !response.headers.get('content-type')?.includes('text/html')) {
+    return response;
+  }
+
+  const canonicalUrl = `${origin}/`;
+
+  return new HTMLRewriter()
+    .on('meta[property="og:url"]', {
+      element(element) {
+        element.setAttribute('content', canonicalUrl);
+      },
+    })
+    .on('meta[property="og:image"]', {
+      element(element) {
+        element.setAttribute('content', `${canonicalUrl}og-image.jpg`);
+      },
+    })
+    .on('link[rel="canonical"]', {
+      element(element) {
+        element.setAttribute('href', canonicalUrl);
+      },
+    })
+    .transform(response);
+}
+
 interface Env {
   ASSETS: { fetch: (request: Request) => Promise<Response> };
 }
@@ -15,7 +41,7 @@ export default {
   async fetch(request: Request, env: Env, ctx: Ctx): Promise<Response> {
     const url = new URL(request.url);
     if (!url.pathname.startsWith(`${PREFIX}/`)) {
-      return env.ASSETS.fetch(request);
+      return withHostMetadata(await env.ASSETS.fetch(request), url.origin, request.method);
     }
 
     const upstreamPath = url.pathname.slice(PREFIX.length) + url.search;

--- a/packages/frontend-next/wrangler.jsonc
+++ b/packages/frontend-next/wrangler.jsonc
@@ -6,14 +6,27 @@
     "directory": "./dist",
     "binding": "ASSETS",
     "not_found_handling": "single-page-application",
-    // Without this the SPA fallback swallows /relay/* before the proxy Worker runs.
-    "run_worker_first": ["/relay/*"],
+    // HTML needs to pass through the Worker so it can set the host-specific canonical and Open
+    // Graph tags. Keep Vite's hashed bundle files on Cloudflare's direct asset path.
+    "run_worker_first": [
+      "/*",
+      "!/assets/*",
+      "!/favicon*",
+      "!/icons.svg",
+      "!/manifest.webmanifest",
+      "!/og-image.jpg",
+      "!/profiles/*",
+      "!/pwa-*",
+      "!/robots.txt",
+      "!/sw.js",
+      "!/workbox-*.js",
+    ],
   },
   // app.freifahren.org stays a Berlin alias (PWA install + Capacitor origin + App Store deep-link
-  // target); berlin.freifahren.org is the canonical per-city host. Both serve the same bundle,
-  // which resolves the city from the hostname at runtime.
+  // target); each city hostname serves the same bundle and resolves its city at runtime.
   "routes": [
     { "pattern": "app.freifahren.org", "custom_domain": true },
     { "pattern": "berlin.freifahren.org", "custom_domain": true },
+    { "pattern": "leipzig.freifahren.org", "custom_domain": true },
   ],
 }


### PR DESCRIPTION
## Summary

Launches `leipzig.freifahren.org` from the existing shared frontend Worker. The same bundle, manifest, social links, and PostHog configuration continue to serve Berlin and Leipzig; city selection remains a runtime hostname concern.

## What changes

- Registers `leipzig.freifahren.org` as a Cloudflare custom domain alongside `app.freifahren.org` and `berlin.freifahren.org`.
- Adds a canonical-link fallback to the shared HTML shell.
- Streams HTML through the Worker and derives `canonical`, `og:url`, and `og:image` from the request origin. This keeps social and crawler metadata correct for every routed hostname without maintaining a per-city metadata list.
- Keeps hashed assets on Cloudflare's direct static-asset path.
- Applies the existing no-index decision to all city application hosts: `freifahren.org` remains the content surface, while the host-specific apps are interactive clients.

## Deliberately shared for now

- The PWA manifest remains shared.
- Instagram/GitHub links remain shared.
- The PostHog `city-switcher` flag is unchanged and remains disabled in production. Direct navigation to `leipzig.freifahren.org` does not depend on that flag.
- PostHog and Sentry already tag events with the city resolved from the hostname.

## Validation

- `bun run lint` (passes with two existing TanStack Virtual / React Compiler warnings)
- `bun run format:check`
- `bun run build`
- `bunx wrangler@latest deploy --dry-run`
- Leipzig API smoke checks:
  - stations: 200 (230 stations)
  - reports: 200
  - risk: 200
- Leipzig tile style and PMTiles range request: 206

The in-app browser session was unavailable during the smoke test, so interactive map rendering was not independently observed in this run.