### PR TITLE
fix: register PostHog version before startup events

### DIFF
--- a/packages/frontend-next/src/lib/posthog-client.ts
+++ b/packages/frontend-next/src/lib/posthog-client.ts
@@ -59,7 +59,7 @@ export function loadPostHog(): Promise<void> {
   }
   const apiHost = optionalEnv('VITE_POSTHOG_HOST') ?? 'https://eu.i.posthog.com';
 
-  loadPromise = import('posthog-js').then(({ default: posthog }) => {
+  loadPromise = import('posthog-js').then(async ({ default: posthog }) => {
     posthog.init(apiKey, {
       api_host: apiHost,
       // api_host is our reverse proxy in prod; keep PostHog UI/toolbar links on the real app.
@@ -93,11 +93,12 @@ export function loadPostHog(): Promise<void> {
       is_native: Capacitor.isNativePlatform(),
       city: currentCitySlug,
     });
+    // Native version discovery awaits @capacitor/app. Finish it before startup events become
+    // observable so the first pageview has the same super properties as later events.
+    await registerVersion(posthog);
     instance = posthog;
     for (const op of queue) op(posthog);
     queue.length = 0;
-    // Trails the register above because it awaits a native plugin call.
-    void registerVersion(posthog);
   });
   // Analytics is non-critical: a content blocker or a stale chunk can make the dynamic import
   // resolve empty (destructuring `default` then throws) or reject outright. Swallow it and disable


### PR DESCRIPTION
## Summary

Registers the PostHog runtime metadata, including the native app version, before exposing the client instance and flushing buffered startup events.

## Root cause

The app captures the router's initial `$pageview` before PostHog is lazy-loaded. `loadPostHog()` registered platform and city, then exposed the instance and flushed that buffered event before `registerVersion()` completed. On web, version registration runs synchronously before its first await; on native, `@capacitor/app` version discovery is asynchronous, so the initial pageview could be sent with `platform` but without `app_version`.

## Scope

This fixes the current-client first-pageview gap only. Historical events from legacy app shells with no `platform`, `app_version`, or `bundle_build` remain unknown and are not backfilled. The `city-switcher` PostHog flag is unchanged.

## Validation

- Triggered fresh local frontend pageviews in the in-app Browser using the production PostHog environment.
- Queried the resulting events with PostHog HogQL. Fresh web pageviews contained `platform=web`, `app_version`, and `bundle_build`; current native events with an iOS platform and bundle build but no app version corroborated the asynchronous ordering gap.
- Ran `bun run lint` (existing React Compiler warnings only), `bun run format:check`, and `bun run build` in `packages/frontend-next`.

No practical frontend module test runner is configured; browser-to-PostHog verification and the production build cover this narrowly scoped initialization ordering change.