### PR TITLE
fix: refresh PWA after service-worker update

### DIFF
--- a/.github/workflows/frontend-next-ci.yml
+++ b/.github/workflows/frontend-next-ci.yml
@@ -28,6 +28,9 @@ jobs:
             - name: Install dependencies
               run: bun install --frozen-lockfile
 
+            - name: Install API test dependencies
+              run: bun --cwd ../api-worker install --frozen-lockfile
+
             - name: Run Prettier check
               run: bun run format:check
 
@@ -38,3 +41,9 @@ jobs:
             # build failures — neither of which the lint/format steps above catch.
             - name: Run build
               run: bun run build
+
+            - name: Install Chromium
+              run: bunx playwright install --with-deps chromium
+
+            - name: Run PWA integration test
+              run: bun run test

--- a/.github/workflows/frontend-next-ci.yml
+++ b/.github/workflows/frontend-next-ci.yml
@@ -29,7 +29,7 @@ jobs:
               run: bun install --frozen-lockfile
 
             - name: Install API test dependencies
-              run: bun --cwd ../api-worker install --frozen-lockfile
+              run: bun install --cwd ../api-worker --frozen-lockfile
 
             - name: Run Prettier check
               run: bun run format:check

--- a/packages/api-worker/src/db/seed/seed-d1.ts
+++ b/packages/api-worker/src/db/seed/seed-d1.ts
@@ -35,6 +35,15 @@ const toSqlLiteral = (value: unknown): string => {
 // Invoke the locally-installed wrangler CLI (via npx so the package's own binary is used).
 const wrangler = (...args: string[]) => execFileSync('npx', ['wrangler', ...args], { stdio: 'inherit' })
 
+const parsePersistToArg = (argv: string[] = process.argv): string | undefined => {
+    const flag = argv.indexOf('--persist-to')
+    if (flag === -1) return undefined
+
+    const path = argv[flag + 1]
+    if (!path) throw new Error('--persist-to requires a directory path')
+    return path
+}
+
 // Dump the reference tables to additive INSERT OR IGNORE statements so a prod load leaves existing
 // Rows (and the reports that reference them) intact.
 const dumpReferenceTables = async (d1: D1Database): Promise<string> => {
@@ -52,6 +61,7 @@ const dumpReferenceTables = async (d1: D1Database): Promise<string> => {
 const seedD1 = async () => {
     const city = parseCityArg()
     const remote = process.argv.includes('--remote')
+    const persistTo = parsePersistToArg()
     process.env.SEED_CITY = city
 
     const binding = getCity(city)!.dbBinding
@@ -66,8 +76,11 @@ const seedD1 = async () => {
     logger.info({ city, binding, target: remote ? 'remote' : 'local' }, 'Seeding D1...')
 
     // Build the reference tables on the local Miniflare D1 via the shared pipeline.
-    wrangler('d1', 'migrations', 'apply', binding, '--local')
-    const { env, dispose } = await getPlatformProxy<Record<string, D1Database>>()
+    const localPersistenceArgs = persistTo !== undefined ? ['--persist-to', persistTo] : []
+    wrangler('d1', 'migrations', 'apply', binding, '--local', ...localPersistenceArgs)
+    const { env, dispose } = await getPlatformProxy<Record<string, D1Database>>(
+        persistTo !== undefined ? { persist: { path: join(persistTo, 'v3') } } : undefined
+    )
     try {
         const d1 = env[binding]
         await seedBaseData(createD1Db(d1))

--- a/packages/frontend-next/bun.lock
+++ b/packages/frontend-next/bun.lock
@@ -50,6 +50,7 @@
         "@capacitor/cli": "^8.4.0",
         "@capgo/cli": "^8.12.4",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.57.0",
         "@rolldown/plugin-babel": "^0.2.3",
         "@sentry/vite-plugin": "^5.3.0",
         "@tanstack/eslint-plugin-query": "^5.100.14",
@@ -450,6 +451,8 @@
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.132.0", "", {}, "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@posthog/core": ["@posthog/core@1.32.3", "", { "dependencies": { "@posthog/types": "1.386.3" } }, "sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA=="],
 
@@ -1909,6 +1912,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+
     "plist": ["plist@3.1.1", "", { "dependencies": { "@xmldom/xmldom": "^0.9.10", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA=="],
 
     "pmtiles": ["pmtiles@4.4.1", "", { "dependencies": { "fflate": "^0.8.2" } }, "sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA=="],
@@ -2886,6 +2893,8 @@
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
     "path-type/pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "posthog-js/fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 

--- a/packages/frontend-next/e2e/pwa-api-server.mjs
+++ b/packages/frontend-next/e2e/pwa-api-server.mjs
@@ -1,0 +1,35 @@
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const apiWorkerDir = fileURLToPath(new URL('../../api-worker/', import.meta.url));
+const persistencePath = await mkdtemp(join(tmpdir(), 'freifahren-pwa-api-'));
+
+const run = (command, args) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd: apiWorkerDir, stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} ${args.join(' ')} exited with ${code}`));
+    });
+  });
+
+await run('bun', ['run', 'seed', '--city', 'berlin', '--persist-to', persistencePath]);
+
+const worker = spawn(
+  'bunx',
+  ['wrangler', 'dev', '--local', '--port', '8787', '--persist-to', persistencePath],
+  { cwd: apiWorkerDir, stdio: 'inherit' },
+);
+
+const stop = () => {
+  worker.kill();
+  void rm(persistencePath, { recursive: true, force: true });
+};
+
+process.once('SIGINT', stop);
+process.once('SIGTERM', stop);
+worker.once('exit', (code) => process.exit(code ?? 1));

--- a/packages/frontend-next/e2e/pwa-offline.spec.ts
+++ b/packages/frontend-next/e2e/pwa-offline.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+test('serves the cached shell offline and fetches a fresh shell when online', async ({
+  browser,
+  baseURL,
+}) => {
+  const context = await browser.newContext();
+  const onlinePage = await context.newPage();
+
+  const firstResponse = await onlinePage.goto(`${baseURL}/?pwa-e2e=first`);
+  expect(firstResponse?.headers()['x-pwa-e2e-shell-revision']).toBeDefined();
+  await expect(onlinePage.locator('#root > *')).not.toHaveCount(0);
+  const apiResponse = await onlinePage.evaluate(async () => {
+    const response = await fetch('http://localhost:8787/v0/transit/stations?city=berlin');
+    return { ok: response.ok, stationCount: Object.keys(await response.json()).length };
+  });
+  expect(apiResponse.ok).toBe(true);
+  expect(apiResponse.stationCount).toBeGreaterThan(0);
+  await onlinePage.waitForFunction(() => navigator.serviceWorker.controller !== null);
+  await expect
+    .poll(() =>
+      onlinePage.evaluate(async () => {
+        const cache = await caches.open('app-shell');
+        return Boolean(await cache.match('/'));
+      }),
+    )
+    .toBe(true);
+  const cachedRevision = await onlinePage.evaluate(async () => {
+    const cache = await caches.open('app-shell');
+    return (await cache.match('/'))?.headers.get('x-pwa-e2e-shell-revision');
+  });
+  expect(cachedRevision).toBeDefined();
+
+  await context.setOffline(true);
+  const offlinePage = await context.newPage();
+  const cachedResponse = await offlinePage.goto(`${baseURL}/`);
+  expect(cachedResponse?.headers()['x-pwa-e2e-shell-revision']).toBe(cachedRevision);
+  await expect(offlinePage.locator('#root > *')).not.toHaveCount(0);
+
+  await context.setOffline(false);
+  const freshResponse = await offlinePage.goto(`${baseURL}/?pwa-e2e=after-reconnect`);
+  expect(Number(freshResponse?.headers()['x-pwa-e2e-shell-revision'])).toBeGreaterThan(
+    Number(cachedRevision),
+  );
+
+  await context.close();
+});

--- a/packages/frontend-next/e2e/pwa-test-server.mjs
+++ b/packages/frontend-next/e2e/pwa-test-server.mjs
@@ -1,0 +1,44 @@
+import { createReadStream, existsSync } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { extname, join, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dist = fileURLToPath(new URL('../dist/', import.meta.url));
+const mimeTypes = {
+  '.css': 'text/css',
+  '.html': 'text/html',
+  '.ico': 'image/x-icon',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.woff2': 'font/woff2',
+};
+
+let shellRevision = 0;
+
+createServer(async (request, response) => {
+  const url = new URL(request.url, 'http://localhost');
+
+  if (url.pathname === '/health') {
+    response.writeHead(200).end();
+    return;
+  }
+
+  const relativePath = normalize(url.pathname).replace(/^[/\\]+/, '');
+  if (relativePath.startsWith('..')) {
+    response.writeHead(400).end();
+    return;
+  }
+  let file = join(dist, relativePath);
+  if (!relativePath || !existsSync(file) || (await stat(file)).isDirectory())
+    file = join(dist, 'index.html');
+
+  const isHtml = file.endsWith('.html');
+  response.writeHead(200, {
+    'content-type': mimeTypes[extname(file)] ?? 'application/octet-stream',
+    ...(isHtml ? { 'x-pwa-e2e-shell-revision': String(++shellRevision) } : {}),
+  });
+  createReadStream(file).pipe(response);
+}).listen(1871, 'localhost');

--- a/packages/frontend-next/package.json
+++ b/packages/frontend-next/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "playwright test"
   },
   "dependencies": {
     "@capacitor/app": "^8.1.0",
@@ -60,6 +61,7 @@
     "@capgo/cli": "^8.12.4",
     "@eslint/js": "^10.0.1",
     "@rolldown/plugin-babel": "^0.2.3",
+    "@playwright/test": "^1.57.0",
     "@sentry/vite-plugin": "^5.3.0",
     "@tanstack/eslint-plugin-query": "^5.100.14",
     "@tanstack/eslint-plugin-router": "^1.162.0",

--- a/packages/frontend-next/playwright.config.ts
+++ b/packages/frontend-next/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  use: {
+    baseURL: 'http://localhost:1871',
+    trace: 'retain-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: [
+    {
+      command: 'bun run build && node e2e/pwa-test-server.mjs',
+      url: 'http://localhost:1871/health',
+      reuseExistingServer: false,
+      env: {
+        VITE_API_URL: 'http://localhost:8787',
+        VITE_POSTHOG_KEY: '',
+        VITE_SENTRY_DSN: '',
+      },
+    },
+    {
+      command: 'node e2e/pwa-api-server.mjs',
+      url: 'http://localhost:8787/v0/transit/stations?city=berlin',
+      reuseExistingServer: false,
+    },
+  ],
+});

--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
 import { get, set, del } from 'idb-keyval';
+import { registerSW } from 'virtual:pwa-register';
 import { queryClient, PERSISTED_CACHE_MAX_AGE } from './api/queryClient';
 import { capturePageview } from './lib/analytics';
 import { syncConsentToPostHog } from './lib/consent';
@@ -21,16 +22,33 @@ initErrorMonitoring();
 
 void initNativePlatform();
 
-// Register the PWA service worker ourselves rather than via vite-plugin-pwa's injected
-// registerSW.js, whose generated call has no .catch — so any registration rejection (bots,
-// crawlers, locked-down WebViews) bubbles up as an unhandled rejection and floods Sentry
-// (WEB-APP-1). The .catch here keeps that failure quiet; the SW is optional, so there's nothing
-// to do on failure. Gated on __CAPACITOR__ because the native build drops the PWA plugin and
-// ships no sw.js (FRE-649). registerType: 'autoUpdate' still applies — it lives in the generated
-// sw.js, not the registration snippet.
+// vite-plugin-pwa's registration API catches failures (bots, crawlers, locked-down WebViews) and
+// reloads once when an auto-updated worker takes control. Recheck after the app returns online or
+// to the foreground so an installed PWA does not keep a suspended shell indefinitely.
 if (!__CAPACITOR__ && 'serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    void navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {});
+  registerSW({
+    onRegisteredSW: (_swUrl, registration) => {
+      if (!registration) return;
+
+      // The install page is not controlled yet, so its navigation cannot populate the runtime cache.
+      // Seed the shell once while online to retain the first offline cold start.
+      void navigator.serviceWorker.ready
+        .then(async () => {
+          const appShell = await caches.open('app-shell');
+          if (!(await appShell.match('/'))) await appShell.add('/');
+        })
+        .catch(() => {});
+
+      const update = () => {
+        void registration.update().catch(() => {});
+      };
+
+      window.addEventListener('online', update);
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') update();
+      });
+    },
+    onRegisterError: () => {},
   });
 }
 

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -74,109 +74,113 @@ export default defineConfig({
     babel({ presets: [reactCompilerPreset({ target: '19' })] }),
     tailwindcss(),
     preloadPrimaryFont(),
-    // `false` is a valid (skipped) Vite plugin slot — keeps the SW out of Capacitor builds.
-    !isCapacitor &&
-      VitePWA({
-        // Silent update: the new service worker takes over and the fresh shell loads on the next
-        // navigation, with no prompt UI (AGENTS.md: keep registration/update UI minimal). skipWaiting
-        // + clientsClaim are implied by autoUpdate, so no rider gets stuck on a stale shell.
-        registerType: 'autoUpdate',
-        // Register the SW ourselves in main.tsx instead of letting the plugin inject registerSW.js.
-        // That generated snippet calls navigator.serviceWorker.register() with no .catch, so a
-        // rejection (common in bots/crawlers and locked-down WebViews) surfaces as an unhandled
-        // rejection and floods Sentry (WEB-APP-1). Our own registration swallows the rejection.
-        injectRegister: false,
-        // Icons live in public/ (generated from the source app-icon.png, matching the native icon).
-        manifest: {
-          name: 'FreiFahren',
-          short_name: 'FreiFahren',
-          description:
-            'Freifahren ist eine Webapp, die es Nutzern ermöglicht Ticketkontrollen zu melden und sich vor Kontrollen zu warnen.',
-          lang: 'de',
-          // Keep theme/background in sync with --card in src/index.css and index.html's theme-color.
-          theme_color: '#25272b',
-          background_color: '#25272b',
-          display: 'standalone',
-          start_url: '/',
-          icons: [
-            { src: '/favicon-16x16.png', type: 'image/png', sizes: '16x16' },
-            { src: '/favicon-32x32.png', type: 'image/png', sizes: '32x32' },
-            { src: '/pwa-192x192.png', type: 'image/png', sizes: '192x192' },
-            { src: '/pwa-512x512.png', type: 'image/png', sizes: '512x512' },
-            {
-              src: '/pwa-maskable-512x512.png',
-              type: 'image/png',
-              sizes: '512x512',
-              purpose: 'maskable',
+    VitePWA({
+      // Keep the virtual registration module resolvable for native builds without emitting a
+      // service worker there. The call site itself is compile-time gated by __CAPACITOR__.
+      disable: isCapacitor,
+      // Silent update: the new service worker takes over and the fresh shell reloads immediately,
+      // with no prompt UI (AGENTS.md: keep registration/update UI minimal).
+      registerType: 'autoUpdate',
+      // Register the SW ourselves in main.tsx instead of letting the plugin inject registerSW.js.
+      // That generated snippet calls navigator.serviceWorker.register() with no .catch, so a
+      // rejection (common in bots/crawlers and locked-down WebViews) surfaces as an unhandled
+      // rejection and floods Sentry (WEB-APP-1). Our own registration swallows the rejection.
+      injectRegister: false,
+      // Icons live in public/ (generated from the source app-icon.png, matching the native icon).
+      manifest: {
+        name: 'FreiFahren',
+        short_name: 'FreiFahren',
+        description:
+          'Freifahren ist eine Webapp, die es Nutzern ermöglicht Ticketkontrollen zu melden und sich vor Kontrollen zu warnen.',
+        lang: 'de',
+        // Keep theme/background in sync with --card in src/index.css and index.html's theme-color.
+        theme_color: '#25272b',
+        background_color: '#25272b',
+        display: 'standalone',
+        start_url: '/',
+        icons: [
+          { src: '/favicon-16x16.png', type: 'image/png', sizes: '16x16' },
+          { src: '/favicon-32x32.png', type: 'image/png', sizes: '32x32' },
+          { src: '/pwa-192x192.png', type: 'image/png', sizes: '192x192' },
+          { src: '/pwa-512x512.png', type: 'image/png', sizes: '512x512' },
+          {
+            src: '/pwa-maskable-512x512.png',
+            type: 'image/png',
+            sizes: '512x512',
+            purpose: 'maskable',
+          },
+        ],
+      },
+      workbox: {
+        // injectRegister is disabled, so configure the auto-update lifecycle explicitly rather
+        // than relying on vite-plugin-pwa's injected registration snippet to do it for us.
+        skipWaiting: true,
+        clientsClaim: true,
+        // Precache the immutable, content-hashed assets: JS/CSS, the IBM Plex woff2 files, and the
+        // lazy maplibre chunk (~1 MB, under the 2 MB default cap) so the map engine paints offline
+        // too. Cache-first is correct for these — a new build gets new filenames, so they're never
+        // stale. The HTML document is deliberately handled by the network-first rule below, not this
+        // precache, so a deploy is never served stale.
+        globPatterns: ['**/*.{js,css,woff2,svg,png,ico}'],
+        // Disable navigateFallback (vite-plugin-pwa defaults it to index.html). Its NavigationRoute is
+        // registered *before* runtimeCaching and first-match-wins, so a precache navigateFallback would
+        // shadow the network-first rule below and keep serving the stale shell. With it off, the
+        // network-first navigation rule is the sole navigation handler; it caches each visited shell, so
+        // returning visitors still cold-boot offline (previously-visited pages only — the best-effort web
+        // offline of ADR 0005). It only matches navigation requests, so it never touches the cross-origin
+        // tile/API fetches.
+        navigateFallback: null,
+        runtimeCaching: [
+          {
+            // The HTML document is network-first: a fresh deploy is picked up on the very next load,
+            // not one navigation later (the autoUpdate lag) and never needing a manual cache clear.
+            // The hashed JS/CSS it references stay precache/cache-first (immutable, so never stale).
+            // The last successful shell is cached, so a returning visitor still cold-boots offline.
+            // See ADR 0008.
+            urlPattern: ({ request }) => request.mode === 'navigate',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'app-shell',
+              // Fall back to the cached shell quickly on a flaky/tunnel connection rather than hanging.
+              networkTimeoutSeconds: 3,
+              expiration: { maxEntries: 8, maxAgeSeconds: 60 * 60 * 24 * 30 },
+              cacheableResponse: { statuses: [0, 200] },
             },
-          ],
-        },
-        workbox: {
-          // Precache the immutable, content-hashed assets: JS/CSS, the IBM Plex woff2 files, and the
-          // lazy maplibre chunk (~1 MB, under the 2 MB default cap) so the map engine paints offline
-          // too. Cache-first is correct for these — a new build gets new filenames, so they're never
-          // stale. The HTML document is deliberately handled by the network-first rule below, not this
-          // precache, so a deploy is never served stale.
-          globPatterns: ['**/*.{js,css,html,woff2,svg,png,ico}'],
-          // Disable navigateFallback (vite-plugin-pwa defaults it to index.html). Its NavigationRoute is
-          // registered *before* runtimeCaching and first-match-wins, so a precache navigateFallback would
-          // shadow the network-first rule below and keep serving the stale shell. With it off, the
-          // network-first navigation rule is the sole navigation handler; it caches each visited shell, so
-          // returning visitors still cold-boot offline (previously-visited pages only — the best-effort web
-          // offline of ADR 0005). It only matches navigation requests, so it never touches the cross-origin
-          // tile/API fetches.
-          navigateFallback: null,
-          runtimeCaching: [
-            {
-              // The HTML document is network-first: a fresh deploy is picked up on the very next load,
-              // not one navigation later (the autoUpdate lag) and never needing a manual cache clear.
-              // The hashed JS/CSS it references stay precache/cache-first (immutable, so never stale).
-              // The last successful shell is cached, so a returning visitor still cold-boots offline.
-              // See ADR 0008.
-              urlPattern: ({ request }) => request.mode === 'navigate',
-              handler: 'NetworkFirst',
-              options: {
-                cacheName: 'app-shell',
-                // Fall back to the cached shell quickly on a flaky/tunnel connection rather than hanging.
-                networkTimeoutSeconds: 3,
-                expiration: { maxEntries: 8, maxAgeSeconds: 60 * 60 * 24 * 30 },
-                cacheableResponse: { statuses: [0, 200] },
-              },
+          },
+          {
+            // Style JSON is the one mutable pointer (it names the current immutable /v<sha>/ archive).
+            // StaleWhileRevalidate paints instantly from cache but refreshes in the background, so a
+            // new tile-server deploy is picked up on the next load — never the 30-day staleness a
+            // CacheFirst rule would impose.
+            urlPattern: ({ url }) =>
+              url.origin === 'https://tiles.freifahren.org' && url.pathname.endsWith('.json'),
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'map-style',
+              expiration: { maxEntries: 4, maxAgeSeconds: 60 * 60 * 24 },
+              cacheableResponse: { statuses: [0, 200] },
             },
-            {
-              // Style JSON is the one mutable pointer (it names the current immutable /v<sha>/ archive).
-              // StaleWhileRevalidate paints instantly from cache but refreshes in the background, so a
-              // new tile-server deploy is picked up on the next load — never the 30-day staleness a
-              // CacheFirst rule would impose.
-              urlPattern: ({ url }) =>
-                url.origin === 'https://tiles.freifahren.org' && url.pathname.endsWith('.json'),
-              handler: 'StaleWhileRevalidate',
-              options: {
-                cacheName: 'map-style',
-                expiration: { maxEntries: 4, maxAgeSeconds: 60 * 60 * 24 },
-                cacheableResponse: { statuses: [0, 200] },
-              },
+          },
+          {
+            // Glyph PBFs are immutable, so CacheFirst is safe (currently unused — the basemap has no
+            // text layers — but ready for when labels are added).
+            urlPattern: ({ url }) =>
+              url.origin === 'https://tiles.freifahren.org' && url.pathname.endsWith('.pbf'),
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'map-fonts',
+              expiration: { maxEntries: 256, maxAgeSeconds: 60 * 60 * 24 * 365 },
+              cacheableResponse: { statuses: [0, 200] },
             },
-            {
-              // Glyph PBFs are immutable, so CacheFirst is safe (currently unused — the basemap has no
-              // text layers — but ready for when labels are added).
-              urlPattern: ({ url }) =>
-                url.origin === 'https://tiles.freifahren.org' && url.pathname.endsWith('.pbf'),
-              handler: 'CacheFirst',
-              options: {
-                cacheName: 'map-fonts',
-                expiration: { maxEntries: 256, maxAgeSeconds: 60 * 60 * 24 * 365 },
-                cacheableResponse: { statuses: [0, 200] },
-              },
-            },
-            // The PMTiles archive (.pmtiles) is deliberately NOT given a runtime cache rule: it's read
-            // via HTTP range requests, and a CacheFirst store could hand a full 200 back to a range
-            // request and corrupt the read. Range reads go straight to the network (the immutable
-            // /v<sha>/ archive is still cached by the browser's HTTP cache).
-          ],
-        },
-        devOptions: { enabled: false },
-      }),
+          },
+          // The PMTiles archive (.pmtiles) is deliberately NOT given a runtime cache rule: it's read
+          // via HTTP range requests, and a CacheFirst store could hand a full 200 back to a range
+          // request and corrupt the read. Range reads go straight to the network (the immutable
+          // /v<sha>/ archive is still cached by the browser's HTTP cache).
+        ],
+      },
+      devOptions: { enabled: false },
+    }),
     // Must be last so it sees the final emitted bundle + maps. No-op without an auth token.
     ...(sentryAuthToken
       ? [


### PR DESCRIPTION
## Summary

Fixes the installed web PWA remaining on an old JavaScript bundle after a new service worker is available.

- Replace the handwritten service-worker registration with `virtual:pwa-register`, already supplied by `vite-plugin-pwa`.
- Check for a worker update at registration, then only when connectivity returns or the app returns to the foreground.
- Configure `skipWaiting` and `clientsClaim` explicitly because registration injection is disabled.
- Exclude `index.html` from precache so the HTML release pointer remains network-first.
- Warm the runtime `app-shell` cache with `/` on first online registration, preserving the first offline cold start.
- Keep the PWA plugin resolvable but disabled for Capacitor builds, so native continues to emit no service worker.
- Add browser-level PWA regression coverage through one frontend command: `bun run test`.

Closes #828.

## Root cause

The custom registration intentionally swallowed service-worker registration failures, but it did not manage the update lifecycle. An installed PWA could therefore keep executing the already-open bundle after a deployment.

With `injectRegister: false`, `registerType: autoUpdate` also does not implicitly configure the generated worker to skip waiting and claim existing clients. The updated worker needs explicit activation settings and page-side lifecycle handling.

A first installation needs a runtime-shell warm-up: the install navigation happens before the worker controls the page, so it cannot populate the `NetworkFirst` cache itself.

## Resulting update path

An online installed PWA checks `/sw.js` at registration and warms a missing `/` entry in `app-shell`. When it reconnects or returns to the foreground, it rechecks. A changed worker activates immediately, takes control of existing clients, and vite-plugin-pwa reloads the page once so it fetches the current network-first HTML shell and matching hashed assets.

Offline behavior remains available for returning users, including a newly installed app after its first online registration. This PR does not add another PWA framework or redesign offline caching.

## Browser regression suite

`bun run test` runs the PWA suite in Chromium. It builds the real frontend, starts the real local API Worker in `workerd`, and seeds Berlin data into an isolated temporary local D1 state. The test verifies:

1. The browser can query real seeded transit data through the API and its CORS policy.
2. The installed service worker warms the `app-shell` cache.
3. A fresh offline page load renders from that cached shell.
4. After connectivity returns, navigation obtains a newer network response instead of reusing the cached shell.

The static frontend server is intentionally only a local host for the generated PWA assets and the changing-shell assertion. It does not mock API endpoints. The temporary Worker persistence directory is removed after the run, so future browser journeys can set up state through API calls without modifying a developer local D1 or production data.

## Validation

- `bun run test`
- `bun run format:check`
- `bun run lint` (passes with the two existing TanStack Virtual / React Compiler warnings)
- `CAPACITOR=true bun run build`
- `bun run build`
- Inspected the generated web service worker: it includes `skipWaiting` and `clientsClaim`, and does not precache `index.html`.
- Verified the Capacitor build emits neither a service worker nor a web manifest.