### PR TITLE
feat: route one Telegram bot by chat ID

### DIFF
--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -152,6 +152,7 @@ const applyServices = (c: Context<Env>, db: DbConnection, config: AppConfig) => 
     const transitNetworkDataService = new TransitNetworkDataService(db, c.get('city').slug, cacheCtx)
     const reportsService = new ReportsService(db, transitNetworkDataService, {
         nodeEnv: config.nodeEnv,
+        city: c.get('city').slug,
         telegramWorkerUrl: config.telegramWorkerUrl,
         reportPassword: config.reportPassword,
     })

--- a/packages/api-worker/src/modules/reports/reports-service.ts
+++ b/packages/api-worker/src/modules/reports/reports-service.ts
@@ -84,6 +84,7 @@ type ReportSummary = Pick<typeof reports.$inferSelect, 'timestamp' | 'stationId'
 
 export type ReportsServiceConfig = {
     nodeEnv: string
+    city: string
     telegramWorkerUrl?: string
     reportPassword?: string
 }
@@ -285,7 +286,8 @@ export class ReportsService {
         const telegramWorkerUrl = z.string().min(1).parse(this.config.telegramWorkerUrl)
         const reportPassword = z.string().min(1).parse(this.config.reportPassword)
 
-        const endpoint = `${telegramWorkerUrl.replace(/\/$/, '')}/report`
+        const endpoint = new URL(`${telegramWorkerUrl.replace(/\/$/, '')}/report`)
+        endpoint.searchParams.set('city', this.config.city)
         const payload = this.buildTelegramNotificationPayload(reportData)
 
         const response = await fetch(endpoint, {

--- a/packages/api-worker/tests/postReport.test.ts
+++ b/packages/api-worker/tests/postReport.test.ts
@@ -28,7 +28,7 @@ beforeAll(() => {
     fetchMock.disableNetConnect()
     fetchMock
         .get(TELEGRAM_ORIGIN)
-        .intercept({ path: '/report', method: 'POST' })
+        .intercept({ path: '/report?city=berlin', method: 'POST' })
         .reply((opts) => {
             const { headers } = opts
             const password = headers instanceof Headers ? headers.get('X-Password') : (headers['x-password'] ?? null)

--- a/packages/telegram-worker/README.md
+++ b/packages/telegram-worker/README.md
@@ -2,8 +2,9 @@
 
 TypeScript Cloudflare Worker for the FreiFahren Telegram bot. Telegram POSTs
 inspector-sighting messages to `/telegram/webhook`; the worker extracts a station/line/direction
-with Mistral and submits a report to the backend. App reports POSTed to `/report` are forwarded
-back into the Telegram chat. All Berlin/German specifics live in `src/config.ts`.
+with Mistral and submits a report to the backend. App reports POSTed to `/report?city=<slug>` are
+forwarded back into that city's Telegram chat. The single deployed Worker routes each incoming
+message through the allowlisted `TELEGRAM_CHAT_CITIES` map in `wrangler.jsonc`.
 
 ## Develop
 
@@ -25,13 +26,14 @@ bun run eval                       # full dataset
 bun run eval --smoke --n 200       # seeded random sample
 ```
 
-Reads `MISTRAL_API_KEY` / `BACKEND_URL` / `MISTRAL_MODEL` from the env or `.dev.vars`.
+Reads `MISTRAL_API_KEY` / `BACKEND_URL` / `MISTRAL_MODEL` from the env or `.dev.vars`. The
+shared dataset contains cases for every supported city.
 
 ## Deploy
 
 Set secrets (`MISTRAL_API_KEY`, `TELEGRAM_BOT_TOKEN`, `REPORT_PASSWORD`, `TELEGRAM_WEBHOOK_SECRET`)
-with `wrangler secret put <NAME>`, fill `TELEGRAM_REPORT_CHAT_ID` in `wrangler.jsonc`, then
-`bun run deploy`. Register the webhook:
+with `wrangler secret put <NAME>`, configure every allowed group in `TELEGRAM_CHAT_CITIES`, then
+`bun run deploy`. Add the existing bot to each configured group and register its webhook once:
 
 ```sh
 curl "https://api.telegram.org/bot<TOKEN>/setWebhook" \

--- a/packages/telegram-worker/evals/run.ts
+++ b/packages/telegram-worker/evals/run.ts
@@ -349,7 +349,7 @@ async function main(): Promise<void> {
     const rows = args.smoke ? sample(dataset, args.n, args.seed) : dataset
 
     const profile = profileFor(cityName)
-    const index = await getTransitIndex(backendUrl, profile)
+    const index = await getTransitIndex(backendUrl, profile, cityName.toLowerCase())
     const linePattern = buildLinePattern(index.lineNames)
     const systemPrompt = buildSystemPrompt(index, profile)
 

--- a/packages/telegram-worker/src/config.ts
+++ b/packages/telegram-worker/src/config.ts
@@ -1,4 +1,4 @@
-import { getCity } from '@freifahren/cities'
+import { DEFAULT_CITY_SLUG, getCity, type CityConfig, type CitySlug } from '@freifahren/cities'
 
 import type { Env } from './types'
 
@@ -87,7 +87,7 @@ export function profileFor(cityName: string): CityProfile {
 export interface RuntimeConfig {
     backendUrl: string
     publicAppUrl: string
-    cityName: string
+    city: CityConfig
     mistralModel: string
     telegramReportChatId: string
     mistralApiKey: string
@@ -106,13 +106,42 @@ function required(env: Env, name: keyof Env): string {
 
 const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, '')
 
-export function readConfig(env: Env): RuntimeConfig {
+function cityForSlug(slug: string): CityConfig {
+    const city = getCity(slug)
+    if (!city) {
+        throw new Error(`Unknown city in TELEGRAM_CHAT_CITIES: ${slug}`)
+    }
+    return city
+}
+
+function cityAppUrl(baseUrl: string, city: CityConfig): string {
+    const url = new URL(baseUrl)
+    if (city.slug !== DEFAULT_CITY_SLUG) {
+        const [, ...domain] = url.hostname.split('.')
+        url.hostname = `${city.subdomain}.${domain.join('.')}`
+    }
+    return stripTrailingSlash(url.toString())
+}
+
+export function cityForChat(env: Env, chatId: string): CityConfig | null {
+    const slug = env.TELEGRAM_CHAT_CITIES[chatId]
+    return slug === undefined ? null : cityForSlug(slug)
+}
+
+export function readConfigForCity(env: Env, citySlug: CitySlug): RuntimeConfig {
+    const city = cityForSlug(citySlug)
+    const chatIds = Object.entries(env.TELEGRAM_CHAT_CITIES)
+        .filter(([, slug]) => slug === city.slug)
+        .map(([chatId]) => chatId)
+    if (chatIds.length !== 1) {
+        throw new Error(`Expected exactly one Telegram chat for city "${city.slug}"`)
+    }
     return {
         backendUrl: stripTrailingSlash(required(env, 'BACKEND_URL')),
-        publicAppUrl: stripTrailingSlash(env.PUBLIC_APP_URL || 'https://app.freifahren.org'),
-        cityName: env.CITY_NAME || 'Berlin',
+        publicAppUrl: cityAppUrl(env.PUBLIC_APP_URL || 'https://app.freifahren.org', city),
+        city,
         mistralModel: env.MISTRAL_MODEL || 'mistral-small-latest',
-        telegramReportChatId: required(env, 'TELEGRAM_REPORT_CHAT_ID'),
+        telegramReportChatId: chatIds[0]!,
         mistralApiKey: required(env, 'MISTRAL_API_KEY'),
         telegramBotToken: required(env, 'TELEGRAM_BOT_TOKEN'),
         reportPassword: required(env, 'REPORT_PASSWORD'),

--- a/packages/telegram-worker/src/forwarding.ts
+++ b/packages/telegram-worker/src/forwarding.ts
@@ -1,7 +1,8 @@
 import type { Env, ForwardedReport, TransitIndex } from './types'
 import { lineNameForId, stationLineNames } from './transit'
 import { getTransitIndex } from './transit'
-import { profileFor, readConfig } from './config'
+import { profileFor, readConfigForCity } from './config'
+import { getCity, type CitySlug } from '@freifahren/cities'
 import { reportError } from './observability'
 
 /** HTML-escape for Telegram markup, quotes included. */
@@ -121,7 +122,12 @@ const json = (body: unknown, status = 200): Response =>
     })
 
 export async function handleReportForward(request: Request, env: Env): Promise<Response> {
-    const cfg = readConfig(env)
+    const citySlug = new URL(request.url).searchParams.get('city')
+    const city = citySlug === null ? null : getCity(citySlug)
+    if (city === null || city === undefined) {
+        return json({ error: 'bad_request', detail: 'unknown city' }, 400)
+    }
+    const cfg = readConfigForCity(env, city.slug as CitySlug)
 
     if (request.headers.get('X-Password') !== cfg.reportPassword) {
         console.warn('Report forward rejected: bad password')
@@ -140,7 +146,7 @@ export async function handleReportForward(request: Request, env: Env): Promise<R
 
     let index: TransitIndex
     try {
-        index = await getTransitIndex(cfg.backendUrl, profileFor(cfg.cityName))
+        index = await getTransitIndex(cfg.backendUrl, profileFor(cfg.city.slug), cfg.city.slug)
     } catch (err) {
         reportError('Failed to load transit data', err)
         return json({ error: 'transit_unavailable' }, 502)

--- a/packages/telegram-worker/src/index.ts
+++ b/packages/telegram-worker/src/index.ts
@@ -14,9 +14,6 @@ export default withSentry(
         enableLogs: true,
         integrations: [consoleLoggingIntegration({ levels: ['info', 'warn', 'error'] })],
         tracesSampleRate: 1.0,
-        // Tag every event with the city so all three Sentry projects are filterable by it.
-        // Static berlin for now (this worker is Berlin-only); resolve per-message later.
-        initialScope: { tags: { city: 'berlin' } },
     }),
     {
         async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {

--- a/packages/telegram-worker/src/pipeline.ts
+++ b/packages/telegram-worker/src/pipeline.ts
@@ -1,5 +1,6 @@
 import type { Env } from './types'
-import { profileFor, readConfig } from './config'
+import { profileFor, readConfigForCity } from './config'
+import type { CitySlug } from '@freifahren/cities'
 import { isSpam } from './spam'
 import { getTransitIndex } from './transit'
 import {
@@ -17,7 +18,7 @@ import { postReport, reportIdentifiers } from './reporting'
  * (Mistral or backend) for the caller to report; returns normally when there's nothing to
  * submit (spam, no extraction, no station). Runs in the background via waitUntil — no retry.
  */
-export async function processMessage(text: string, env: Env): Promise<void> {
+export async function processMessage(text: string, env: Env, city: CitySlug): Promise<void> {
     if (isSpam(text)) {
         // Never log the message text — the privacy policy promises we don't store it, and logs are
         // persisted in Sentry. Length is a non-identifying signal that's still useful for triage.
@@ -25,9 +26,9 @@ export async function processMessage(text: string, env: Env): Promise<void> {
         return
     }
 
-    const cfg = readConfig(env)
-    const profile = profileFor(cfg.cityName)
-    const index = await getTransitIndex(cfg.backendUrl, profile)
+    const cfg = readConfigForCity(env, city)
+    const profile = profileFor(cfg.city.slug)
+    const index = await getTransitIndex(cfg.backendUrl, profile, cfg.city.slug)
 
     const linePattern = buildLinePattern(index.lineNames)
     const detectedLine = detectLineName(text, index.lineNames, linePattern, index.circularLineNames, profile)
@@ -46,5 +47,5 @@ export async function processMessage(text: string, env: Env): Promise<void> {
     }
 
     console.info('Submitting report:', extractionToLog(result))
-    await postReport(cfg.backendUrl, cfg.reportPassword, ids)
+    await postReport(cfg.backendUrl, cfg.reportPassword, ids, cfg.city.slug)
 }

--- a/packages/telegram-worker/src/reporting.ts
+++ b/packages/telegram-worker/src/reporting.ts
@@ -53,8 +53,11 @@ export async function postReport(
     backendUrl: string,
     reportPassword: string,
     ids: ReportIdentifiers,
+    city: string,
 ): Promise<void> {
-    const response = await fetch(`${backendUrl}/v0/reports`, {
+    const url = new URL('/v0/reports', `${backendUrl}/`)
+    url.searchParams.set('city', city)
+    const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Password': reportPassword },
         body: JSON.stringify(buildReportPayload(ids)),

--- a/packages/telegram-worker/src/transit.ts
+++ b/packages/telegram-worker/src/transit.ts
@@ -56,10 +56,16 @@ export function buildIndex(
 }
 
 // No caching here; the api-worker serves these from its edge cache.
-export async function getTransitIndex(backendUrl: string, profile: CityProfile): Promise<TransitIndex> {
+const cityUrl = (backendUrl: string, path: string, city: string): string => {
+    const url = new URL(path, `${backendUrl}/`)
+    url.searchParams.set('city', city)
+    return url.toString()
+}
+
+export async function getTransitIndex(backendUrl: string, profile: CityProfile, city: string): Promise<TransitIndex> {
     const [stationsResp, linesResp] = await Promise.all([
-        fetch(`${backendUrl}/v0/transit/stations`),
-        fetch(`${backendUrl}/v0/transit/lines`),
+        fetch(cityUrl(backendUrl, '/v0/transit/stations', city)),
+        fetch(cityUrl(backendUrl, '/v0/transit/lines', city)),
     ])
     if (!stationsResp.ok) {
         throw new Error(`GET /v0/transit/stations failed: ${stationsResp.status}`)

--- a/packages/telegram-worker/src/types.ts
+++ b/packages/telegram-worker/src/types.ts
@@ -4,9 +4,8 @@ export interface Env {
     // Vars (wrangler.jsonc)
     BACKEND_URL: string
     PUBLIC_APP_URL: string
-    CITY_NAME: string
+    TELEGRAM_CHAT_CITIES: Record<string, string>
     MISTRAL_MODEL: string
-    TELEGRAM_REPORT_CHAT_ID: string
     SENTRY_DSN: string
     NODE_ENV?: string
     // Git SHA injected at deploy via `wrangler deploy --var SENTRY_RELEASE:<sha>`; tags Sentry

--- a/packages/telegram-worker/src/webhook.ts
+++ b/packages/telegram-worker/src/webhook.ts
@@ -2,8 +2,12 @@ import type { Env, TelegramMessage } from './types'
 import { TelegramUpdate } from './types'
 import { processMessage } from './pipeline'
 import { reportError } from './observability'
+import { cityForChat } from './config'
+import { setTag } from '@sentry/cloudflare'
+import type { CitySlug } from '@freifahren/cities'
 
 export const WEBHOOK_SECRET_HEADER = 'X-Telegram-Bot-Api-Secret-Token'
+type WebhookContext = Pick<ExecutionContext, 'waitUntil'>
 
 function effectiveMessage(update: TelegramUpdate): TelegramMessage | null {
     return update.message ?? update.edited_message ?? update.channel_post ?? update.edited_channel_post ?? null
@@ -25,22 +29,24 @@ function isCommand(message: TelegramMessage): boolean {
 
 // Filter to the allowed chat (text/caption, non-command). Returns the text to process, or
 // null to ignore. Pure, so the filtering rules are testable without the pipeline.
-export function acceptUpdate(update: TelegramUpdate, allowedChatId: string): string | null {
+export function acceptUpdate(update: TelegramUpdate, env: Env): { text: string; city: CitySlug } | null {
     const message = effectiveMessage(update)
     if (message === null) {
         return null
     }
     const chat = message.chat
-    if (!chat || String(chat.id) !== allowedChatId) {
+    const city = chat ? cityForChat(env, String(chat.id)) : null
+    if (!city) {
         return null
     }
     if (isCommand(message)) {
         return null
     }
-    return messageReportText(message)
+    const text = messageReportText(message)
+    return text === null ? null : { text, city: city.slug as CitySlug }
 }
 
-type Processor = (text: string, env: Env) => Promise<void>
+type Processor = (text: string, env: Env, city: CitySlug) => Promise<void>
 
 /**
  * Verify the Telegram secret, filter, then process in the background via waitUntil so we
@@ -51,7 +57,7 @@ type Processor = (text: string, env: Env) => Promise<void>
 export async function handleWebhook(
     request: Request,
     env: Env,
-    ctx: ExecutionContext,
+    ctx: WebhookContext,
     process: Processor = processMessage,
 ): Promise<Response> {
     if (request.headers.get(WEBHOOK_SECRET_HEADER) !== env.TELEGRAM_WEBHOOK_SECRET) {
@@ -67,13 +73,14 @@ export async function handleWebhook(
         return new Response('ok', { status: 200 })
     }
 
-    const text = acceptUpdate(update, env.TELEGRAM_REPORT_CHAT_ID)
-    if (text) {
+    const accepted = acceptUpdate(update, env)
+    if (accepted) {
+        setTag('city', accepted.city)
         ctx.waitUntil(
             // Pass the length, not the text: the privacy policy promises we don't store message
             // content, and reportError persists to Sentry. Length still helps correlate failures.
-            process(text, env).catch((err) =>
-                reportError('telegram pipeline failed', err, { length: text.length }),
+            process(accepted.text, env, accepted.city).catch((err) =>
+                reportError('telegram pipeline failed', err, { length: accepted.text.length, city: accepted.city }),
             ),
         )
     }

--- a/packages/telegram-worker/test/forwarding.test.ts
+++ b/packages/telegram-worker/test/forwarding.test.ts
@@ -2,7 +2,7 @@ import { env, fetchMock } from 'cloudflare:test'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { handleReportForward } from '../src/forwarding'
 import type { Env } from '../src/types'
-import { makeIndex, pickStationFixture, rawTransit } from './fixtures'
+import { ALLOWED_CHAT_ID, makeIndex, pickStationFixture, rawTransit } from './fixtures'
 
 const testEnv = env as unknown as Env
 const index = makeIndex()
@@ -12,11 +12,11 @@ function interceptTransit() {
     const { rawStations, rawLines } = rawTransit()
     fetchMock
         .get('https://backend.test')
-        .intercept({ path: '/v0/transit/stations', method: 'GET' })
+        .intercept({ path: '/v0/transit/stations?city=berlin', method: 'GET' })
         .reply(200, JSON.stringify(rawStations), { headers: { 'content-type': 'application/json' } })
     fetchMock
         .get('https://backend.test')
-        .intercept({ path: '/v0/transit/lines', method: 'GET' })
+        .intercept({ path: '/v0/transit/lines?city=berlin', method: 'GET' })
         .reply(200, JSON.stringify(rawLines), { headers: { 'content-type': 'application/json' } })
 }
 
@@ -33,7 +33,7 @@ function interceptTelegram(statusCode: number, capture?: { body?: Record<string,
 function reportRequest(body: unknown, password: string | null = 'password'): Request {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' }
     if (password !== null) headers['X-Password'] = password
-    return new Request('https://worker.test/report', {
+    return new Request('https://worker.test/report?city=berlin', {
         method: 'POST',
         headers,
         body: JSON.stringify(body),
@@ -66,6 +66,7 @@ describe('handleReportForward', () => {
 
         expect(res.status).toBe(200)
         expect(await res.json()).toEqual({ status: 'success' })
+        expect(capture.body?.chat_id).toBe(ALLOWED_CHAT_ID)
 
         const text = capture.body!.text as string
         expect(text).toContain(index.stations[picked.stationId].name)
@@ -169,11 +170,11 @@ describe('handleReportForward', () => {
         const rawLines = [{ id: 'U1-v', name: 'U1', isCircular: false, stations: ['U-evil', 'U-end'] }]
         fetchMock
             .get('https://backend.test')
-            .intercept({ path: '/v0/transit/stations', method: 'GET' })
+            .intercept({ path: '/v0/transit/stations?city=berlin', method: 'GET' })
             .reply(200, JSON.stringify(rawStations), { headers: { 'content-type': 'application/json' } })
         fetchMock
             .get('https://backend.test')
-            .intercept({ path: '/v0/transit/lines', method: 'GET' })
+            .intercept({ path: '/v0/transit/lines?city=berlin', method: 'GET' })
             .reply(200, JSON.stringify(rawLines), { headers: { 'content-type': 'application/json' } })
         const capture: { body?: Record<string, unknown> } = {}
         interceptTelegram(200, capture)

--- a/packages/telegram-worker/test/pipeline.test.ts
+++ b/packages/telegram-worker/test/pipeline.test.ts
@@ -6,15 +6,15 @@ import { rawTransit } from './fixtures'
 
 const testEnv = env as unknown as Env
 
-function interceptTransit() {
+function interceptTransit(city = 'berlin') {
     const { rawStations, rawLines } = rawTransit()
     fetchMock
         .get('https://backend.test')
-        .intercept({ path: '/v0/transit/stations', method: 'GET' })
+        .intercept({ path: `/v0/transit/stations?city=${city}`, method: 'GET' })
         .reply(200, JSON.stringify(rawStations), { headers: { 'content-type': 'application/json' } })
     fetchMock
         .get('https://backend.test')
-        .intercept({ path: '/v0/transit/lines', method: 'GET' })
+        .intercept({ path: `/v0/transit/lines?city=${city}`, method: 'GET' })
         .reply(200, JSON.stringify(rawLines), { headers: { 'content-type': 'application/json' } })
 }
 
@@ -28,10 +28,10 @@ function interceptMistral(stationName: string | null, directionName: string | nu
         .reply(200, body, { headers: { 'content-type': 'application/json' } })
 }
 
-function interceptBackendReport(capture: { body?: Record<string, unknown> }) {
+function interceptBackendReport(capture: { body?: Record<string, unknown> }, city = 'berlin') {
     fetchMock
         .get('https://backend.test')
-        .intercept({ path: '/v0/reports', method: 'POST' })
+        .intercept({ path: `/v0/reports?city=${city}`, method: 'POST' })
         .reply((opts) => {
             capture.body = JSON.parse(opts.body as string)
             return { statusCode: 200, data: '{}' }
@@ -54,20 +54,20 @@ describe('processMessage', () => {
         const capture: { body?: Record<string, unknown> } = {}
         interceptBackendReport(capture)
 
-        await processMessage('U7 Rudow 2x BOS', testEnv)
+        await processMessage('U7 Rudow 2x BOS', testEnv, 'berlin')
 
         expect(capture.body).toEqual({ stationId: 'U-rudow', source: 'telegram', lineId: 'U7-v' })
     })
 
     it('drops spam before fetching transit, Mistral, or the backend', async () => {
         // No interceptors registered: any outbound fetch would throw on disableNetConnect.
-        await processMessage('ok', testEnv)
+        await processMessage('ok', testEnv, 'berlin')
     })
 
     it('does not submit when the extraction is empty', async () => {
         interceptTransit()
         interceptMistral(null, null)
-        await processMessage('this is fine', testEnv)
+        await processMessage('this is fine', testEnv, 'berlin')
     })
 
     it('throws when the backend rejects the report, so the caller reports it', async () => {
@@ -75,12 +75,12 @@ describe('processMessage', () => {
         interceptMistral('Rudow', null)
         fetchMock
             .get('https://backend.test')
-            .intercept({ path: '/v0/reports', method: 'POST' })
+            .intercept({ path: '/v0/reports?city=berlin', method: 'POST' })
             .reply(500, '{"error":"boom"}')
 
         // A backend 5xx must reject (webhook routes it to reportError); swallowing it here
         // would silently drop reports with no error-rate signal.
-        await expect(processMessage('U7 Rudow 2x BOS', testEnv)).rejects.toThrow()
+        await expect(processMessage('U7 Rudow 2x BOS', testEnv, 'berlin')).rejects.toThrow()
     })
 
     it('submits station-only with no lineId/directionId', async () => {
@@ -89,7 +89,18 @@ describe('processMessage', () => {
         const capture: { body?: Record<string, unknown> } = {}
         interceptBackendReport(capture)
 
-        await processMessage('Rudow 2x bos', testEnv)
+        await processMessage('Rudow 2x bos', testEnv, 'berlin')
+
+        expect(capture.body).toEqual({ stationId: 'U-rudow', source: 'telegram' })
+    })
+
+    it('submits a Leipzig message to the Leipzig city-scoped API', async () => {
+        interceptTransit('leipzig')
+        interceptMistral('Rudow', null)
+        const capture: { body?: Record<string, unknown> } = {}
+        interceptBackendReport(capture, 'leipzig')
+
+        await processMessage('Rudow 3k Kontrolle', testEnv, 'leipzig')
 
         expect(capture.body).toEqual({ stationId: 'U-rudow', source: 'telegram' })
     })

--- a/packages/telegram-worker/test/webhook.test.ts
+++ b/packages/telegram-worker/test/webhook.test.ts
@@ -12,7 +12,7 @@ vi.mock('../src/observability', () => ({ reportError: vi.fn() }))
 const testEnv: Env = {
     BACKEND_URL: 'https://backend.test',
     PUBLIC_APP_URL: 'https://app.example.test',
-    TELEGRAM_CHAT_CITIES: { [ALLOWED_CHAT_ID]: 'berlin', '-5211691627': 'leipzig' },
+    TELEGRAM_CHAT_CITIES: { [ALLOWED_CHAT_ID]: 'berlin', '-1002': 'leipzig' },
     MISTRAL_MODEL: 'mistral-small-latest',
     SENTRY_DSN: 'https://example.invalid/1',
     MISTRAL_API_KEY: 'test-mistral-key',
@@ -191,7 +191,7 @@ describe('handleWebhook', () => {
 
         await handleWebhook(webhookRequest(makeUpdate({ text: 'U2 Alex', chatId: -1001 })), testEnv, berlin.ctx, process)
         await handleWebhook(
-            webhookRequest(makeUpdate({ text: '3k Hbf', chatId: -5211691627 })),
+            webhookRequest(makeUpdate({ text: '3k Hbf', chatId: -1002 })),
             testEnv,
             leipzig.ctx,
             process

--- a/packages/telegram-worker/test/webhook.test.ts
+++ b/packages/telegram-worker/test/webhook.test.ts
@@ -1,4 +1,4 @@
-import { createExecutionContext, env, waitOnExecutionContext } from 'cloudflare:test'
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
 import { describe, expect, it, vi } from 'vitest'
 import { WEBHOOK_SECRET_HEADER, acceptUpdate, handleWebhook } from '../src/webhook'
 import { TelegramUpdate } from '../src/types'
@@ -8,6 +8,18 @@ import { ALLOWED_CHAT_ID } from './fixtures'
 
 // Spy seam for the privacy assertions below; the real implementation writes to Sentry.
 vi.mock('../src/observability', () => ({ reportError: vi.fn() }))
+
+const testEnv: Env = {
+    BACKEND_URL: 'https://backend.test',
+    PUBLIC_APP_URL: 'https://app.example.test',
+    TELEGRAM_CHAT_CITIES: { [ALLOWED_CHAT_ID]: 'berlin', '-5211691627': 'leipzig' },
+    MISTRAL_MODEL: 'mistral-small-latest',
+    SENTRY_DSN: 'https://example.invalid/1',
+    MISTRAL_API_KEY: 'test-mistral-key',
+    TELEGRAM_BOT_TOKEN: '1:fake',
+    REPORT_PASSWORD: 'password',
+    TELEGRAM_WEBHOOK_SECRET: 'webhook-secret',
+}
 
 function makeUpdate(opts: {
     text?: string
@@ -31,26 +43,30 @@ function makeUpdate(opts: {
 
 describe('acceptUpdate (filtering)', () => {
     it('accepts a text message from the allowed chat', () => {
-        expect(acceptUpdate(makeUpdate({ text: 'U2 alex 2x BOS' }), ALLOWED_CHAT_ID)).toBe('U2 alex 2x BOS')
+        expect(acceptUpdate(makeUpdate({ text: 'U2 alex 2x BOS' }), testEnv)).toEqual({
+            text: 'U2 alex 2x BOS',
+            city: 'berlin',
+        })
     })
 
     it('accepts a photo caption', () => {
-        expect(acceptUpdate(makeUpdate({ caption: 'U2 alex 2x BOS', hasPhoto: true }), ALLOWED_CHAT_ID)).toBe(
-            'U2 alex 2x BOS'
-        )
+        expect(acceptUpdate(makeUpdate({ caption: 'U2 alex 2x BOS', hasPhoto: true }), testEnv)).toEqual({
+            text: 'U2 alex 2x BOS',
+            city: 'berlin',
+        })
     })
 
     it('ignores a sticker with no text or caption', () => {
-        expect(acceptUpdate(makeUpdate({}), ALLOWED_CHAT_ID)).toBeNull()
+        expect(acceptUpdate(makeUpdate({}), testEnv)).toBeNull()
     })
 
     it('ignores a message from an unallowed chat', () => {
-        expect(acceptUpdate(makeUpdate({ text: 'U2 alex 2x BOS', chatId: -9999 }), ALLOWED_CHAT_ID)).toBeNull()
+        expect(acceptUpdate(makeUpdate({ text: 'U2 alex 2x BOS', chatId: -9999 }), testEnv)).toBeNull()
     })
 
     it('ignores bot commands', () => {
         const update = makeUpdate({ text: '/start', entities: [{ type: 'bot_command', offset: 0, length: 6 }] })
-        expect(acceptUpdate(update, ALLOWED_CHAT_ID)).toBeNull()
+        expect(acceptUpdate(update, testEnv)).toBeNull()
     })
 })
 
@@ -65,7 +81,7 @@ function webhookRequest(body: unknown, secret = 'webhook-secret'): Request {
 function fakeCtx() {
     const promises: Promise<unknown>[] = []
     return {
-        ctx: { waitUntil: (p: Promise<unknown>) => void promises.push(p) } as unknown as ExecutionContext,
+        ctx: { waitUntil: (p: Promise<unknown>) => void promises.push(p) },
         promises,
     }
 }
@@ -76,7 +92,7 @@ describe('handleWebhook', () => {
         const { ctx, promises } = fakeCtx()
         const res = await handleWebhook(
             webhookRequest(makeUpdate({ text: 'U2 alex' }), 'wrong'),
-            env as unknown as Env,
+            testEnv,
             ctx,
             process
         )
@@ -90,12 +106,12 @@ describe('handleWebhook', () => {
         const { ctx, promises } = fakeCtx()
         const res = await handleWebhook(
             webhookRequest(makeUpdate({ text: 'U2 alex 2x BOS' })),
-            env as unknown as Env,
+            testEnv,
             ctx,
             process
         )
         expect(res.status).toBe(200)
-        expect(process).toHaveBeenCalledExactlyOnceWith('U2 alex 2x BOS', expect.anything())
+        expect(process).toHaveBeenCalledExactlyOnceWith('U2 alex 2x BOS', expect.anything(), 'berlin')
         expect(promises).toHaveLength(1)
         await Promise.all(promises)
     })
@@ -105,7 +121,7 @@ describe('handleWebhook', () => {
         const { ctx, promises } = fakeCtx()
         const res = await handleWebhook(
             webhookRequest(makeUpdate({ text: 'U2 alex', chatId: -9999 })),
-            env as unknown as Env,
+            testEnv,
             ctx,
             process
         )
@@ -121,7 +137,7 @@ describe('handleWebhook', () => {
 
         const res = await handleWebhook(
             webhookRequest(makeUpdate({ text: 'U8 Hermannplatz' })),
-            env as unknown as Env,
+            testEnv,
             ctx,
             process
         )
@@ -141,7 +157,7 @@ describe('handleWebhook', () => {
         })
         const ctx = createExecutionContext()
 
-        const res = await handleWebhook(webhookRequest(makeUpdate({ text })), env as unknown as Env, ctx, process)
+        const res = await handleWebhook(webhookRequest(makeUpdate({ text })), testEnv, ctx, process)
         // The failure stays in the background: Telegram still gets its 200 ack.
         expect(res.status).toBe(200)
         await waitOnExecutionContext(ctx)
@@ -151,7 +167,7 @@ describe('handleWebhook', () => {
         expect((err as Error).message).toBe('mistral timeout')
         // The privacy invariant: the extra payload carries the length and nothing else — the
         // message text must never reach the (persisted) error report.
-        expect(extra).toEqual({ length: text.length })
+        expect(extra).toEqual({ length: text.length, city: 'berlin' })
     })
 
     it('acks malformed JSON with 200 and does not process', async () => {
@@ -162,8 +178,29 @@ describe('handleWebhook', () => {
             headers: { 'Content-Type': 'application/json', [WEBHOOK_SECRET_HEADER]: 'webhook-secret' },
             body: 'not json',
         })
-        const res = await handleWebhook(badReq, env as unknown as Env, ctx, process)
+        const res = await handleWebhook(badReq, testEnv, ctx, process)
         expect(res.status).toBe(200)
         expect(process).not.toHaveBeenCalled()
+    })
+
+    it('routes Berlin and Leipzig chats to their configured cities and ignores an unknown chat', async () => {
+        const process = vi.fn(async () => {})
+        const berlin = fakeCtx()
+        const leipzig = fakeCtx()
+        const unknown = fakeCtx()
+
+        await handleWebhook(webhookRequest(makeUpdate({ text: 'U2 Alex', chatId: -1001 })), testEnv, berlin.ctx, process)
+        await handleWebhook(
+            webhookRequest(makeUpdate({ text: '3k Hbf', chatId: -5211691627 })),
+            testEnv,
+            leipzig.ctx,
+            process
+        )
+        await handleWebhook(webhookRequest(makeUpdate({ text: 'not allowed', chatId: -9999 })), testEnv, unknown.ctx, process)
+
+        await Promise.all([...berlin.promises, ...leipzig.promises, ...unknown.promises])
+        expect(process).toHaveBeenNthCalledWith(1, 'U2 Alex', expect.anything(), 'berlin')
+        expect(process).toHaveBeenNthCalledWith(2, '3k Hbf', expect.anything(), 'leipzig')
+        expect(process).toHaveBeenCalledTimes(2)
     })
 })

--- a/packages/telegram-worker/vitest.config.ts
+++ b/packages/telegram-worker/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineWorkersConfig({
                         BACKEND_URL: 'https://backend.test',
                         PUBLIC_APP_URL: 'https://app.example.test',
                         MISTRAL_MODEL: 'mistral-small-latest',
-                        TELEGRAM_CHAT_CITIES: { '-1001': 'berlin', '-5211691627': 'leipzig' },
+                        TELEGRAM_CHAT_CITIES: { '-1001': 'berlin', '-1002': 'leipzig' },
                         MISTRAL_API_KEY: 'test-mistral-key',
                         TELEGRAM_BOT_TOKEN: '1:fake',
                         REPORT_PASSWORD: 'password',

--- a/packages/telegram-worker/vitest.config.ts
+++ b/packages/telegram-worker/vitest.config.ts
@@ -16,9 +16,8 @@ export default defineWorkersConfig({
                     bindings: {
                         BACKEND_URL: 'https://backend.test',
                         PUBLIC_APP_URL: 'https://app.example.test',
-                        CITY_NAME: 'Berlin',
                         MISTRAL_MODEL: 'mistral-small-latest',
-                        TELEGRAM_REPORT_CHAT_ID: '-1001',
+                        TELEGRAM_CHAT_CITIES: { '-1001': 'berlin', '-5211691627': 'leipzig' },
                         MISTRAL_API_KEY: 'test-mistral-key',
                         TELEGRAM_BOT_TOKEN: '1:fake',
                         REPORT_PASSWORD: 'password',

--- a/packages/telegram-worker/wrangler.jsonc
+++ b/packages/telegram-worker/wrangler.jsonc
@@ -11,9 +11,11 @@
         "BACKEND_URL": "https://api.freifahren.org",
         "PUBLIC_APP_URL": "https://app.freifahren.org",
         "MISTRAL_MODEL": "mistral-small-latest",
-        // TODO: Add each group chat ID after the bot has been added to that group.
         // One bot and webhook route messages by their incoming chat ID.
-        "TELEGRAM_CHAT_CITIES": {},
+        "TELEGRAM_CHAT_CITIES": {
+            "-1001370021231": "berlin",
+            "-1001138115617": "leipzig"
+        },
         "SENTRY_DSN": "https://9d9ac700f1213d4db367b557167a0594@o4508609338867712.ingest.de.sentry.io/4511633367564368",
     },
     // Messages are processed in the background (ctx.waitUntil) with no queue/retry; failed

--- a/packages/telegram-worker/wrangler.jsonc
+++ b/packages/telegram-worker/wrangler.jsonc
@@ -10,10 +10,10 @@
         // Backend that serves /v0/transit/* and accepts POST /v0/reports.
         "BACKEND_URL": "https://api.freifahren.org",
         "PUBLIC_APP_URL": "https://app.freifahren.org",
-        "CITY_NAME": "Berlin",
         "MISTRAL_MODEL": "mistral-small-latest",
-        // Group chat the bot listens to and forwards app reports into. Negative for groups.
-        "TELEGRAM_REPORT_CHAT_ID": "-1001370021231",
+        // TODO: Add each group chat ID after the bot has been added to that group.
+        // One bot and webhook route messages by their incoming chat ID.
+        "TELEGRAM_CHAT_CITIES": {},
         "SENTRY_DSN": "https://9d9ac700f1213d4db367b557167a0594@o4508609338867712.ingest.de.sentry.io/4511633367564368",
     },
     // Messages are processed in the background (ctx.waitUntil) with no queue/retry; failed


### PR DESCRIPTION
## Summary

Routes the single Telegram bot by the incoming chat ID, so one Worker deployment can process reports for multiple cities.

- maps the production Berlin and Leipzig group chats to their cities
- resolves an allowlisted chat ID to a city at webhook ingress and ignores unknown chats
- uses the resolved city for extraction, city-scoped API requests, Sentry tags, public links, and report forwarding
- forwards API-originated reports back to the mapped city chat via `?city=`
- uses synthetic chat IDs in Vitest, keeping production chat IDs out of test configuration

## Why

Telegram delivers every update for a bot to one webhook. The previous Berlin-only runtime configuration could not safely select the correct city database or destination group for a shared bot.

## Validation

- `bun run test` (telegram-worker): 63 passing
- `bun run typecheck` (telegram-worker)
- `bun run test -- webhook.test.ts forwarding.test.ts`: 28 passing
- `bun run test -- postReport.test.ts` (api-worker): 31 passing
- `wrangler deploy --dry-run`

## Follow-up

`evals/messages.json` is intentionally gitignored, so the locally added Leipzig cases are not included in this PR.