### PR TITLE
feat: add lazy station insights endpoint

### DIFF
--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -5,6 +5,7 @@ import { Context, Hono } from 'hono'
 import { AppError } from './common/errors'
 import { createLogger, Logger, LogLevel } from './common/logger'
 import { createD1Db, DbConnection } from './db'
+import { InsightsService } from './modules/insights'
 import { ReportsService } from './modules/reports'
 import { RiskService } from './modules/risk'
 import type { CacheCtx } from './modules/transit/reference-cache'
@@ -56,6 +57,7 @@ export const isAllowedCorsOrigin = (origin: string, config: AppConfig) => {
 
 export type Services = {
     reportsService: ReportsService
+    insightsService: InsightsService
     riskService: RiskService
     transitNetworkDataService: TransitNetworkDataService
 }
@@ -158,6 +160,10 @@ const applyServices = (c: Context<Env>, db: DbConnection, config: AppConfig) => 
 
     c.set('config', config)
     c.set('reportsService', reportsService)
+    c.set(
+        'insightsService',
+        new InsightsService(db, transitNetworkDataService, c.get('city').slug, c.get('city').timezone)
+    )
     c.set('riskService', new RiskService(reportsService, transitNetworkDataService))
     c.set('transitNetworkDataService', transitNetworkDataService)
 }

--- a/packages/api-worker/src/index.ts
+++ b/packages/api-worker/src/index.ts
@@ -6,6 +6,11 @@ import { requestId } from 'hono/request-id'
 import { Env, isAllowedCorsOrigin, registerContext } from './app-env'
 import { handleError } from './common/error-handler'
 import { registerVersionedRoutes } from './common/router'
+import { getStationInsights } from './modules/insights'
+import {
+    insightsCacheMiddleware,
+    VERSIONED_INSIGHTS_CACHEABLE_PATH,
+} from './modules/insights/insights-cache-middleware'
 import { getReports, getReportsByStation, postReport } from './modules/reports/'
 import { getRisk } from './modules/risk/risk-routes'
 import {
@@ -53,6 +58,7 @@ export const createApp = () => {
     for (const path of VERSIONED_TRANSIT_CACHEABLE_PATHS) {
         app.use(path, transitCacheMiddleware)
     }
+    app.use(VERSIONED_INSIGHTS_CACHEABLE_PATH, insightsCacheMiddleware)
     app.use('*', async (c, next) => {
         await next()
         c.header('Cache-Control', 'no-store')
@@ -79,6 +85,9 @@ export const createApp = () => {
     })
     registerVersionedRoutes(app, 'risk', 'v0', {
         v0: [getRisk],
+    })
+    registerVersionedRoutes(app, 'insights', 'v0', {
+        v0: [getStationInsights],
     })
 
     return app

--- a/packages/api-worker/src/modules/insights/index.ts
+++ b/packages/api-worker/src/modules/insights/index.ts
@@ -1,0 +1,2 @@
+export * from './insights-routes'
+export * from './insights-service'

--- a/packages/api-worker/src/modules/insights/insights-cache-middleware.ts
+++ b/packages/api-worker/src/modules/insights/insights-cache-middleware.ts
@@ -1,0 +1,17 @@
+import type { MiddlewareHandler } from 'hono'
+
+import type { Env } from '../../app-env'
+
+export const VERSIONED_INSIGHTS_CACHEABLE_PATH = '/:version{v\\d+}/insights/station/:stationId'
+
+export const INSIGHTS_CACHE_CONTROL = 'public, max-age=0, must-revalidate'
+export const INSIGHTS_WORKERS_CACHE_CONTROL = 'public, max-age=86400'
+
+export const insightsCacheMiddleware: MiddlewareHandler<Env> = async (c, next) => {
+    await next()
+
+    if (c.req.method !== 'GET' || c.res.status >= 500) return
+
+    c.header('Cache-Control', INSIGHTS_CACHE_CONTROL)
+    c.header('Cloudflare-CDN-Cache-Control', INSIGHTS_WORKERS_CACHE_CONTROL)
+}

--- a/packages/api-worker/src/modules/insights/insights-cache-middleware.ts
+++ b/packages/api-worker/src/modules/insights/insights-cache-middleware.ts
@@ -10,7 +10,7 @@ export const INSIGHTS_WORKERS_CACHE_CONTROL = 'public, max-age=86400'
 export const insightsCacheMiddleware: MiddlewareHandler<Env> = async (c, next) => {
     await next()
 
-    if (c.req.method !== 'GET' || c.res.status >= 500) return
+    if (c.req.method !== 'GET' || c.res.status >= 400) return
 
     c.header('Cache-Control', INSIGHTS_CACHE_CONTROL)
     c.header('Cloudflare-CDN-Cache-Control', INSIGHTS_WORKERS_CACHE_CONTROL)

--- a/packages/api-worker/src/modules/insights/insights-routes.ts
+++ b/packages/api-worker/src/modules/insights/insights-routes.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+import { Env } from '../../app-env'
+import { defineRoute } from '../../common/router'
+
+export const getStationInsights = defineRoute<Env>()({
+    method: 'get',
+    path: '/station/:stationId',
+    schemas: {
+        param: z.object({ stationId: z.string().min(1) }),
+    },
+    handler: async (c) => {
+        const { stationId } = c.req.valid('param')
+        return c.json(await c.get('insightsService').getStationInsights(stationId))
+    },
+})

--- a/packages/api-worker/src/modules/insights/insights-service.ts
+++ b/packages/api-worker/src/modules/insights/insights-service.ts
@@ -1,0 +1,213 @@
+import { count, eq, gte } from 'drizzle-orm'
+import { DateTime } from 'luxon'
+import { z } from 'zod'
+
+import { AppError } from '../../common/errors'
+import { DbConnection, reports } from '../../db'
+import type { TransitNetworkDataService } from '../transit/transit-network-data-service'
+import type { StationId } from '../transit/types'
+
+const STATION_PROFILE_MINIMUM_REPORTS = 250
+const LINE_PROFILE_MINIMUM_REPORTS = 1500
+const THIRTY_DAYS_IN_MS = 30 * 24 * 60 * 60 * 1000
+
+const rangeSchema = z.object({
+    start: z.iso.datetime(),
+    end: z.iso.datetime(),
+})
+
+export const stationInsightsSchema = z.object({
+    stationId: z.string(),
+    generatedAt: z.iso.datetime(),
+    timezone: z.string(),
+    scope: z.discriminatedUnion('kind', [
+        z.object({ kind: z.literal('station'), stationId: z.string() }),
+        z.object({ kind: z.literal('line'), lineId: z.string() }),
+        z.object({ kind: z.literal('city'), city: z.string() }),
+    ]),
+    profile: z.object({
+        sourceRange: rangeSchema,
+        bucket: z.object({
+            unit: z.literal('hour'),
+            partition: z.literal('dayOfWeek'),
+        }),
+        values: z
+            .array(
+                z.object({
+                    dayOfWeek: z.union([
+                        z.literal(1),
+                        z.literal(2),
+                        z.literal(3),
+                        z.literal(4),
+                        z.literal(5),
+                        z.literal(6),
+                        z.literal(7),
+                    ]),
+                    hour: z.number().int().min(0).max(23),
+                    reportCount: z.number().int().nonnegative(),
+                })
+            )
+            .length(168),
+    }),
+    reportCount: z.object({
+        value: z.number().int().nonnegative(),
+        range: rangeSchema,
+    }),
+    ranking: z.object({
+        position: z.number().int().positive(),
+        population: z.number().int().positive(),
+        metric: z.object({
+            name: z.literal('reports'),
+            aggregation: z.literal('count'),
+            range: rangeSchema,
+        }),
+    }),
+})
+
+export type StationInsights = z.infer<typeof stationInsightsSchema>
+
+type ProfileReport = {
+    timestamp: Date
+}
+
+const toIso = (date: Date) => date.toISOString()
+
+const earliestTimestamp = (values: readonly ProfileReport[], fallback: Date) => {
+    const earliest = values.reduce<Date | undefined>(
+        (current, value) => (current === undefined || value.timestamp < current ? value.timestamp : current),
+        undefined
+    )
+    return earliest ?? fallback
+}
+
+export const resolveProfileScope = ({
+    stationId,
+    stationLines,
+    stationReportCount,
+    lineReportCount,
+    citySlug,
+}: {
+    stationId: string
+    stationLines: readonly string[]
+    stationReportCount: number
+    lineReportCount?: number
+    citySlug: string
+}): StationInsights['scope'] => {
+    if (stationReportCount >= STATION_PROFILE_MINIMUM_REPORTS) {
+        return { kind: 'station', stationId }
+    }
+
+    const [lineId] = stationLines
+    if (stationLines.length === 1 && (lineReportCount ?? 0) >= LINE_PROFILE_MINIMUM_REPORTS) {
+        return { kind: 'line', lineId }
+    }
+
+    return { kind: 'city', city: citySlug }
+}
+
+export class InsightsService {
+    constructor(
+        private db: DbConnection,
+        private transitNetworkDataService: TransitNetworkDataService,
+        private citySlug: string,
+        private timezone: string
+    ) {}
+
+    async getStationInsights(stationId: StationId, now: Date = new Date()): Promise<StationInsights> {
+        const stations = await this.transitNetworkDataService.getStations()
+
+        if (!Object.hasOwn(stations, stationId)) {
+            throw new AppError({
+                message: 'Station not found',
+                statusCode: 404,
+                internalCode: 'STATION_NOT_FOUND',
+                description: `stationId=${stationId}`,
+            })
+        }
+        const station = stations[stationId]
+
+        const countRangeStart = new Date(now.getTime() - THIRTY_DAYS_IN_MS)
+        const [[stationReportCountRow], recentReportsByStation] = await Promise.all([
+            this.db.select({ value: count() }).from(reports).where(eq(reports.stationId, stationId)),
+            this.db
+                .select({ stationId: reports.stationId, value: count() })
+                .from(reports)
+                .where(gte(reports.timestamp, countRangeStart))
+                .groupBy(reports.stationId),
+        ])
+        const stationReportCount = stationReportCountRow.value
+        let lineReportCount: number | undefined
+        if (stationReportCount < STATION_PROFILE_MINIMUM_REPORTS && station.lines.length === 1) {
+            const [lineReportCountRow] = await this.db
+                .select({ value: count() })
+                .from(reports)
+                .where(eq(reports.lineId, station.lines[0]))
+            lineReportCount = lineReportCountRow.value
+        }
+
+        const scope = resolveProfileScope({
+            stationId,
+            stationLines: station.lines,
+            stationReportCount,
+            lineReportCount,
+            citySlug: this.citySlug,
+        })
+        let profileReports: ProfileReport[]
+        switch (scope.kind) {
+            case 'station':
+                profileReports = await this.db
+                    .select({ timestamp: reports.timestamp })
+                    .from(reports)
+                    .where(eq(reports.stationId, stationId))
+                break
+            case 'line':
+                profileReports = await this.db
+                    .select({ timestamp: reports.timestamp })
+                    .from(reports)
+                    .where(eq(reports.lineId, scope.lineId))
+                break
+            case 'city':
+                profileReports = await this.db.select({ timestamp: reports.timestamp }).from(reports)
+                break
+        }
+
+        const profileCounts = new Map<string, number>()
+        for (const report of profileReports) {
+            const localTime = DateTime.fromJSDate(report.timestamp, { zone: this.timezone })
+            const bucketKey = `${localTime.weekday}:${localTime.hour}`
+            profileCounts.set(bucketKey, (profileCounts.get(bucketKey) ?? 0) + 1)
+        }
+
+        const reportCount = recentReportsByStation.find((row) => row.stationId === stationId)?.value ?? 0
+        const population = Object.keys(stations).length
+        const position = 1 + recentReportsByStation.filter((row) => row.value > reportCount).length
+
+        const countRange = { start: toIso(countRangeStart), end: toIso(now) }
+        return stationInsightsSchema.parse({
+            stationId,
+            generatedAt: toIso(now),
+            timezone: this.timezone,
+            scope,
+            profile: {
+                sourceRange: {
+                    start: toIso(earliestTimestamp(profileReports, now)),
+                    end: toIso(now),
+                },
+                bucket: { unit: 'hour', partition: 'dayOfWeek' },
+                values: Array.from({ length: 7 }, (_, dayIndex) =>
+                    Array.from({ length: 24 }, (_, hour) => ({
+                        dayOfWeek: dayIndex + 1,
+                        hour,
+                        reportCount: profileCounts.get(`${dayIndex + 1}:${hour}`) ?? 0,
+                    }))
+                ).flat(),
+            },
+            reportCount: { value: reportCount, range: countRange },
+            ranking: {
+                position,
+                population,
+                metric: { name: 'reports', aggregation: 'count', range: countRange },
+            },
+        })
+    }
+}

--- a/packages/api-worker/tests/getInsights.test.ts
+++ b/packages/api-worker/tests/getInsights.test.ts
@@ -67,6 +67,8 @@ describe('GET /insights/station/:stationId', () => {
         const response = await appRequestWithRedirect('/insights/station/UNKNOWN_STATION')
 
         expect(response.status).toBe(404)
+        expect(response.headers.get('Cache-Control')).toBe('no-store')
+        expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBeNull()
         await expect(response.json()).resolves.toMatchObject({ details: { internal_code: 'STATION_NOT_FOUND' } })
     })
 })

--- a/packages/api-worker/tests/getInsights.test.ts
+++ b/packages/api-worker/tests/getInsights.test.ts
@@ -1,0 +1,104 @@
+import { eq } from 'drizzle-orm'
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { lineStations, lines, reports } from '../src/db'
+import { resolveProfileScope, stationInsightsSchema } from '../src/modules/insights'
+import { appRequestWithRedirect, sendReportRequest, setSystemTime } from './test-utils'
+import { db } from './test-db'
+
+let stationId: string
+let lineId: string
+
+const sendReportAt = async (timestamp: Date) => {
+    setSystemTime(timestamp)
+    expect((await sendReportRequest({ stationId, lineId, source: 'telegram' })).status).toBe(200)
+}
+
+describe('GET /insights/station/:stationId', () => {
+    beforeAll(async () => {
+        const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
+        lineId = line.id
+        const [station] = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, lineId))
+            .limit(1)
+        stationId = station.stationId
+    })
+
+    beforeEach(async () => {
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        await db.delete(reports)
+        setSystemTime()
+    })
+
+    it('returns a city-scoped 7 by 24 historic profile with self-describing count ranges', async () => {
+        const reportTime = new Date('2026-07-14T09:15:00.000Z')
+        const now = new Date('2026-07-15T12:00:00.000Z')
+        await sendReportAt(reportTime)
+        setSystemTime(now)
+
+        const response = await appRequestWithRedirect(`/insights/station/${stationId}`)
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, must-revalidate')
+        expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBe('public, max-age=86400')
+
+        const body = stationInsightsSchema.parse(await response.json())
+        expect(body.scope).toEqual({ kind: 'city', city: 'berlin' })
+        expect(body.profile.values).toHaveLength(168)
+        expect(body.profile.values.find((bucket) => bucket.dayOfWeek === 2 && bucket.hour === 11)?.reportCount).toBe(1)
+        expect(body.profile.sourceRange.start).toBe(reportTime.toISOString())
+        expect(body.profile.sourceRange.end).toBe(now.toISOString())
+        expect(body.reportCount).toEqual({
+            value: 1,
+            range: {
+                start: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+                end: now.toISOString(),
+            },
+        })
+        expect(body.ranking.metric.range).toEqual(body.reportCount.range)
+    })
+
+    it('returns the standard station-not-found error', async () => {
+        const response = await appRequestWithRedirect('/insights/station/UNKNOWN_STATION')
+
+        expect(response.status).toBe(404)
+        await expect(response.json()).resolves.toMatchObject({ details: { internal_code: 'STATION_NOT_FOUND' } })
+    })
+})
+
+describe('insight scope resolution', () => {
+    it('uses a line only for thin stations served by exactly one qualifying line', () => {
+        expect(
+            resolveProfileScope({
+                stationId: 'station',
+                stationLines: ['U8'],
+                stationReportCount: 249,
+                lineReportCount: 1500,
+                citySlug: 'berlin',
+            })
+        ).toEqual({ kind: 'line', lineId: 'U8' })
+        expect(
+            resolveProfileScope({
+                stationId: 'station',
+                stationLines: ['U8', 'U2'],
+                stationReportCount: 249,
+                lineReportCount: 1500,
+                citySlug: 'berlin',
+            })
+        ).toEqual({ kind: 'city', city: 'berlin' })
+        expect(
+            resolveProfileScope({
+                stationId: 'station',
+                stationLines: ['U8'],
+                stationReportCount: 250,
+                lineReportCount: 1500,
+                citySlug: 'berlin',
+            })
+        ).toEqual({ kind: 'station', stationId: 'station' })
+    })
+})

--- a/packages/cities/src/berlin.ts
+++ b/packages/cities/src/berlin.ts
@@ -57,6 +57,7 @@ export const BERLIN: CityConfig = {
     dbName: CITY_DATABASES.berlin.dbName,
     dbBinding: CITY_DATABASES.berlin.dbBinding,
     lang: 'de',
+    timezone: 'Europe/Berlin',
     map: {
         center: [13.388, 52.5162],
         zoom: 11,

--- a/packages/cities/src/leipzig.ts
+++ b/packages/cities/src/leipzig.ts
@@ -27,6 +27,7 @@ export const LEIPZIG: CityConfig = {
     dbName: CITY_DATABASES.leipzig.dbName,
     dbBinding: CITY_DATABASES.leipzig.dbBinding,
     lang: 'de',
+    timezone: 'Europe/Berlin',
     map: {
         center: [12.3731, 51.3397],
         zoom: 12,

--- a/packages/cities/src/types.ts
+++ b/packages/cities/src/types.ts
@@ -128,6 +128,8 @@ export interface CityConfig extends CityDatabaseConfig {
     displayName: string
     /** BCP-47 language tag for the city's primary language. */
     lang: string
+    /** IANA timezone used to bucket reports into local service hours. */
+    timezone: string
     map: CityMap
     /** Basemap tile-build inputs. Every city ships with a basemap. */
     tiles: CityTiles


### PR DESCRIPTION
## Summary

Introduces `GET /v0/insights/station/:stationId` as the historical-data contract for the upcoming station sheet.

The endpoint deliberately separates durable historical insights from live activity:
- returns an exported Zod contract with a full local-week profile (7 × 24 buckets), resolved scope, a 30-day station report count, and rank metadata;
- resolves profile scope as station (≥250 all-history reports), then only a single served line (≥1,500 reports), otherwise city;
- derives local buckets using each city’s IANA timezone, so DST is handled outside SQL;
- sets a 24-hour Workers edge TTL while browsers revalidate on every use.

It does not add KV, cron, scheduled work, or a live-activity endpoint. Clients derive last-hour/today counts from the existing reports API and exclude predicted reports.

## Why

The original rollup/KV proposal optimized aggregation before it had a consumer. The Worker already has a lazy CDN-cache path: D1 computes an insight response only on an edge miss, then Workers Cache serves it for 24 hours. This keeps the public contract stable while avoiding storage and scheduling infrastructure.

## Validation

- `bunx vitest run tests/getInsights.test.ts`
- focused Prettier and ESLint checks
- `bunx wrangler deploy --dry-run`
- read-only production D1 checks for station, single-line, and multi-line fallback cases

The full API-worker suite also runs, with three pre-existing failures in randomized predicted-report threshold assertions; they reproduce when `tests/getReports.test.ts` runs alone.