### PR TITLE
feat: add station sheet live status

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -127,6 +127,7 @@ export const useReports = (timeframeMs: number) =>
       data: mergeReportSlices(results),
       isLoading: results.some((result) => result.isLoading),
       isError: results.some((result) => result.isError),
+      isSuccess: results.every((result) => result.isSuccess),
     }),
   });
 

--- a/packages/frontend-next/src/api/risk.ts
+++ b/packages/frontend-next/src/api/risk.ts
@@ -2,8 +2,26 @@ import { useQuery } from '@tanstack/react-query';
 
 import { fetchJson } from './transit';
 
-export type SegmentRisk = { color: string; risk: number };
+export type SegmentRisk = { risk: number };
 export type RiskData = { segments_risk: Record<string, SegmentRisk> };
+
+export const RISK_COLORS = {
+  clear: '#13C184',
+  moderate: '#FACB3F',
+  high: '#F05044',
+  severe: '#A92725',
+} as const;
+
+export type RiskLevel = keyof typeof RISK_COLORS;
+
+export const riskLevel = (risk: number): RiskLevel => {
+  if (risk <= 0.2) return 'clear';
+  if (risk <= 0.5) return 'moderate';
+  if (risk <= 0.9) return 'high';
+  return 'severe';
+};
+
+export const riskColor = (risk: number | undefined): string => RISK_COLORS[riskLevel(risk ?? 0)];
 
 export const riskQueryOptions = () =>
   ({

--- a/packages/frontend-next/src/components/map/DetailCard.tsx
+++ b/packages/frontend-next/src/components/map/DetailCard.tsx
@@ -7,15 +7,22 @@ import { CardContent } from '@/components/ui/card';
 import { PopupCard } from './PopupCard';
 
 type DetailCardProps = {
-  title: string;
+  title: React.ReactNode;
   closeLabel: string;
   onClose: () => void;
+  cardClassName?: string;
   children: React.ReactNode;
 };
 
-export function DetailCard({ title, closeLabel, onClose, children }: DetailCardProps) {
+export function DetailCard({
+  title,
+  closeLabel,
+  onClose,
+  cardClassName,
+  children,
+}: DetailCardProps) {
   return (
-    <PopupCard onClose={onClose} closeLabel={closeLabel}>
+    <PopupCard onClose={onClose} closeLabel={closeLabel} cardClassName={cardClassName}>
       <CardContent className="flex items-start justify-between">
         <h2 className="font-heading text-lg font-semibold">{title}</h2>
         <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label={closeLabel}>

--- a/packages/frontend-next/src/components/map/PopupCard.tsx
+++ b/packages/frontend-next/src/components/map/PopupCard.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { Backdrop } from '@/components/ui/backdrop';
 import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 
 type PopupCardProps = {
   /**
@@ -11,10 +12,11 @@ type PopupCardProps = {
    */
   onClose?: () => void;
   closeLabel?: string;
+  cardClassName?: string;
   children: React.ReactNode;
 };
 
-export function PopupCard({ onClose, closeLabel, children }: PopupCardProps) {
+export function PopupCard({ onClose, closeLabel, cardClassName, children }: PopupCardProps) {
   return (
     <>
       {onClose && (
@@ -27,7 +29,12 @@ export function PopupCard({ onClose, closeLabel, children }: PopupCardProps) {
         />
       )}
       <div className="pb-safe-3 pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center px-3 pt-3">
-        <Card className="animate-in slide-in-from-bottom-4 fade-in pointer-events-auto w-full max-w-md gap-1 py-4 duration-200 ease-out">
+        <Card
+          className={cn(
+            'animate-in slide-in-from-bottom-4 fade-in pointer-events-auto w-full max-w-md gap-1 py-4 duration-200 ease-out',
+            cardClassName,
+          )}
+        >
           {children}
         </Card>
       </div>

--- a/packages/frontend-next/src/components/map/ReportDetail.i18n.ts
+++ b/packages/frontend-next/src/components/map/ReportDetail.i18n.ts
@@ -4,6 +4,7 @@ export const NAMESPACE = 'reportDetail';
 
 i18n.addResourceBundle('en', NAMESPACE, {
   close: 'Close',
+  openStationDetails: 'Open details for {{station}}',
   now: 'Just now',
   minutesAgo: '{{count}} min ago',
   moreThan45Min: 'More than 45 min ago',
@@ -19,6 +20,7 @@ i18n.addResourceBundle('en', NAMESPACE, {
 
 i18n.addResourceBundle('de', NAMESPACE, {
   close: 'Schließen',
+  openStationDetails: 'Details zu {{station}} öffnen',
   now: 'Gerade eben',
   minutesAgo: 'vor {{count}} min',
   moreThan45Min: 'Vor mehr als 45 min',

--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -1,4 +1,5 @@
-import { MapPin } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
+import { ChevronRight, MapPin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { formatElapsed, HOUR_MS, useReports, useStationReportCount } from '@/api/reports';
@@ -7,7 +8,9 @@ import { LineBadge } from '@/components/transit/LineBadge';
 import { CardContent } from '@/components/ui/card';
 import { useGeolocation } from '@/contexts/Geolocation.context';
 import { useModalViewDuration } from '@/hooks/useModalViewDuration';
+import { track } from '@/lib/analytics';
 import { currentCity } from '@/lib/city';
+import { Route as StationRoute } from '@/routes/_map/station/$stationId';
 
 import { DetailCard } from './DetailCard';
 import { NAMESPACE } from './ReportDetail.i18n';
@@ -43,7 +46,22 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
   const directionName = report?.directionId ? stations?.[report.directionId]?.name : undefined;
 
   return (
-    <DetailCard title={station.name} closeLabel={t('close')} onClose={onClose}>
+    <DetailCard
+      title={
+        <Link
+          to={StationRoute.to}
+          params={{ stationId: station.id }}
+          className="inline-flex items-center gap-0.5 rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2"
+          aria-label={t('openStationDetails', { station: station.name })}
+          onClick={() => track('station_selected', { source: 'report' })}
+        >
+          {station.name}
+          <ChevronRight className="size-4" aria-hidden />
+        </Link>
+      }
+      closeLabel={t('close')}
+      onClose={onClose}
+    >
       {(lineName || directionName) && (
         <CardContent className="flex items-center gap-2">
           {lineName && <LineBadge name={lineName} />}

--- a/packages/frontend-next/src/components/map/RiskLayer.tsx
+++ b/packages/frontend-next/src/components/map/RiskLayer.tsx
@@ -1,7 +1,7 @@
 import type { FeatureCollection, LineString } from 'geojson';
 import { Layer, Source } from 'react-map-gl/maplibre';
 
-import { useRisk } from '@/api/risk';
+import { riskColor, useRisk } from '@/api/risk';
 
 import { STATIONS_BASE_LAYER_ID } from './StationsLayer';
 import {
@@ -10,10 +10,6 @@ import {
   type TypedSegmentProperties,
   useTypedSegments,
 } from './line-style';
-
-// Neutral green for segments without elevated risk. The backend
-// only returns risky (non-green) segments, so everything else falls back to this.
-const NEUTRAL_GREEN = '#13C184';
 
 type RiskSegmentProperties = TypedSegmentProperties & { line_color: string };
 
@@ -30,7 +26,7 @@ export function RiskLayer() {
       ...feature,
       properties: {
         ...feature.properties,
-        line_color: segmentsRisk?.[String(feature.properties.id)]?.color ?? NEUTRAL_GREEN,
+        line_color: riskColor(segmentsRisk?.[String(feature.properties.id)]?.risk),
       },
     })),
   };

--- a/packages/frontend-next/src/components/map/StationDetail.i18n.ts
+++ b/packages/frontend-next/src/components/map/StationDetail.i18n.ts
@@ -5,9 +5,37 @@ export const NAMESPACE = 'stationDetail';
 i18n.addResourceBundle('en', NAMESPACE, {
   reportSighting: 'Report sighting',
   close: 'Close',
+  allClear: 'All clear',
+  riskLevel: '{{level}} risk',
+  riskLevels: {
+    moderate: 'Moderate',
+    high: 'High',
+    severe: 'Very high',
+  },
+  stationReportsLast24Hours_one: '{{count}} report · 24h',
+  stationReportsLast24Hours_other: '{{count}} reports · 24h',
+  lineReports: 'Line-wide · 24h',
+  lineReportsLast24Hours_one: '{{count}} report',
+  lineReportsLast24Hours_other: '{{count}} reports',
+  inLastHour: '{{count}} in the last hour',
+  showMoreLines: '{{count}} more lines',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
   reportSighting: 'Sichtung melden',
   close: 'Schließen',
+  allClear: 'Alles ruhig',
+  riskLevel: '{{level}}es Risiko',
+  riskLevels: {
+    moderate: 'Mäßig',
+    high: 'Hoh',
+    severe: 'Sehr hoh',
+  },
+  stationReportsLast24Hours_one: '{{count}} Meldung · 24 Std.',
+  stationReportsLast24Hours_other: '{{count}} Meldungen · 24 Std.',
+  lineReports: 'Linienweit · 24 Std.',
+  lineReportsLast24Hours_one: '{{count}} Meldung',
+  lineReportsLast24Hours_other: '{{count}} Meldungen',
+  inLastHour: '{{count}} in der letzten Stunde',
+  showMoreLines: '{{count}} weitere Linien',
 });

--- a/packages/frontend-next/src/components/map/StationDetail.tsx
+++ b/packages/frontend-next/src/components/map/StationDetail.tsx
@@ -1,8 +1,9 @@
 import { Link } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
-import { resolveStationLineNames, type Station, useLines } from '@/api/transit';
-import { LineBadge } from '@/components/transit/LineBadge';
+import { DAY_MS, useReports } from '@/api/reports';
+import { useRisk } from '@/api/risk';
+import { type Station, useLines, useSegments } from '@/api/transit';
 import { Button } from '@/components/ui/button';
 import { CardContent } from '@/components/ui/card';
 import { useModalViewDuration } from '@/hooks/useModalViewDuration';
@@ -10,6 +11,9 @@ import { Route as ReportRoute } from '@/routes/report';
 
 import { DetailCard } from './DetailCard';
 import { NAMESPACE } from './StationDetail.i18n';
+import { StationLineReports } from './StationLineReports';
+import { StationRiskStatus } from './StationRiskStatus';
+import { stationLiveData, stationRiskFor } from './station-detail-data';
 
 type StationDetailProps = {
   station: Station;
@@ -19,16 +23,25 @@ type StationDetailProps = {
 export function StationDetail({ station, onClose }: StationDetailProps) {
   const { t } = useTranslation(NAMESPACE);
   const { data: lines } = useLines();
-  const lineNames = resolveStationLineNames(station.lines, lines);
+  const { data: risk, isSuccess: hasRisk } = useRisk();
+  const { data: segments } = useSegments();
+  const { data: reports, isSuccess: hasLiveReports } = useReports(DAY_MS);
+  const { stationReportCount, lineReports } = stationLiveData(station, lines, reports);
+  const stationRisk = stationRiskFor(station.id, segments, risk);
+  const hasRiskStatus = hasRisk && segments !== undefined;
   useModalViewDuration('station');
 
   return (
-    <DetailCard title={station.name} closeLabel={t('close')} onClose={onClose}>
-      <CardContent className="flex flex-wrap gap-1.5">
-        {lineNames.map((name) => (
-          <LineBadge key={name} name={name} />
-        ))}
-      </CardContent>
+    <DetailCard
+      title={station.name}
+      closeLabel={t('close')}
+      onClose={onClose}
+      cardClassName="max-h-[calc(100dvh-6rem)]"
+    >
+      {hasRiskStatus && <StationRiskStatus risk={stationRisk} />}
+      {hasLiveReports && lineReports.length > 0 && (
+        <StationLineReports stationReportCount={stationReportCount} lineReports={lineReports} />
+      )}
       <CardContent className="mt-2">
         <Button
           asChild

--- a/packages/frontend-next/src/components/map/StationLineReports.tsx
+++ b/packages/frontend-next/src/components/map/StationLineReports.tsx
@@ -1,0 +1,81 @@
+import { ChevronDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { LineBadge } from '@/components/transit/LineBadge';
+import { CardContent } from '@/components/ui/card';
+import { track } from '@/lib/analytics';
+
+import { NAMESPACE } from './StationDetail.i18n';
+import { sortStationLineReports, type StationLineReports } from './station-detail-data';
+
+const INITIAL_LINE_COUNT = 3;
+
+type StationLineReportsProps = {
+  stationReportCount: number;
+  lineReports: StationLineReports[];
+};
+
+function LineReportRow({ line }: { line: StationLineReports }) {
+  const { t } = useTranslation(NAMESPACE);
+  const hasRecentReports = line.reportsInLastHour > 0;
+
+  return (
+    <div className="flex items-center gap-3 px-3 py-2.5">
+      <LineBadge name={line.name} />
+      <div className="text-muted-foreground text-sm">
+        <p>{t('lineReportsLast24Hours', { count: line.reportsInLast24Hours })}</p>
+        {hasRecentReports && (
+          <p className="text-muted-foreground text-xs">
+            {t('inLastHour', { count: line.reportsInLastHour })}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function StationLineReports({ stationReportCount, lineReports }: StationLineReportsProps) {
+  const { t } = useTranslation(NAMESPACE);
+  const rankedLines = sortStationLineReports(lineReports);
+  const visibleLines = rankedLines.slice(0, INITIAL_LINE_COUNT);
+  const remainingLines = rankedLines.slice(INITIAL_LINE_COUNT);
+  const hasAdditionalLines = remainingLines.length > 0;
+
+  return (
+    <CardContent className="space-y-2">
+      <p className="text-muted-foreground text-sm">
+        {t('stationReportsLast24Hours', { count: stationReportCount })}
+      </p>
+      <h3 className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+        {t('lineReports')}
+      </h3>
+      <div className="divide-border max-h-[30dvh] overflow-y-auto overscroll-contain rounded-md border">
+        {visibleLines.map((line) => (
+          <LineReportRow key={line.name} line={line} />
+        ))}
+        {hasAdditionalLines && (
+          <details
+            className="group"
+            onToggle={(event) => {
+              if (!event.currentTarget.open) return;
+              track('station_detail_lines_expanded', {
+                additional_line_count: remainingLines.length,
+              });
+            }}
+          >
+            <summary className="text-muted-foreground flex h-9 cursor-pointer list-none items-center gap-1 px-3 text-xs [&::-webkit-details-marker]:hidden">
+              {t('showMoreLines', { count: remainingLines.length })}
+              <ChevronDown
+                className="size-3.5 transition-transform group-open:rotate-180"
+                aria-hidden
+              />
+            </summary>
+            {remainingLines.map((line) => (
+              <LineReportRow key={line.name} line={line} />
+            ))}
+          </details>
+        )}
+      </div>
+    </CardContent>
+  );
+}

--- a/packages/frontend-next/src/components/map/StationRiskStatus.tsx
+++ b/packages/frontend-next/src/components/map/StationRiskStatus.tsx
@@ -1,0 +1,29 @@
+import { Check, TriangleAlert } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { riskColor, riskLevel } from '@/api/risk';
+import { CardContent } from '@/components/ui/card';
+
+import { NAMESPACE } from './StationDetail.i18n';
+
+export function StationRiskStatus({ risk }: { risk: number }) {
+  const { t } = useTranslation(NAMESPACE);
+  const isClear = risk === 0;
+  const Icon = isClear ? Check : TriangleAlert;
+  const label = isClear
+    ? t('allClear')
+    : t('riskLevel', { level: t(`riskLevels.${riskLevel(risk)}`) });
+  const color = riskColor(risk);
+
+  return (
+    <CardContent>
+      <div
+        className="flex items-center gap-2 rounded-md px-3 py-2"
+        style={{ backgroundColor: `${color}26`, color }}
+      >
+        <Icon className="size-4 shrink-0" aria-hidden />
+        <p className="text-sm font-semibold">{label}</p>
+      </div>
+    </CardContent>
+  );
+}

--- a/packages/frontend-next/src/components/map/station-detail-data.ts
+++ b/packages/frontend-next/src/components/map/station-detail-data.ts
@@ -1,0 +1,85 @@
+import { HOUR_MS, type Report } from '@/api/reports';
+import type { RiskData } from '@/api/risk';
+import { compareLineOrder, type Line, type Segments, type Station } from '@/api/transit';
+
+type StationLine = Pick<Line, 'name' | 'type'> & { ids: string[] };
+
+export type StationLineReports = StationLine & {
+  reportsInLast24Hours: number;
+  reportsInLastHour: number;
+};
+
+export type StationLiveData = {
+  stationReportCount: number;
+  lineReports: StationLineReports[];
+};
+
+function stationLinesByName(station: Station, lines: Line[] | undefined): StationLine[] {
+  const linesByName = new Map<string, StationLine>();
+
+  for (const lineId of station.lines) {
+    const line = lines?.find((candidate) => candidate.id === lineId);
+    if (!line) continue;
+
+    const existing = linesByName.get(line.name);
+    if (existing) existing.ids.push(line.id);
+    else linesByName.set(line.name, { name: line.name, type: line.type, ids: [line.id] });
+  }
+
+  return [...linesByName.values()].sort(compareLineOrder);
+}
+
+export function stationLiveData(
+  station: Station,
+  lines: Line[] | undefined,
+  reports: Report[] | undefined,
+  now = Date.now(),
+): StationLiveData {
+  const lineReports = stationLinesByName(station, lines).map((line) => ({
+    ...line,
+    reportsInLast24Hours: 0,
+    reportsInLastHour: 0,
+  }));
+  const lineById = new Map(lineReports.flatMap((line) => line.ids.map((id) => [id, line])));
+  const lastHourStart = now - HOUR_MS;
+  let stationReportCount = 0;
+
+  for (const report of reports ?? []) {
+    if (report.stationId === station.id) stationReportCount += 1;
+
+    const line = report.lineId ? lineById.get(report.lineId) : undefined;
+    if (!line) continue;
+
+    line.reportsInLast24Hours += 1;
+    if (new Date(report.timestamp).getTime() >= lastHourStart) line.reportsInLastHour += 1;
+  }
+
+  return { stationReportCount, lineReports };
+}
+
+export function stationRiskFor(
+  stationId: string,
+  segments: Segments | undefined,
+  risk: RiskData | undefined,
+): number {
+  if (!segments || !risk) return 0;
+
+  let highestRisk = 0;
+  for (const segment of segments.features) {
+    if (segment.properties.from !== stationId && segment.properties.to !== stationId) continue;
+    highestRisk = Math.max(
+      highestRisk,
+      risk.segments_risk[String(segment.properties.id)]?.risk ?? 0,
+    );
+  }
+  return highestRisk;
+}
+
+export function sortStationLineReports(lineReports: StationLineReports[]): StationLineReports[] {
+  return [...lineReports].sort(
+    (a, b) =>
+      b.reportsInLastHour - a.reportsInLastHour ||
+      b.reportsInLast24Hours - a.reportsInLast24Hours ||
+      compareLineOrder(a, b),
+  );
+}

--- a/packages/frontend-next/src/components/reports/ReportRow.tsx
+++ b/packages/frontend-next/src/components/reports/ReportRow.tsx
@@ -53,13 +53,14 @@ export function ReportRow({
     </>
   );
 
-  const trackSelection = () => {
+  const trackSelection = (opensStationDetail: boolean) => {
     selectionTap();
     track('report_row_selected', {
       report_age_minutes: Math.round((Date.now() - new Date(report.timestamp).getTime()) / 60000),
       has_line: report.lineId !== null,
       has_direction: report.directionId !== null,
     });
+    if (opensStationDetail) track('station_selected', { source: 'reports_list' });
   };
 
   // A report from the last hour opens the live report view; older ones fall back to the station.
@@ -70,7 +71,7 @@ export function ReportRow({
           to={ReportDetailRoute.to}
           params={{ stationId: report.stationId }}
           className="flex flex-col gap-1 px-4 py-3"
-          onClick={trackSelection}
+          onClick={() => trackSelection(false)}
         >
           {content}
         </Link>
@@ -79,7 +80,7 @@ export function ReportRow({
           to={StationRoute.to}
           params={{ stationId: report.stationId }}
           className="flex flex-col gap-1 px-4 py-3"
-          onClick={trackSelection}
+          onClick={() => trackSelection(true)}
         >
           {content}
         </Link>

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -43,7 +43,8 @@ type AnalyticsEvents = {
   // (tram/bus) tier. Sessions that never fire it never discovered those lines exist — the
   // denominator being map pageviews. `zoom` is where the reveal happened.
   secondary_lines_revealed: { zoom: number };
-  station_selected: { source: 'map' | 'search' };
+  station_selected: { source: 'map' | 'search' | 'report' | 'reports_list' };
+  station_detail_lines_expanded: { additional_line_count: number };
   report_marker_selected: { report_age_minutes: number };
   reports_overview_opened: { report_count: number };
   reports_tab_selected: { tab: 'summary' | 'lines' | 'reports' };

--- a/packages/frontend-next/src/routes/_map/station/$stationId.tsx
+++ b/packages/frontend-next/src/routes/_map/station/$stationId.tsx
@@ -1,10 +1,8 @@
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 
-import { HOUR_MS, reportsSliceQueryOptions } from '@/api/reports';
 import { stationsQueryOptions } from '@/api/transit';
 import { queryClient } from '@/api/queryClient';
 import { StationDetail } from '@/components/map/StationDetail';
-import { Route as ReportDetailRoute } from '@/routes/_map/reports/$stationId';
 
 export const Route = createFileRoute('/_map/station/$stationId')({
   staticData: { legalDisclaimer: true },
@@ -12,14 +10,6 @@ export const Route = createFileRoute('/_map/station/$stationId')({
     const stations = await queryClient.ensureQueryData(stationsQueryOptions());
     const station = stations[params.stationId];
     if (!station) throw redirect({ to: '/', replace: true });
-
-    // A station deep link (e.g. from the Telegram bot) should land on the live report view when
-    // there's a sighting from the last hour, matching the recent/older split in the reports list.
-    // Reuses the map's cached last-hour slice, so this rarely costs an extra request.
-    const recentReports = await queryClient.ensureQueryData(reportsSliceQueryOptions(HOUR_MS, 0));
-    if (recentReports.some((report) => report.stationId === params.stationId)) {
-      throw redirect({ to: ReportDetailRoute.to, params, replace: true });
-    }
 
     return { station };
   },


### PR DESCRIPTION
## What this ships

The station sheet now answers the live questions available from the existing reports and risk APIs:

- a qualitative risk status for the station;
- how many reports are associated with the station in the last 24 hours;
- per-line report counts for the entire line during the same window; and
- a compact, expandable list for stations served by many lines.

A report detail’s station title now links to this sheet, so a user can move from an individual report to the station context.

## Data flow

The sheet reuses the shared `useReports(DAY_MS)` query instead of issuing a station-specific request. That query stitches the shared, live last-hour slice with the older part of the 24-hour window. The station sheet derives all counts locally in a single pass:

- **station count**: reports whose `stationId` is the selected station;
- **line count**: every report on each served line, across the network;
- **recent line count**: the subset from the last hour, used only to rank the initially visible lines.

Predicted reports deliberately remain in these counts. This keeps the station sheet consistent when someone opens a station from a historical predicted report.

## Risk consistency

Risk classification and colours now have one client-side definition. Both map risk lines and the station status use the same `riskLevel` thresholds and `riskColor` palette, preventing a segment and its station from communicating different severities. The station sheet shows a qualitative level only; it does not expose a raw percentage.

## Interaction and layout

The sheet has a fixed maximum height. Only the line list scrolls, so the backdrop remains available to close the modal. Three lines are shown initially, ranked by recent relevance. The remaining lines are exposed through native `<details>`, which gives a lightweight, accessible expand/collapse affordance without component state.

## Analytics

- `station_selected` now records the entry source: `map`, `search`, `report`, or `reports_list`.
- `station_detail_lines_expanded` records how many additional lines were revealed.

The existing PostHog station-selection insights use the expanded event property, and the new disclosure event supports measuring whether large interchanges need a different presentation.

## Not included

Historical comparisons, profile/ranking data, and line-detail navigation remain separate work. This PR only uses existing live reports and risk data.

## Verification

- Prettier check
- ESLint
- TypeScript production build
- Diff whitespace check

@codex Please review the data derivation, risk consistency, and station-sheet interaction model.