### PR TITLE
fix: propagate circular-line risk in both directions

### DIFF
--- a/packages/api-worker/src/modules/risk/risk-model.ts
+++ b/packages/api-worker/src/modules/risk/risk-model.ts
@@ -2,7 +2,8 @@
  * For each report, three risk components (direct, bidirect, line) are
  * computed as base_risk × temporal decay (logistic in report age), then
  * spread along the report's lines with a spatial decay (beta-binomial in
- * segment distance). Components accumulate additively across reports
+ * segment distance; on circular lines the distance wraps around the ring).
+ * Components accumulate additively across reports
  * (capped at 1.0), are summed into a final risk per segment (capped at
  * 1.0), mapped to a color, and finally propagated to overlapping segments
  * (segments sharing the same unordered station pair).
@@ -158,6 +159,49 @@ type LineIndex = {
      * original linear scan did.
      */
     stationRank: Map<string, number>
+    firstFromStationId: string
+    lastToStationId: string
+}
+
+/*
+ * Number of arcs a circular line's segment list wraps over, or null for
+ * linear lines. A segment list that closes on itself (last toStation ===
+ * first fromStation) is a ring regardless of any flag. Seeded rings instead
+ * drop the closing station repeat (the line_stations PK forbids it), leaving
+ * the list open by exactly one arc — the modulus adds it back.
+ */
+const ringSize = (lineIndex: LineIndex, isFlaggedCircular: boolean): number | null => {
+    const count = lineIndex.segments.length
+    if (count < 2) return null
+    if (lineIndex.lastToStationId === lineIndex.firstFromStationId) return count
+    return isFlaggedCircular ? count + 1 : null
+}
+
+// Per-line index so the per-report loop is O(line segments) with O(1) lookups
+const buildLineIndexes = (segments: RiskModelSegment[]): Map<string, LineIndex> => {
+    const lineIndexes = new Map<string, LineIndex>()
+    for (const segment of segments) {
+        let lineIndex = lineIndexes.get(segment.lineId)
+        if (!lineIndex) {
+            lineIndex = {
+                segments: [],
+                stationRank: new Map(),
+                firstFromStationId: segment.fromStationId,
+                lastToStationId: segment.toStationId,
+            }
+            lineIndexes.set(segment.lineId, lineIndex)
+        }
+        const rank = lineIndex.segments.length
+        lineIndex.segments.push({ sid: segment.sid, rank })
+        lineIndex.lastToStationId = segment.toStationId
+        if (!lineIndex.stationRank.has(segment.fromStationId)) {
+            lineIndex.stationRank.set(segment.fromStationId, rank)
+        }
+        if (!lineIndex.stationRank.has(segment.toStationId)) {
+            lineIndex.stationRank.set(segment.toStationId, rank)
+        }
+    }
+    return lineIndexes
 }
 
 const sortedPairKey = (a: string, b: string): string => (a < b ? `${a}\u0000${b}` : `${b}\u0000${a}`)
@@ -172,26 +216,13 @@ const sortedPairKey = (a: string, b: string): string => (a < b ? `${a}\u0000${b}
 export const predictSegmentRisk = (
     segments: RiskModelSegment[],
     reports: RiskModelReport[],
-    now: Date
+    now: Date,
+    circularLineIds: ReadonlySet<string> = new Set()
 ): Record<string, SegmentRisk> => {
-    // Per-line index so the per-report loop is O(line segments) with O(1) lookups
-    const lineIndexes = new Map<string, LineIndex>()
+    const lineIndexes = buildLineIndexes(segments)
+
     const segmentsByStationPair = new Map<string, string[]>()
     for (const segment of segments) {
-        let lineIndex = lineIndexes.get(segment.lineId)
-        if (!lineIndex) {
-            lineIndex = { segments: [], stationRank: new Map() }
-            lineIndexes.set(segment.lineId, lineIndex)
-        }
-        const rank = lineIndex.segments.length
-        lineIndex.segments.push({ sid: segment.sid, rank })
-        if (!lineIndex.stationRank.has(segment.fromStationId)) {
-            lineIndex.stationRank.set(segment.fromStationId, rank)
-        }
-        if (!lineIndex.stationRank.has(segment.toStationId)) {
-            lineIndex.stationRank.set(segment.toStationId, rank)
-        }
-
         const pairKey = sortedPairKey(segment.fromStationId, segment.toStationId)
         const overlapping = segmentsByStationPair.get(pairKey)
         if (overlapping) {
@@ -222,8 +253,13 @@ export const predictSegmentRisk = (
                 const stationRank = lineIndex.stationRank.get(report.stationId)
                 if (stationRank === undefined) continue
 
+                // A ring has no terminal, so risk spreads the shorter way around
+                const lineRingSize = ringSize(lineIndex, circularLineIds.has(lineId))
+
                 for (const segment of lineIndex.segments) {
-                    const distance = Math.abs(segment.rank - stationRank)
+                    const linearDistance = Math.abs(segment.rank - stationRank)
+                    const distance =
+                        lineRingSize === null ? linearDistance : Math.min(linearDistance, lineRingSize - linearDistance)
                     const risks = segmentRisks.get(segment.sid)!
                     risks.direct = Math.min(1, risks.direct + reportDirectRisk * spatialDecay(distance, 'direct'))
                     risks.bidirect = Math.min(

--- a/packages/api-worker/src/modules/risk/risk-service.ts
+++ b/packages/api-worker/src/modules/risk/risk-service.ts
@@ -24,11 +24,14 @@ export class RiskService {
     async getRisk(now: DateTime = DateTime.utc()): Promise<RiskData> {
         const oneHourAgo = now.minus({ hours: 1 })
 
-        const [segmentCollection, realReports, stations] = await Promise.all([
+        const [segmentCollection, realReports, stations, lines] = await Promise.all([
             this.transitNetworkDataService.getSegments(),
             this.reportsService.getRealReports({ from: oneHourAgo, to: now }),
             this.transitNetworkDataService.getStations(),
+            this.transitNetworkDataService.getLines(),
         ])
+
+        const circularLineIds = new Set(lines.filter((line) => line.isCircular).map((line) => line.id))
 
         const segments: RiskModelSegment[] = segmentCollection.features.map((feature) => ({
             sid: String(feature.properties.id),
@@ -51,7 +54,7 @@ export class RiskService {
         })
 
         try {
-            return { segments_risk: predictSegmentRisk(segments, reports, now.toJSDate()) }
+            return { segments_risk: predictSegmentRisk(segments, reports, now.toJSDate(), circularLineIds) }
         } catch (error) {
             throw new AppError({
                 message: 'Risk model failed',

--- a/packages/api-worker/tests/getRisk.test.ts
+++ b/packages/api-worker/tests/getRisk.test.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm'
+import { asc, eq } from 'drizzle-orm'
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { createApp } from '../src'
@@ -510,6 +510,40 @@ describe('GET /v0/risk report type handling', () => {
             expect(VALID_COLORS).toContain(c)
             expect(c).not.toBe(GREEN)
         }
+    })
+})
+
+describe('GET /v0/risk circular lines', () => {
+    beforeEach(async () => {
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        await db.delete(reports)
+    })
+
+    it('a report at the segment-list boundary of a circular line colours both adjacent branches', async () => {
+        const [circularLine] = await db.select({ id: lines.id }).from(lines).where(eq(lines.isCircular, true)).limit(1)
+        if (!circularLine) return // skip if the seeded city has no circular line
+
+        const lineSegments = await db
+            .select({ id: segments.id, fromStationId: segments.fromStationId })
+            .from(segments)
+            .where(eq(segments.lineId, circularLine.id))
+            .orderBy(asc(segments.position))
+        if (lineSegments.length < 2) return
+
+        // The first segment's fromStation sits at the boundary where the list wraps
+        const boundaryStationId = lineSegments[0]!.fromStationId
+        await postRiskReport({ stationId: boundaryStationId, lineId: circularLine.id, source: 'telegram' })
+
+        const response = await getRisk()
+        const body = (await response.json()) as RiskResponse
+
+        const firstSid = String(lineSegments[0]!.id)
+        const lastSid = String(lineSegments[lineSegments.length - 1]!.id)
+        expect(body.segments_risk[firstSid]).toBeDefined()
+        expect(body.segments_risk[lastSid]).toBeDefined()
     })
 })
 

--- a/packages/api-worker/tests/risk-model.test.ts
+++ b/packages/api-worker/tests/risk-model.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import { predictSegmentRisk, type RiskModelReport, type RiskModelSegment } from '../src/modules/risk/risk-model'
+
+/*
+ * Real station ids (Berlin Ringbahn) used as opaque identifiers — the model
+ * itself is city-agnostic and these tests never touch city config or the DB.
+ */
+const RING_STATIONS = [
+    'n29190907', // Gesundbrunnen
+    'n2924245391', // Wedding
+    'n29045594', // Westhafen
+    'BBEU', // Beusselstraße
+    'n4330752281', // Jungfernheide
+    'BWES', // Westend
+    'BMN', // Messe Nord/ZOB
+    'BWKRR', // Westkreuz
+    'BHAL', // Halensee
+    'BHO', // Hohenzollerndamm
+    'n3783145806', // Heidelberger Platz
+    'n29046990', // Bundesplatz
+    'n29497638', // Innsbrucker Platz
+    'BSGV', // Schöneberg
+    'BSKV', // Südkreuz
+    'n29058343', // Tempelhof
+    'n31048718', // Hermannstraße
+    'n3865616066', // Neukölln
+    'BSO', // Sonnenallee
+    'BTP', // Treptower Park
+    'BOKS', // Ostkreuz
+    'n710904931', // Frankfurter Allee
+    'BSTO', // Storkower Straße
+    'n98878581', // Landsberger Allee
+    'n98878847', // Greifswalder Straße
+    'n30305102', // Prenzlauer Allee
+    'n91711807', // Schönhauser Allee
+]
+
+const LINE_ID = 'ring'
+const REPORT_STATION = RING_STATIONS[0]!
+
+const buildSegments = (stationIds: string[], { closed }: { closed: boolean }): RiskModelSegment[] => {
+    const arcCount = closed ? stationIds.length : stationIds.length - 1
+    return Array.from({ length: arcCount }, (_, position) => ({
+        sid: `seg-${position}`,
+        lineId: LINE_ID,
+        fromStationId: stationIds[position]!,
+        toStationId: stationIds[(position + 1) % stationIds.length]!,
+    }))
+}
+
+const freshReportAt = (stationId: string, now: Date): RiskModelReport => ({
+    stationId,
+    lines: [LINE_ID],
+    directionId: null,
+    timestamp: now,
+})
+
+describe('predictSegmentRisk circular lines', () => {
+    const now = new Date('2026-01-01T12:00:00Z')
+
+    it('propagates risk to both adjacent branches of a closed loop of segments', () => {
+        const segments = buildSegments(RING_STATIONS, { closed: true })
+        const lastPosition = segments.length - 1
+
+        const risk = predictSegmentRisk(segments, [freshReportAt(REPORT_STATION, now)], now)
+
+        // Branch in segment-list order
+        expect(risk['seg-0']).toBeDefined()
+        expect(risk['seg-1']).toBeDefined()
+        // Branch across the list boundary, where the first and last segments meet
+        expect(risk[`seg-${lastPosition}`]).toBeDefined()
+        expect(risk[`seg-${lastPosition - 1}`]).toBeDefined()
+        expect(risk[`seg-${lastPosition}`]!.risk).toBeGreaterThan(0.2)
+
+        // The wrap is a shortest path, not a blanket: the far side of the ring stays green
+        const halfway = Math.floor(segments.length / 2)
+        expect(risk[`seg-${halfway}`]).toBeUndefined()
+    })
+
+    it('wraps a flagged circular line whose seeded segment list is open by the closing arc', () => {
+        // Seeded rings drop the closing station repeat, so N stations yield N-1 segments
+        const segments = buildSegments(RING_STATIONS, { closed: false })
+        const lastPosition = segments.length - 1
+
+        const risk = predictSegmentRisk(segments, [freshReportAt(REPORT_STATION, now)], now, new Set([LINE_ID]))
+
+        expect(risk['seg-0']).toBeDefined()
+        expect(risk[`seg-${lastPosition}`]).toBeDefined()
+        expect(risk[`seg-${lastPosition}`]!.risk).toBeGreaterThan(0.2)
+    })
+
+    it('keeps linear-line behaviour unchanged: no wrap without a circular flag or closed loop', () => {
+        const segments = buildSegments(RING_STATIONS, { closed: false })
+        const lastPosition = segments.length - 1
+
+        const risk = predictSegmentRisk(segments, [freshReportAt(REPORT_STATION, now)], now)
+
+        expect(risk['seg-0']).toBeDefined()
+        expect(risk[`seg-${lastPosition}`]).toBeUndefined()
+    })
+
+    it('keeps directional-report semantics on a circular line', () => {
+        const segments = buildSegments(RING_STATIONS, { closed: true })
+        const lastPosition = segments.length - 1
+
+        const directed = predictSegmentRisk(
+            segments,
+            [{ ...freshReportAt(REPORT_STATION, now), directionId: RING_STATIONS[1]! }],
+            now
+        )
+        const undirected = predictSegmentRisk(segments, [freshReportAt(REPORT_STATION, now)], now)
+
+        // Directed reports still colour both sides of the loop
+        expect(directed['seg-0']).toBeDefined()
+        expect(directed[`seg-${lastPosition}`]).toBeDefined()
+        // And stay distinguishable from undirected ones at the reported station
+        expect(directed['seg-0']!.risk).not.toBe(undirected['seg-0']!.risk)
+    })
+})

--- a/packages/api-worker/tests/risk-model.test.ts
+++ b/packages/api-worker/tests/risk-model.test.ts
@@ -1,57 +1,56 @@
-import { describe, expect, it } from 'vitest'
+import { asc } from 'drizzle-orm'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { predictSegmentRisk, type RiskModelReport, type RiskModelSegment } from '../src/modules/risk/risk-model'
+import { db, lineStations } from './test-db'
 
 /*
- * Real station ids (Berlin Ringbahn) used as opaque identifiers — the model
- * itself is city-agnostic and these tests never touch city config or the DB.
+ * The loop must be long enough that the unwrapped distance from one end of
+ * the segment list to the other decays to green — exactly the broken case a
+ * wrapped distance has to repair.
  */
-const RING_STATIONS = [
-    'n29190907', // Gesundbrunnen
-    'n2924245391', // Wedding
-    'n29045594', // Westhafen
-    'BBEU', // Beusselstraße
-    'n4330752281', // Jungfernheide
-    'BWES', // Westend
-    'BMN', // Messe Nord/ZOB
-    'BWKRR', // Westkreuz
-    'BHAL', // Halensee
-    'BHO', // Hohenzollerndamm
-    'n3783145806', // Heidelberger Platz
-    'n29046990', // Bundesplatz
-    'n29497638', // Innsbrucker Platz
-    'BSGV', // Schöneberg
-    'BSKV', // Südkreuz
-    'n29058343', // Tempelhof
-    'n31048718', // Hermannstraße
-    'n3865616066', // Neukölln
-    'BSO', // Sonnenallee
-    'BTP', // Treptower Park
-    'BOKS', // Ostkreuz
-    'n710904931', // Frankfurter Allee
-    'BSTO', // Storkower Straße
-    'n98878581', // Landsberger Allee
-    'n98878847', // Greifswalder Straße
-    'n30305102', // Prenzlauer Allee
-    'n91711807', // Schönhauser Allee
-]
+const LOOP_STATION_COUNT = 13
 
-const LINE_ID = 'ring'
-const REPORT_STATION = RING_STATIONS[0]!
+let lineId = ''
+let loopStationIds: string[] = []
 
-const buildSegments = (stationIds: string[], { closed }: { closed: boolean }): RiskModelSegment[] => {
-    const arcCount = closed ? stationIds.length : stationIds.length - 1
+// Station ids come from whatever line the seeded city has that is long enough
+// to build a loop from, so the test uses real ids without hard-coding a city.
+beforeAll(async () => {
+    const rows = await db
+        .select({ lineId: lineStations.lineId, stationId: lineStations.stationId })
+        .from(lineStations)
+        .orderBy(asc(lineStations.lineId), asc(lineStations.order))
+
+    const stationsByLine = new Map<string, string[]>()
+    for (const row of rows) {
+        const stationIds = stationsByLine.get(row.lineId) ?? []
+        stationIds.push(row.stationId)
+        stationsByLine.set(row.lineId, stationIds)
+    }
+
+    for (const [id, stationIds] of stationsByLine) {
+        if (stationIds.length >= LOOP_STATION_COUNT) {
+            lineId = id
+            loopStationIds = stationIds.slice(0, LOOP_STATION_COUNT)
+            break
+        }
+    }
+})
+
+const buildSegments = ({ closed }: { closed: boolean }): RiskModelSegment[] => {
+    const arcCount = closed ? loopStationIds.length : loopStationIds.length - 1
     return Array.from({ length: arcCount }, (_, position) => ({
         sid: `seg-${position}`,
-        lineId: LINE_ID,
-        fromStationId: stationIds[position]!,
-        toStationId: stationIds[(position + 1) % stationIds.length]!,
+        lineId,
+        fromStationId: loopStationIds[position]!,
+        toStationId: loopStationIds[(position + 1) % loopStationIds.length]!,
     }))
 }
 
 const freshReportAt = (stationId: string, now: Date): RiskModelReport => ({
     stationId,
-    lines: [LINE_ID],
+    lines: [lineId],
     directionId: null,
     timestamp: now,
 })
@@ -60,10 +59,12 @@ describe('predictSegmentRisk circular lines', () => {
     const now = new Date('2026-01-01T12:00:00Z')
 
     it('propagates risk to both adjacent branches of a closed loop of segments', () => {
-        const segments = buildSegments(RING_STATIONS, { closed: true })
+        if (loopStationIds.length === 0) return // skip if the seeded city has no line long enough
+
+        const segments = buildSegments({ closed: true })
         const lastPosition = segments.length - 1
 
-        const risk = predictSegmentRisk(segments, [freshReportAt(REPORT_STATION, now)], now)
+        const risk = predictSegmentRisk(segments, [freshReportAt(loopStationIds[0]!, now)], now)
 
         // Branch in segment-list order
         expect(risk['seg-0']).toBeDefined()
@@ -79,11 +80,13 @@ describe('predictSegmentRisk circular lines', () => {
     })
 
     it('wraps a flagged circular line whose seeded segment list is open by the closing arc', () => {
+        if (loopStationIds.length === 0) return
+
         // Seeded rings drop the closing station repeat, so N stations yield N-1 segments
-        const segments = buildSegments(RING_STATIONS, { closed: false })
+        const segments = buildSegments({ closed: false })
         const lastPosition = segments.length - 1
 
-        const risk = predictSegmentRisk(segments, [freshReportAt(REPORT_STATION, now)], now, new Set([LINE_ID]))
+        const risk = predictSegmentRisk(segments, [freshReportAt(loopStationIds[0]!, now)], now, new Set([lineId]))
 
         expect(risk['seg-0']).toBeDefined()
         expect(risk[`seg-${lastPosition}`]).toBeDefined()
@@ -91,25 +94,29 @@ describe('predictSegmentRisk circular lines', () => {
     })
 
     it('keeps linear-line behaviour unchanged: no wrap without a circular flag or closed loop', () => {
-        const segments = buildSegments(RING_STATIONS, { closed: false })
+        if (loopStationIds.length === 0) return
+
+        const segments = buildSegments({ closed: false })
         const lastPosition = segments.length - 1
 
-        const risk = predictSegmentRisk(segments, [freshReportAt(REPORT_STATION, now)], now)
+        const risk = predictSegmentRisk(segments, [freshReportAt(loopStationIds[0]!, now)], now)
 
         expect(risk['seg-0']).toBeDefined()
         expect(risk[`seg-${lastPosition}`]).toBeUndefined()
     })
 
     it('keeps directional-report semantics on a circular line', () => {
-        const segments = buildSegments(RING_STATIONS, { closed: true })
+        if (loopStationIds.length === 0) return
+
+        const segments = buildSegments({ closed: true })
         const lastPosition = segments.length - 1
 
         const directed = predictSegmentRisk(
             segments,
-            [{ ...freshReportAt(REPORT_STATION, now), directionId: RING_STATIONS[1]! }],
+            [{ ...freshReportAt(loopStationIds[0]!, now), directionId: loopStationIds[1]! }],
             now
         )
-        const undirected = predictSegmentRisk(segments, [freshReportAt(REPORT_STATION, now)], now)
+        const undirected = predictSegmentRisk(segments, [freshReportAt(loopStationIds[0]!, now)], now)
 
         // Directed reports still colour both sides of the loop
         expect(directed['seg-0']).toBeDefined()


### PR DESCRIPTION
## Describe the issue:

A report on a circular line only coloured the risk layer in one direction (FRE-752, #837). Reproduced with a fresh S42 report at Gesundbrunnen: only the Wedding-side branch turned red/yellow while everything from Schönhauser Allee around the ring stayed green.

`predictSegmentRisk` measures a segment's distance from the reported station as the absolute difference between the segment's rank and the station's rank in the line's ordered segment list. Gesundbrunnen is position 0 in S42's list, so segments on the other adjacent branch sit at ranks 23–25, the spatial decay (beta-binomial, zero beyond distance 4–6) evaluated to 0, and that whole side stayed green. A circular service has no terminal, so the ordered segment list must wrap.

## Explain how you solved the issue:

- **Wrapped distance for rings** (`risk-model.ts`): for circular lines the distance is now the shorter way around the ring, `min(d, ringSize − d)`. Linear lines keep the unwrapped distance, and directional-report semantics are untouched.
- **Ring size**: seeded rings drop the closing station repeat (the `line_stations` PK forbids it), so their segment list is open by exactly one arc — S41/S42 have 27 stations but 26 segments. The wrap modulus for a flagged circular line is therefore `segment count + 1`. A segment list that already closes on itself (last `toStationId` === first `fromStationId`) wraps with its own length and is treated as a ring even without the flag.
- **Plumbing** (`risk-service.ts`): `RiskService` resolves circular line ids from the (cached) lines table and passes them to `predictSegmentRisk` as a new optional parameter, keeping the model itself city-agnostic.

With the fix, the same Gesundbrunnen report colours both branches symmetrically (verified in the Vitest suite and against a locally seeded `wrangler dev` API):

```
pos 0  Gesundbrunnen → Wedding            1.000 dark red      pos 25 Prenzlauer Allee → Schönhauser  0.831 red
pos 1  Wedding → Westhafen                0.980 dark red      pos 24 Greifswalder → Prenzlauer       0.619 red
pos 2  Westhafen → Beusselstraße          0.831 red           pos 23 Landsberger → Greifswalder      0.357 yellow
pos 3–4 fade to yellow, pos 5–22 stay green (wrap is a shortest path, not a blanket)
```

Tests:
- New city-agnostic unit test for `predictSegmentRisk` (`tests/risk-model.test.ts`) using real station ids and a closed loop of segments — a report at one loop station must produce non-green risk on both adjacent branches, including across the list boundary. It also covers the open-list + flag shape the seed produces, unchanged linear behaviour, and directional reports on a ring. All circular assertions fail on `main` and pass with the fix.
- New integration test in `tests/getRisk.test.ts` that reports at the segment-list boundary station of whatever circular line the seeded city has and asserts both boundary segments come back non-green through the public API.

## Additional notes or considerations:

- The arc between the boundary station and the previous station (e.g. Schönhauser Allee → Gesundbrunnen) belongs only to the sibling ring line (S41), so an S42-only report still leaves that single arc green on S42's layer; risk reaching it would require spreading a report across sibling ring lines, which is report-semantics work outside this fix.
- `buildLineIndexes` was extracted from `predictSegmentRisk` unchanged to keep the function under the ESLint complexity ceiling.

Fixes FRE-752
Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYWRQkkyWDoU5Nho9n35fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYWRQkkyWDoU5Nho9n35fH)_