### PR TITLE
fix: reserve space for station insights

### DIFF
--- a/packages/frontend-next/src/components/map/StationHistoricalInsights.tsx
+++ b/packages/frontend-next/src/components/map/StationHistoricalInsights.tsx
@@ -13,19 +13,19 @@ export function StationHistoricalInsights({ stationId }: StationHistoricalInsigh
   const { t } = useTranslation(NAMESPACE);
   const { data: insights } = useStationInsights(stationId);
 
-  if (!insights) return null;
-
   return (
-    <CardContent>
-      <div className="text-muted-foreground flex items-baseline justify-between gap-3 text-sm">
-        <p>
-          {t('stationRank', {
-            position: insights.ranking.position,
-            population: insights.ranking.population,
-          })}
-        </p>
-        <p>{t('stationReportsLast30Days', { count: insights.reportCount.value })}</p>
-      </div>
+    <CardContent className="min-h-5">
+      {insights && (
+        <div className="text-muted-foreground flex items-baseline justify-between gap-3 text-sm">
+          <p>
+            {t('stationRank', {
+              position: insights.ranking.position,
+              population: insights.ranking.population,
+            })}
+          </p>
+          <p>{t('stationReportsLast30Days', { count: insights.reportCount.value })}</p>
+        </div>
+      )}
     </CardContent>
   );
 }


### PR DESCRIPTION
## Why this follow-up exists

The station insight row is intentionally quiet while its cached request resolves: no spinner and no skeleton compete with the live station and line information.

Without an element in the layout during loading, the line list and report button move downward when the rank/count row arrives. That is a cumulative layout shift.

## Design

`StationHistoricalInsights` now always renders its `CardContent` wrapper with a `min-h-5` reservation.

- `min-h-5` is the same 20px height as the final `text-sm` rank/count row.
- The reserved area is visually empty while the response is pending.
- When data arrives, the row replaces the reservation without changing the sheet's vertical geometry.

This retains a calm loading state while keeping the primary action and scrollable line card fixed in place.

## Verification

- `bun run build` in `packages/frontend-next`
- Confirmed the reserved wrapper and rendered row use the same 20px height in the component contract.

A trace-based CLS measurement could not be captured because the local browser performance connector is unavailable in this session.

@codex please review the reserved-height approach for the station insights row.