### PR TITLE
fix: detect native platform and set report source dynamically

### DIFF
--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -1,3 +1,4 @@
+import { Capacitor } from '@capacitor/core';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { TFunction } from 'i18next';
 import { useEffect, useState } from 'react';
@@ -234,14 +235,21 @@ export function useSubmitReport() {
         const lineId = resolveLineId(input, lines);
         const submitUrl = new URL(`${API_URL}/v0/reports`);
         submitUrl.searchParams.set('city', currentCitySlug);
+        // The native (Capacitor iOS/Android) builds and the web build share this same code, so the
+        // report `source` — which the Reports dashboard splits on — must be derived at runtime.
+        // `getPlatform()` is 'ios' | 'android' | 'web'; only 'web' is the browser build.
+        const isNative = Capacitor.isNativePlatform();
         const response = await fetch(submitUrl, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'ff-platform': 'web' },
+          headers: {
+            'Content-Type': 'application/json',
+            'ff-platform': Capacitor.getPlatform(),
+          },
           body: JSON.stringify({
             stationId: input.stationId,
             lineId,
             directionId: input.directionStationId ?? null,
-            source: 'web_app',
+            source: isNative ? 'mobile_app' : 'web_app',
           }),
         });
         if (!response.ok) throw new Error(`Report submission failed: ${response.status}`);


### PR DESCRIPTION
## Describe the issue:

The report submission endpoint needs to distinguish between web browser and native (iOS/Android) app submissions. Currently, the `source` field is hardcoded to `'web_app'` and the `ff-platform` header is hardcoded to `'web'`, which doesn't account for native mobile builds that share the same codebase.

## Explain how you solved the issue:

- Added Capacitor platform detection using `Capacitor.isNativePlatform()` and `Capacitor.getPlatform()`
- Dynamically set the `ff-platform` header to the actual platform (`'ios'`, `'android'`, or `'web'`) instead of hardcoding `'web'`
- Conditionally set the `source` field to `'mobile_app'` for native builds and `'web_app'` for web builds
- Added explanatory comments documenting why runtime detection is necessary for shared code

## Additional notes or considerations:

The native and web builds share the same source code, so platform detection must happen at runtime rather than build time. The Reports dashboard uses the `source` field to split analytics, so accurate reporting is important for both web and mobile users.

https://claude.ai/code/session_01FGTsTfkDUGxmRzQ8q7epfJ