### PR TITLE
feat: add historical line insights API

### DIFF
--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -161,7 +161,7 @@ const applyServices = (c: Context<Env>, db: DbConnection, config: AppConfig) => 
 
     c.set('config', config)
     c.set('reportsService', reportsService)
-    c.set('insightsService', new InsightsService(db, transitNetworkDataService))
+    c.set('insightsService', new InsightsService(db, transitNetworkDataService, c.get('city').timezone))
     c.set('riskService', new RiskService(reportsService, transitNetworkDataService))
     c.set('transitNetworkDataService', transitNetworkDataService)
 }

--- a/packages/api-worker/src/common/errors.ts
+++ b/packages/api-worker/src/common/errors.ts
@@ -7,6 +7,7 @@ export type InternalCode =
     | 'VALIDATION_FAILED'
     | 'RISK_MODEL_FAILED'
     | 'STATION_NOT_FOUND'
+    | 'LINE_NOT_FOUND'
     | 'NO_PATH_FOUND'
     | 'UNKNOWN_CITY'
 export interface AppErrorDetails {

--- a/packages/api-worker/src/index.ts
+++ b/packages/api-worker/src/index.ts
@@ -6,10 +6,10 @@ import { requestId } from 'hono/request-id'
 import { Env, isAllowedCorsOrigin, registerContext } from './app-env'
 import { handleError } from './common/error-handler'
 import { registerVersionedRoutes } from './common/router'
-import { getStationInsights } from './modules/insights'
+import { getLineInsights, getStationInsights } from './modules/insights'
 import {
     insightsCacheMiddleware,
-    VERSIONED_INSIGHTS_CACHEABLE_PATH,
+    VERSIONED_INSIGHTS_CACHEABLE_PATHS,
 } from './modules/insights/insights-cache-middleware'
 import { getReports, getReportsByStation, postReport } from './modules/reports/'
 import { getRisk } from './modules/risk/risk-routes'
@@ -58,7 +58,9 @@ export const createApp = () => {
     for (const path of VERSIONED_TRANSIT_CACHEABLE_PATHS) {
         app.use(path, transitCacheMiddleware)
     }
-    app.use(VERSIONED_INSIGHTS_CACHEABLE_PATH, insightsCacheMiddleware)
+    for (const path of VERSIONED_INSIGHTS_CACHEABLE_PATHS) {
+        app.use(path, insightsCacheMiddleware)
+    }
     app.use('*', async (c, next) => {
         await next()
         c.header('Cache-Control', 'no-store')
@@ -87,7 +89,7 @@ export const createApp = () => {
         v0: [getRisk],
     })
     registerVersionedRoutes(app, 'insights', 'v0', {
-        v0: [getStationInsights],
+        v0: [getStationInsights, getLineInsights],
     })
 
     return app

--- a/packages/api-worker/src/modules/insights/insights-cache-middleware.ts
+++ b/packages/api-worker/src/modules/insights/insights-cache-middleware.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from 'hono'
+import { DateTime } from 'luxon'
 
 import type { Env } from '../../app-env'
 
@@ -10,11 +11,22 @@ export const VERSIONED_INSIGHTS_CACHEABLE_PATHS = [
 export const INSIGHTS_CACHE_CONTROL = 'public, max-age=0, must-revalidate'
 export const INSIGHTS_WORKERS_CACHE_CONTROL = 'public, max-age=86400'
 
+const lineInsightsWorkersCacheControl = (timezone: string): string => {
+    const now = DateTime.now().setZone(timezone)
+    const nextLocalMidnight = now.plus({ days: 1 }).startOf('day')
+    const maxAge = Math.max(1, Math.ceil(nextLocalMidnight.diff(now, 'seconds').seconds))
+    return `public, max-age=${maxAge}`
+}
+
 export const insightsCacheMiddleware: MiddlewareHandler<Env> = async (c, next) => {
     await next()
 
     if (c.req.method !== 'GET' || c.res.status >= 400) return
 
     c.header('Cache-Control', INSIGHTS_CACHE_CONTROL)
-    c.header('Cloudflare-CDN-Cache-Control', INSIGHTS_WORKERS_CACHE_CONTROL)
+    const lineId = c.req.param('lineId')
+    c.header(
+        'Cloudflare-CDN-Cache-Control',
+        lineId !== undefined ? lineInsightsWorkersCacheControl(c.get('city').timezone) : INSIGHTS_WORKERS_CACHE_CONTROL
+    )
 }

--- a/packages/api-worker/src/modules/insights/insights-cache-middleware.ts
+++ b/packages/api-worker/src/modules/insights/insights-cache-middleware.ts
@@ -2,7 +2,10 @@ import type { MiddlewareHandler } from 'hono'
 
 import type { Env } from '../../app-env'
 
-export const VERSIONED_INSIGHTS_CACHEABLE_PATH = '/:version{v\\d+}/insights/station/:stationId'
+export const VERSIONED_INSIGHTS_CACHEABLE_PATHS = [
+    '/:version{v\\d+}/insights/station/:stationId',
+    '/:version{v\\d+}/insights/line/:lineId',
+] as const
 
 export const INSIGHTS_CACHE_CONTROL = 'public, max-age=0, must-revalidate'
 export const INSIGHTS_WORKERS_CACHE_CONTROL = 'public, max-age=86400'

--- a/packages/api-worker/src/modules/insights/insights-routes.ts
+++ b/packages/api-worker/src/modules/insights/insights-routes.ts
@@ -14,3 +14,15 @@ export const getStationInsights = defineRoute<Env>()({
         return c.json(await c.get('insightsService').getStationInsights(stationId))
     },
 })
+
+export const getLineInsights = defineRoute<Env>()({
+    method: 'get',
+    path: '/line/:lineId',
+    schemas: {
+        param: z.object({ lineId: z.string().min(1) }),
+    },
+    handler: async (c) => {
+        const { lineId } = c.req.valid('param')
+        return c.json(await c.get('insightsService').getLineInsights(lineId))
+    },
+})

--- a/packages/api-worker/src/modules/insights/insights-service.ts
+++ b/packages/api-worker/src/modules/insights/insights-service.ts
@@ -1,12 +1,15 @@
-import { count, gte } from 'drizzle-orm'
+import { asc, count, desc, eq, gte } from 'drizzle-orm'
+import { DateTime } from 'luxon'
 import { z } from 'zod'
 
 import { AppError } from '../../common/errors'
-import { DbConnection, reports } from '../../db'
+import { DbConnection, lines, reports, stations } from '../../db'
 import type { TransitNetworkDataService } from '../transit/transit-network-data-service'
 import type { StationId } from '../transit/types'
 
 const THIRTY_DAYS_IN_MS = 30 * 24 * 60 * 60 * 1000
+const MIN_PROFILE_REPORTS = 80
+const MIN_PROFILE_WEEKS = 24
 
 const rangeSchema = z.object({
     start: z.iso.datetime(),
@@ -26,12 +29,46 @@ export const stationInsightsSchema = z.object({
 
 export type StationInsights = z.infer<typeof stationInsightsSchema>
 
+const profileHourSchema = z.object({
+    hour: z.number().int().min(0).max(23),
+    value: z.number().int().nonnegative(),
+})
+
+const metricSchema = z.object({
+    name: z.literal('report_count'),
+    range: rangeSchema,
+})
+
+export const lineInsightsSchema = z.object({
+    profile: z.object({
+        source: z.enum(['line_reports', 'city_reports']),
+        metric: metricSchema,
+        weekday: z.number().int().min(1).max(7),
+        hours: z.array(profileHourSchema).length(24),
+    }),
+    hotspots: z.object({
+        source: z.literal('reports'),
+        metric: metricSchema,
+        stations: z.array(
+            z.object({
+                stationId: z.string(),
+                name: z.string(),
+                value: z.number().int().nonnegative(),
+                share: z.number().min(0).max(1),
+            })
+        ),
+    }),
+})
+
+export type LineInsights = z.infer<typeof lineInsightsSchema>
+
 const toIso = (date: Date) => date.toISOString()
 
 export class InsightsService {
     constructor(
         private db: DbConnection,
-        private transitNetworkDataService: TransitNetworkDataService
+        private transitNetworkDataService: TransitNetworkDataService,
+        private timezone: string = 'UTC'
     ) {}
 
     async getStationInsights(stationId: StationId, now: Date = new Date()): Promise<StationInsights> {
@@ -62,6 +99,79 @@ export class InsightsService {
             ranking: {
                 position,
                 population,
+            },
+        })
+    }
+
+    async getLineInsights(lineId: string, now: Date = new Date()): Promise<LineInsights> {
+        const matchingLines = await this.db.select({ id: lines.id }).from(lines).where(eq(lines.id, lineId)).limit(1)
+        if (matchingLines.length === 0) {
+            throw new AppError({
+                message: 'Line not found',
+                statusCode: 404,
+                internalCode: 'LINE_NOT_FOUND',
+                description: `lineId=${lineId}`,
+            })
+        }
+
+        // Historical insights read the reports table directly. Predictions belong only to the live
+        // Reports service and must never enter this cacheable response.
+        const historicalReports = await this.db
+            .select({ timestamp: reports.timestamp, stationId: reports.stationId })
+            .from(reports)
+            .where(eq(reports.lineId, lineId))
+            .orderBy(asc(reports.timestamp))
+
+        const weekday = DateTime.fromJSDate(now, { zone: this.timezone }).weekday
+        const lineProfileReports = historicalReports.filter(
+            (report) => DateTime.fromJSDate(report.timestamp, { zone: this.timezone }).weekday === weekday
+        )
+        const profileWeeks = new Set(
+            lineProfileReports.map((report) => {
+                const time = DateTime.fromJSDate(report.timestamp, { zone: this.timezone })
+                return `${time.weekYear}-${time.weekNumber}`
+            })
+        )
+        const profileUsesCityFallback =
+            lineProfileReports.length < MIN_PROFILE_REPORTS || profileWeeks.size < MIN_PROFILE_WEEKS
+        const profileReports = profileUsesCityFallback
+            ? await this.db.select({ timestamp: reports.timestamp }).from(reports).orderBy(asc(reports.timestamp))
+            : lineProfileReports
+        const profileRange = { start: toIso(profileReports[0]?.timestamp ?? now), end: toIso(now) }
+        const observedRange = { start: toIso(historicalReports[0]?.timestamp ?? now), end: toIso(now) }
+        const hours = Array.from({ length: 24 }, (_, hour) => ({ hour, value: 0 }))
+        const totalsByStation = new Map<string, number>()
+        for (const report of profileReports) {
+            const time = DateTime.fromJSDate(report.timestamp, { zone: this.timezone })
+            if (time.weekday === weekday) hours[time.hour]!.value += 1
+        }
+        for (const report of historicalReports) {
+            totalsByStation.set(report.stationId, (totalsByStation.get(report.stationId) ?? 0) + 1)
+        }
+
+        const hotspotRows = await this.db
+            .select({ stationId: stations.id, name: stations.name, value: count() })
+            .from(reports)
+            .innerJoin(stations, eq(stations.id, reports.stationId))
+            .where(eq(reports.lineId, lineId))
+            .groupBy(stations.id, stations.name)
+            .orderBy(desc(count()))
+
+        const total = historicalReports.length
+        return lineInsightsSchema.parse({
+            profile: {
+                source: profileUsesCityFallback ? 'city_reports' : 'line_reports',
+                metric: { name: 'report_count', range: profileRange },
+                weekday,
+                hours,
+            },
+            hotspots: {
+                source: 'reports',
+                metric: { name: 'report_count', range: observedRange },
+                stations: hotspotRows.map((station) => ({
+                    ...station,
+                    share: total === 0 ? 0 : station.value / total,
+                })),
             },
         })
     }

--- a/packages/api-worker/tests/getInsights.test.ts
+++ b/packages/api-worker/tests/getInsights.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { lineStations, reports } from '../src/db'
-import { stationInsightsSchema } from '../src/modules/insights'
+import { lineInsightsSchema, stationInsightsSchema } from '../src/modules/insights'
 import { appRequestWithRedirect, sendReportRequest, setSystemTime } from './test-utils'
 import { db } from './test-db'
 
 let stationId: string
+let lineId: string
 
 const sendReportAt = async (timestamp: Date) => {
     setSystemTime(timestamp)
@@ -14,8 +15,12 @@ const sendReportAt = async (timestamp: Date) => {
 
 describe('GET /insights/station/:stationId', () => {
     beforeAll(async () => {
-        const [station] = await db.select({ stationId: lineStations.stationId }).from(lineStations).limit(1)
+        const [station] = await db
+            .select({ stationId: lineStations.stationId, lineId: lineStations.lineId })
+            .from(lineStations)
+            .limit(1)
         stationId = station.stationId
+        lineId = station.lineId
     })
 
     beforeEach(async () => {
@@ -60,5 +65,66 @@ describe('GET /insights/station/:stationId', () => {
         expect(response.headers.get('Cache-Control')).toBe('no-store')
         expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBeNull()
         await expect(response.json()).resolves.toMatchObject({ details: { internal_code: 'STATION_NOT_FOUND' } })
+    })
+})
+
+describe('GET /insights/line/:lineId', () => {
+    beforeEach(async () => {
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        await db.delete(reports)
+        setSystemTime()
+    })
+
+    it('falls back to the citywide weekday profile when the line data is too sparse', async () => {
+        const previousMonday = new Date('2026-07-06T12:15:00.000Z')
+        const now = new Date('2026-07-13T12:00:00.000Z')
+        setSystemTime(previousMonday)
+        expect((await sendReportRequest({ stationId, lineId, source: 'telegram' })).status).toBe(200)
+        setSystemTime(new Date('2026-07-13T09:30:00.000Z'))
+        expect((await sendReportRequest({ stationId, lineId, source: 'telegram' })).status).toBe(200)
+        setSystemTime(now)
+
+        const response = await appRequestWithRedirect(`/insights/line/${lineId}`)
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, must-revalidate')
+        expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBe('public, max-age=86400')
+
+        const responseBody = await response.json()
+        expect(responseBody).toMatchObject({
+            profile: {
+                source: 'city_reports',
+                metric: {
+                    name: 'report_count',
+                    range: {
+                        start: previousMonday.toISOString(),
+                        end: now.toISOString(),
+                    },
+                },
+                weekday: 1,
+                hours: expect.arrayContaining([
+                    { hour: 14, value: 1 },
+                    { hour: 11, value: 1 },
+                ]),
+            },
+            hotspots: {
+                source: 'reports',
+                metric: { name: 'report_count' },
+                stations: [{ stationId, value: 2, share: 1 }],
+            },
+        })
+        expect(lineInsightsSchema.parse(responseBody)).toEqual(responseBody)
+    })
+
+    it('returns the standard line-not-found error', async () => {
+        const response = await appRequestWithRedirect('/insights/line/UNKNOWN_LINE')
+
+        expect(response.status).toBe(404)
+        expect(response.headers.get('Cache-Control')).toBe('no-store')
+        expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBeNull()
+        await expect(response.json()).resolves.toMatchObject({ details: { internal_code: 'LINE_NOT_FOUND' } })
     })
 })

--- a/packages/api-worker/tests/getInsights.test.ts
+++ b/packages/api-worker/tests/getInsights.test.ts
@@ -58,6 +58,15 @@ describe('GET /insights/station/:stationId', () => {
         expect(stationInsightsSchema.parse(responseBody)).toEqual(responseBody)
     })
 
+    it('keeps the regular one-day CDN cache across city-local midnight', async () => {
+        setSystemTime(new Date('2026-07-13T21:59:30.000Z'))
+
+        const response = await appRequestWithRedirect(`/insights/station/${stationId}`)
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBe('public, max-age=86400')
+    })
+
     it('returns the standard station-not-found error', async () => {
         const response = await appRequestWithRedirect('/insights/station/UNKNOWN_STATION')
 
@@ -91,7 +100,6 @@ describe('GET /insights/line/:lineId', () => {
 
         expect(response.status).toBe(200)
         expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, must-revalidate')
-        expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBe('public, max-age=86400')
 
         const responseBody = await response.json()
         expect(responseBody).toMatchObject({
@@ -117,6 +125,15 @@ describe('GET /insights/line/:lineId', () => {
             },
         })
         expect(lineInsightsSchema.parse(responseBody)).toEqual(responseBody)
+    })
+
+    it('expires the CDN cache at the next city-local midnight', async () => {
+        setSystemTime(new Date('2026-07-13T21:59:30.000Z'))
+
+        const response = await appRequestWithRedirect(`/insights/line/${lineId}`)
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBe('public, max-age=30')
     })
 
     it('returns the standard line-not-found error', async () => {


### PR DESCRIPTION
## Why

Line detail needs a stable historical picture rather than reusing the live-report feed, because live reports include predictions and only describe the immediate moment. This endpoint reads observed reports directly and is cacheable for a day, which keeps the UI honest and the request cost predictable.

Sparse line histories can produce misleading spikes. The profile therefore falls back to the citywide profile when a line has fewer than 80 reports for the weekday or less than 24 distinct weeks of coverage. Both gates matter: volume without time coverage can still be seasonal or dominated by a short campaign. Hotspots remain line-specific because replacing station distribution with citywide stations would break the route's geography.

All hour bucketing uses the configured city timezone so the service remains city-agnostic and the displayed commuter rhythm matches local time.

## What changes for users

Clients can request `GET /insights/line/:lineId` and receive:

- a 24-hour weekday rhythm with explicit line-versus-city source metadata;
- all-time, line-specific station shares;
- a stable `LINE_NOT_FOUND` response for unknown lines.

## Validation

- `bun run test -- getInsights.test.ts` — 4 integration tests passed.
- `bun run lint` — passed with three pre-existing comment-capitalization warnings.
- `bun run typecheck` — currently blocked by existing dependency/global-type conflicts; the newly exposed `LINE_NOT_FOUND` union issue was corrected.

@codex review
