### PR TITLE
feat: link report line references

### DIFF
--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -10,6 +10,7 @@ import { useGeolocation } from '@/contexts/Geolocation.context';
 import { useModalViewDuration } from '@/hooks/useModalViewDuration';
 import { track } from '@/lib/analytics';
 import { currentCity } from '@/lib/city';
+import { Route as LineDetailRoute } from '@/routes/_map/line/$lineName';
 import { Route as StationRoute } from '@/routes/_map/station/$stationId';
 
 import { DetailCard } from './DetailCard';
@@ -62,11 +63,24 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
       closeLabel={t('close')}
       onClose={onClose}
     >
-      {(lineName || directionName) && (
-        <CardContent className="flex items-center gap-2">
-          {lineName && <LineBadge name={lineName} />}
-          {directionName && <span className="text-sm font-semibold">{directionName}</span>}
+      {lineName ? (
+        <CardContent className="px-0">
+          <Link
+            to={LineDetailRoute.to}
+            params={{ lineName }}
+            className="hover:bg-muted/70 focus-visible:ring-ring flex items-center gap-2 px-4 py-2 outline-none focus-visible:ring-2"
+          >
+            <LineBadge name={lineName} className="underline underline-offset-2" />
+            {directionName && <span className="text-sm font-semibold">{directionName}</span>}
+            <ChevronRight className="text-muted-foreground ml-auto size-4 shrink-0" aria-hidden />
+          </Link>
         </CardContent>
+      ) : (
+        directionName && (
+          <CardContent className="flex items-center gap-2">
+            <span className="text-sm font-semibold">{directionName}</span>
+          </CardContent>
+        )
       )}
       <CardContent className="space-y-1">
         {report && (

--- a/packages/frontend-next/src/components/reports/LineScoreList.tsx
+++ b/packages/frontend-next/src/components/reports/LineScoreList.tsx
@@ -1,4 +1,8 @@
+import { Link } from '@tanstack/react-router';
+import { ChevronRight } from 'lucide-react';
+
 import { LineBadge } from '@/components/transit/LineBadge';
+import { Route as LineDetailRoute } from '@/routes/_map/line/$lineName';
 
 import type { LineScore } from './lineScores';
 
@@ -22,17 +26,24 @@ export function LineScoreList({ scores, total }: LineScoreListProps) {
         const percent = denominator > 0 ? Math.round((entry.score / denominator) * 100) : 0;
         const width = maxScore > 0 ? (entry.score / maxScore) * 100 : 0;
         return (
-          <li key={entry.name} className="flex h-14 items-center gap-3 px-4">
-            <LineBadge name={entry.name} />
-            <div className="bg-muted h-2.5 flex-1 overflow-hidden rounded-full">
-              <div
-                className="h-full rounded-full"
-                style={{ width: `${width}%`, backgroundColor: entry.fill }}
-              />
-            </div>
-            <span className="w-9 shrink-0 text-right text-sm font-semibold tabular-nums">
-              {percent}%
-            </span>
+          <li key={entry.name}>
+            <Link
+              to={LineDetailRoute.to}
+              params={{ lineName: entry.name }}
+              className="hover:bg-muted/70 focus-visible:ring-ring flex h-14 items-center gap-3 px-4 outline-none focus-visible:ring-2"
+            >
+              <LineBadge name={entry.name} className="underline underline-offset-2" />
+              <div className="bg-muted h-2.5 flex-1 overflow-hidden rounded-full">
+                <div
+                  className="h-full rounded-full"
+                  style={{ width: `${width}%`, backgroundColor: entry.fill }}
+                />
+              </div>
+              <span className="w-9 shrink-0 text-right text-sm font-semibold tabular-nums">
+                {percent}%
+              </span>
+              <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
+            </Link>
           </li>
         );
       })}

--- a/packages/frontend-next/src/components/reports/lineScores.ts
+++ b/packages/frontend-next/src/components/reports/lineScores.ts
@@ -12,12 +12,19 @@ export function computeLineScores(
   stations: Stations | undefined,
   lines: Line[] | undefined,
 ): LineScore[] {
+  if (!lines) return [];
+
   const scores = new Map<string, number>();
   const add = (name: string, value: number) => scores.set(name, (scores.get(name) ?? 0) + value);
+  const lineById = new Map(lines.map((line) => [line.id, line]));
+  const lineByName = new Map<string, Line>();
+  for (const line of lines) {
+    if (!lineByName.has(line.name)) lineByName.set(line.name, line);
+  }
 
   for (const report of reports) {
     if (report.lineId) {
-      const name = lines?.find((line) => line.id === report.lineId)?.name;
+      const name = lineById.get(report.lineId)?.name;
       if (name) add(name, 1);
       continue;
     }
@@ -26,15 +33,15 @@ export function computeLineScores(
     const names = resolveStationLineNames(stationLines, lines);
     if (names.length === 0) continue;
     const share = 1 / names.length;
-    for (const name of names) add(name, share);
+    for (const name of names) {
+      if (lineByName.has(name)) add(name, share);
+    }
   }
 
-  const colorByName = new Map(lines?.map((line) => [line.name, line.color]));
   return [...scores.entries()]
-    .map(([name, score]) => ({
-      name,
-      score,
-      fill: colorByName.get(name) ?? 'var(--color-muted-foreground)',
-    }))
+    .flatMap(([name, score]) => {
+      const line = lineByName.get(name);
+      return line ? [{ name, score, fill: line.color }] : [];
+    })
     .sort((a, b) => b.score - a.score || compareLineOrder(a, b));
 }


### PR DESCRIPTION
## Stack

Depends on #850, which introduces the line-detail route. Keeping these affordances separate makes the core sheet reviewable without mixing in every discovery surface.

## Why

Once line detail exists, line badges that still behave like static labels become dead ends. Reports are already organized around lines, so making those references navigable lets users move from aggregate or individual evidence into the broader route context without returning to the map.

The complete row is clickable rather than only the badge. This provides a larger touch target on mobile and makes the interaction consistent across the reports summary, line ranking, and report detail. Underlining the badge and placing a chevron at the trailing edge gives both a conventional text cue and a directional cue; color alone would not be an accessible affordance.

Line scores now retain the canonical line ID instead of trying to navigate by display name. Names can be shared by route variants, while the ID is the stable routing identity.

## What changes for users

- Line rows in report summaries and line rankings open line detail.
- A report's line header opens the same line detail.
- Underlines, row hover/focus states, and trailing chevrons make navigation discoverable and keyboard-visible.

## Validation

- `bun run build` — passed with this stacked diff.
- `bun run lint` — passed with two existing React Compiler/TanStack Virtual warnings.

@codex review
