### PR TITLE
fix: unify station and line drill-down affordances

### DIFF
--- a/packages/frontend-next/src/components/map/StationLineReports.tsx
+++ b/packages/frontend-next/src/components/map/StationLineReports.tsx
@@ -26,7 +26,7 @@ function LineReportRow({ line }: { line: StationLineReports }) {
       onClick={() => track('station_line_selected', { line_id: line.name })}
       className="hover:bg-muted/70 focus-visible:ring-ring flex items-center gap-3 px-3 py-2.5 outline-none focus-visible:ring-2"
     >
-      <LineBadge name={line.name} className="underline underline-offset-2" />
+      <LineBadge name={line.name} />
       <div className="text-muted-foreground text-sm">
         <p>{t('lineReportsLast24Hours', { count: line.reportsInLast24Hours })}</p>
         {hasRecentReports && (


### PR DESCRIPTION
## What changed

Removed the underline from served-line badges in station detail. The full row remains the semantic link and keeps its hover, pressed, and visible keyboard-focus treatment.

## Why this was necessary

Station and line drill-down rows represented the same navigation pattern but used different text decoration. On a mobile-first surface the underline did not add a dependable affordance; it made the line destination look different even though both interactions rely on the full-row tap target and chevron.

## Impact

Station and line destinations now use one consistent non-underlined label treatment without shrinking the tap target or changing analytics.

## Validation

- frontend ESLint (no errors; existing React Compiler warnings only)
- `git diff --check`
- pairwise merge simulation against the other ticket branches

Linear: [FRE-762](https://linear.app/freifahren/issue/FRE-762/fix-unify-station-and-line-drill-down-affordances)

@codex review