### PR TITLE
fix: align line-row chevrons with station navigation

### DIFF
--- a/packages/frontend-next/src/components/map/StationLineReports.tsx
+++ b/packages/frontend-next/src/components/map/StationLineReports.tsx
@@ -25,6 +25,7 @@ function LineReportRow({ line }: { line: StationLineReports }) {
       onClick={() => track('station_line_selected', { line_id: line.name })}
       className="hover:bg-muted/70 focus-visible:ring-ring flex items-center gap-3 px-3 py-2.5 outline-none focus-visible:ring-2"
     >
+      <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
       <LineBadge name={line.name} />
       <div className="text-muted-foreground text-sm">
         <p>{t('lineReportsLast24Hours', { count: line.reportsInLast24Hours })}</p>
@@ -34,7 +35,6 @@ function LineReportRow({ line }: { line: StationLineReports }) {
           </p>
         )}
       </div>
-      <ChevronRight className="text-muted-foreground ml-auto size-4 shrink-0" aria-hidden />
     </Link>
   );
 }


### PR DESCRIPTION
## What changed

Moved the served-line chevron to the leading edge of the row while preserving the full-width semantic link, activity copy, analytics, and keyboard-focus styling.

## Why this was necessary

The station destination and served-line destination used different chevron placement for equivalent drill-down actions. Aligning them makes the interaction pattern easier to scan and understand on narrow sheets.

## Merge strategy

Rebased onto the current `main` after FRE-762 and the other station-detail PRs merged. The PR now contains only the chevron move and has a clean three-way merge result.

## Validation

- targeted Prettier and ESLint checks
- frontend production build
- `git diff --check`
- clean three-way merge simulation against current `origin/main`

Linear: [FRE-761](https://linear.app/freifahren/issue/FRE-761/fix-align-line-row-chevrons-with-station-navigation)

@codex review