### PR TITLE
fix: preserve line detail entry sources

### DIFF
--- a/packages/frontend-next/src/components/map/LineDetail.tsx
+++ b/packages/frontend-next/src/components/map/LineDetail.tsx
@@ -8,7 +8,7 @@ import { useStations } from '@/api/transit';
 import { Button } from '@/components/ui/button';
 import { CardContent } from '@/components/ui/card';
 import { useModalViewDuration } from '@/hooks/useModalViewDuration';
-import { track } from '@/lib/analytics';
+import { track, type LineDetailSource } from '@/lib/analytics';
 import { currentCity } from '@/lib/city';
 import { cn } from '@/lib/utils';
 import { Route as ReportRoute } from '@/routes/report';
@@ -28,7 +28,11 @@ export type LineDetailLine = {
   variantIds: string[];
 };
 
-type LineDetailProps = { line: LineDetailLine; onClose: () => void };
+type LineDetailProps = {
+  line: LineDetailLine;
+  onClose: () => void;
+  source: LineDetailSource;
+};
 
 const cityHourFormatter = new Intl.DateTimeFormat('en-GB', {
   timeZone: currentCity.timezone,
@@ -51,7 +55,7 @@ function countReportsOnLine(
   return count;
 }
 
-export function LineDetail({ line, onClose }: LineDetailProps) {
+export function LineDetail({ line, onClose, source }: LineDetailProps) {
   const { t, i18n } = useTranslation(NAMESPACE);
   const { data: insights } = useLineInsights(line.name);
   const { data: reports, isSuccess: hasLiveReports } = useReports(DAY_MS);
@@ -60,8 +64,8 @@ export function LineDetail({ line, onClose }: LineDetailProps) {
   useModalViewDuration('line');
 
   useEffect(() => {
-    track('line_detail_opened', { line_id: line.name, source: 'station' });
-  }, [line.name]);
+    track('line_detail_opened', { line_id: line.name, source });
+  }, [line.name, source]);
 
   const variantIds = new Set(line.variantIds);
   const recentReportCount = countReportsOnLine(reports, variantIds);

--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -81,6 +81,7 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
           <Link
             to={LineDetailRoute.to}
             params={{ lineName }}
+            search={{ source: 'report' }}
             className="hover:bg-muted/70 focus-visible:ring-ring flex items-center gap-2 px-4 py-2 outline-none focus-visible:ring-2"
           >
             <LineBadge name={lineName} className="underline underline-offset-2" />

--- a/packages/frontend-next/src/components/map/StationLineReports.tsx
+++ b/packages/frontend-next/src/components/map/StationLineReports.tsx
@@ -22,6 +22,7 @@ function LineReportRow({ line }: { line: StationLineReports }) {
     <Link
       to={LineDetailRoute.to}
       params={{ lineName: line.name }}
+      search={{ source: 'station' }}
       onClick={() => track('station_line_selected', { line_id: line.name })}
       className="hover:bg-muted/70 focus-visible:ring-ring flex items-center gap-3 px-3 py-2.5 outline-none focus-visible:ring-2"
     >

--- a/packages/frontend-next/src/components/reports/LineScoreList.tsx
+++ b/packages/frontend-next/src/components/reports/LineScoreList.tsx
@@ -30,6 +30,7 @@ export function LineScoreList({ scores, total }: LineScoreListProps) {
             <Link
               to={LineDetailRoute.to}
               params={{ lineName: entry.name }}
+              search={{ source: 'reports_list' }}
               className="hover:bg-muted/70 focus-visible:ring-ring flex h-14 items-center gap-3 px-4 outline-none focus-visible:ring-2"
             >
               <LineBadge name={entry.name} className="underline underline-offset-2" />

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -7,6 +7,7 @@ import { enqueuePostHog } from '@/lib/posthog-client';
 // until it's ready — otherwise a startup burst would all collapse to the SDK's init time.
 
 export type LocationRequestTrigger = 'auto';
+export type LineDetailSource = 'direct' | 'map' | 'report' | 'reports_list' | 'search' | 'station';
 type SuperProperties = {
   map_layer: 'RISK' | 'LINES';
 };
@@ -49,7 +50,7 @@ type AnalyticsEvents = {
   reports_tab_selected: { tab: 'summary' | 'lines' | 'reports' };
   report_row_selected: { report_age_minutes: number; has_line: boolean; has_direction: boolean };
   detail_modal_closed: { modal: 'station' | 'line' | 'report'; duration_ms: number };
-  line_detail_opened: { line_id: string; source: 'station' };
+  line_detail_opened: { line_id: string; source: LineDetailSource };
   line_detail_cta_clicked: { line_id: string };
   line_hotspot_selected: { line_id: string; station_id: string };
   station_line_selected: { line_id: string };

--- a/packages/frontend-next/src/routes/_map/line/$lineName.tsx
+++ b/packages/frontend-next/src/routes/_map/line/$lineName.tsx
@@ -3,6 +3,18 @@ import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { queryClient } from '@/api/queryClient';
 import { type Line, linesQueryOptions, stationsQueryOptions } from '@/api/transit';
 import { LineDetail, type LineDetailLine } from '@/components/map/LineDetail';
+import type { LineDetailSource } from '@/lib/analytics';
+
+const lineDetailSources = new Set<LineDetailSource>([
+  'direct',
+  'map',
+  'report',
+  'reports_list',
+  'search',
+  'station',
+]);
+
+type LineDetailSearch = { source: LineDetailSource };
 
 function mergeStationOrder(variants: Line[]): string[] {
   const orderedVariants = [...variants].sort((a, b) => b.stations.length - a.stations.length);
@@ -39,6 +51,12 @@ function mergeLineVariants(variants: Line[]): LineDetailLine {
 
 export const Route = createFileRoute('/_map/line/$lineName')({
   staticData: { legalDisclaimer: true },
+  validateSearch: (search: Record<string, unknown>): LineDetailSearch => ({
+    source:
+      typeof search.source === 'string' && lineDetailSources.has(search.source as LineDetailSource)
+        ? (search.source as LineDetailSource)
+        : 'direct',
+  }),
   loader: async ({ params }) => {
     const [lines] = await Promise.all([
       queryClient.ensureQueryData(linesQueryOptions()),
@@ -53,6 +71,7 @@ export const Route = createFileRoute('/_map/line/$lineName')({
 
 function LineRoute() {
   const { line } = Route.useLoaderData();
+  const { source } = Route.useSearch();
   const navigate = useNavigate();
-  return <LineDetail line={line} onClose={() => navigate({ to: '/' })} />;
+  return <LineDetail line={line} source={source} onClose={() => navigate({ to: '/' })} />;
 }


### PR DESCRIPTION
## What changed

- Pass the originating entry point through the line-detail route.
- Record `station`, `report`, and `reports_list` for the currently shipped entry points.
- Reserve `map` and `search` for the planned entry points, and use `direct` for deep links or invalid/missing source values.

## Why this was necessary

`line_detail_opened` was emitted inside `LineDetail` with `source: 'station'` hardcoded, and its TypeScript contract only permitted that value. As a result, opens from report detail and the reports overview were silently misclassified as station traffic, leaving the PostHog source breakdown with only one series.

Keeping capture at the successfully rendered destination preserves the event's meaning while explicit route context provides the missing attribution.

## Validation

- `bun run format:check`
- `bun run lint` (passes with two pre-existing React Compiler warnings)
- `bun run build`
- In-app browser against the local app with live data:
  - station → `/line/U8?source=station`
  - reports overview → `/line/U8?source=reports_list`
  - report detail → `/line/U6?source=report`
  - each route rendered the expected line detail and emitted `line_detail_opened`

No tests were added.

@codex review