### PR TITLE
feat: pause Telegram writes by city

### DIFF
--- a/packages/telegram-worker/src/config.ts
+++ b/packages/telegram-worker/src/config.ts
@@ -128,6 +128,13 @@ export function cityForChat(env: Env, chatId: string): CityConfig | null {
     return slug === undefined ? null : cityForSlug(slug)
 }
 
+export function isTelegramWritingDisabled(env: Env, city: CityConfig): boolean {
+    return (env.TELEGRAM_WRITING_DISABLED_CITIES ?? '')
+        .split(',')
+        .map((slug) => slug.trim())
+        .includes(city.slug)
+}
+
 export function readConfigForCity(env: Env, citySlug: CitySlug): RuntimeConfig {
     const city = cityForSlug(citySlug)
     const chatIds = Object.entries(env.TELEGRAM_CHAT_CITIES)

--- a/packages/telegram-worker/src/forwarding.ts
+++ b/packages/telegram-worker/src/forwarding.ts
@@ -1,7 +1,7 @@
 import type { Env, ForwardedReport, TransitIndex } from './types'
 import { lineNameForId, stationLineNames } from './transit'
 import { getTransitIndex } from './transit'
-import { profileFor, readConfigForCity } from './config'
+import { isTelegramWritingDisabled, profileFor, readConfigForCity } from './config'
 import { getCity, type CitySlug } from '@freifahren/cities'
 import { reportError } from './observability'
 
@@ -142,6 +142,11 @@ export async function handleReportForward(request: Request, env: Env): Promise<R
     } catch (err) {
         const detail = err instanceof Error ? err.message : 'invalid request'
         return json({ error: 'bad_request', detail }, 400)
+    }
+
+    if (isTelegramWritingDisabled(env, cfg.city)) {
+        console.info('Skipped Telegram report forward: writing disabled for city', { city: cfg.city.slug })
+        return json({ status: 'skipped' })
     }
 
     let index: TransitIndex

--- a/packages/telegram-worker/src/types.ts
+++ b/packages/telegram-worker/src/types.ts
@@ -5,6 +5,8 @@ export interface Env {
     BACKEND_URL: string
     PUBLIC_APP_URL: string
     TELEGRAM_CHAT_CITIES: Record<string, string>
+    /** Comma-separated city slugs whose Telegram group notifications are paused. */
+    TELEGRAM_WRITING_DISABLED_CITIES?: string
     MISTRAL_MODEL: string
     SENTRY_DSN: string
     NODE_ENV?: string

--- a/packages/telegram-worker/test/forwarding.test.ts
+++ b/packages/telegram-worker/test/forwarding.test.ts
@@ -76,6 +76,22 @@ describe('handleReportForward', () => {
         expect(text).toContain('utm_medium=bot')
     })
 
+    it('skips writing to a disabled city without affecting request validation', async () => {
+        const disabledEnv: Env = { ...testEnv, TELEGRAM_WRITING_DISABLED_CITIES: 'leipzig, berlin' }
+
+        const res = await handleReportForward(
+            reportRequest({
+                stationId: picked.stationId,
+                lineId: picked.lineId,
+                directionId: picked.directionId,
+            }),
+            disabledEnv,
+        )
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ status: 'skipped' })
+    })
+
     it('rejects a request with no password (401)', async () => {
         const res = await handleReportForward(
             reportRequest({ stationId: picked.stationId, lineId: picked.lineId, directionId: picked.directionId }, null),

--- a/packages/telegram-worker/test/webhook.test.ts
+++ b/packages/telegram-worker/test/webhook.test.ts
@@ -116,6 +116,23 @@ describe('handleWebhook', () => {
         await Promise.all(promises)
     })
 
+    it('continues reading messages from a city with writing disabled', async () => {
+        const process = vi.fn(async () => {})
+        const { ctx, promises } = fakeCtx()
+        const writingDisabledEnv: Env = { ...testEnv, TELEGRAM_WRITING_DISABLED_CITIES: 'leipzig' }
+
+        const res = await handleWebhook(
+            webhookRequest(makeUpdate({ text: '3k Hbf', chatId: -1002 })),
+            writingDisabledEnv,
+            ctx,
+            process,
+        )
+
+        expect(res.status).toBe(200)
+        expect(process).toHaveBeenCalledExactlyOnceWith('3k Hbf', expect.anything(), 'leipzig')
+        await Promise.all(promises)
+    })
+
     it('returns 200 without processing a filtered message', async () => {
         const process = vi.fn(async () => {})
         const { ctx, promises } = fakeCtx()

--- a/packages/telegram-worker/wrangler.jsonc
+++ b/packages/telegram-worker/wrangler.jsonc
@@ -16,6 +16,9 @@
             "-1001370021231": "berlin",
             "-1001138115617": "leipzig"
         },
+        // Comma-separated city slugs for which app-to-Telegram notifications are paused.
+        // Webhook reading and report creation remain enabled. Leave empty to enable all cities.
+        "TELEGRAM_WRITING_DISABLED_CITIES": "leipzig",
         "SENTRY_DSN": "https://9d9ac700f1213d4db367b557167a0594@o4508609338867712.ingest.de.sentry.io/4511633367564368",
     },
     // Messages are processed in the background (ctx.waitUntil) with no queue/retry; failed


### PR DESCRIPTION
## Summary

Adds `TELEGRAM_WRITING_DISABLED_CITIES`, initially set to `leipzig`, so app-originated reports are not posted into the Leipzig Telegram group.

## Why

Leipzig's Telegram integration is still being tested. We need to keep reading messages from the group and submitting those reports while preventing automated outbound posts until the group is ready for a clean go-live. Berlin remains unaffected.

This is implemented as a Telegram Worker deployment variable rather than city metadata or a PostHog feature flag. It is a temporary operational control, not a permanent property of Leipzig's transit configuration; keeping it in the Worker avoids a server-side PostHog dependency and allows deployment-level control. The disabled-city path returns a successful skipped response, so reports already saved by the API do not become notification failures while group posting is paused.

## Validation

- `bun run test` (65 tests)
- `bun run typecheck`

@codex please review.