### PR TITLE
fix: redact Telegram bot token from Sentry

### DIFF
--- a/packages/telegram-worker/src/index.ts
+++ b/packages/telegram-worker/src/index.ts
@@ -2,6 +2,7 @@ import { withSentry, consoleLoggingIntegration } from '@sentry/cloudflare'
 import type { Env } from './types'
 import { handleWebhook } from './webhook'
 import { handleReportForward } from './forwarding'
+import { redactTelegramBotTokenFromBreadcrumb, redactTelegramBotTokenFromSpan } from './observability'
 
 // withSentry wraps the handler: unhandled errors in fetch are captured automatically,
 // console.* is forwarded to Sentry Logs, and Sentry.captureException works inside
@@ -14,6 +15,8 @@ export default withSentry(
         enableLogs: true,
         integrations: [consoleLoggingIntegration({ levels: ['info', 'warn', 'error'] })],
         tracesSampleRate: 1.0,
+        beforeBreadcrumb: redactTelegramBotTokenFromBreadcrumb,
+        beforeSendSpan: redactTelegramBotTokenFromSpan,
     }),
     {
         async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -31,5 +34,5 @@ export default withSentry(
 
             return new Response('not found', { status: 404 })
         },
-    } satisfies ExportedHandler<Env>,
+    } satisfies ExportedHandler<Env>
 )

--- a/packages/telegram-worker/src/observability.ts
+++ b/packages/telegram-worker/src/observability.ts
@@ -1,4 +1,45 @@
-import { captureException } from '@sentry/cloudflare'
+import { captureException, type Breadcrumb, type CloudflareOptions } from '@sentry/cloudflare'
+
+const TELEGRAM_BOT_API_TOKEN = /(https:\/\/api\.telegram\.org\/bot)[^/\s?#]+/gi
+
+const redactTelegramBotApiUrl = (value: string): string => value.replace(TELEGRAM_BOT_API_TOKEN, '$1[REDACTED]')
+
+type SentrySpan = Parameters<NonNullable<CloudflareOptions['beforeSendSpan']>>[0]
+
+export function redactTelegramBotTokenFromBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb {
+    const message = breadcrumb.message === undefined ? undefined : redactTelegramBotApiUrl(breadcrumb.message)
+    const url = breadcrumb.data?.url
+    const redactedUrl = typeof url === 'string' ? redactTelegramBotApiUrl(url) : url
+
+    if (message === breadcrumb.message && redactedUrl === url) return breadcrumb
+
+    return {
+        ...breadcrumb,
+        ...(message === undefined ? {} : { message }),
+        ...(redactedUrl === url ? {} : { data: { ...breadcrumb.data, url: redactedUrl } }),
+    }
+}
+
+export function redactTelegramBotTokenFromSpan(span: SentrySpan): SentrySpan {
+    const description = span.description === undefined ? undefined : redactTelegramBotApiUrl(span.description)
+    let data = span.data
+
+    for (const [key, value] of Object.entries(span.data)) {
+        if (typeof value !== 'string') continue
+        const redactedValue = redactTelegramBotApiUrl(value)
+        if (redactedValue === value) continue
+        if (data === span.data) data = { ...span.data }
+        data[key] = redactedValue
+    }
+
+    if (description === span.description && data === span.data) return span
+
+    return {
+        ...span,
+        ...(description === undefined ? {} : { description }),
+        data,
+    }
+}
 
 // Single seam for error reporting. With no queue/retry, a failed pipeline run drops the
 // message, so we capture it as a Sentry issue (alert on the error rate) and also log to

--- a/packages/telegram-worker/test/observability.test.ts
+++ b/packages/telegram-worker/test/observability.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { redactTelegramBotTokenFromBreadcrumb, redactTelegramBotTokenFromSpan } from '../src/observability'
+
+describe('redactTelegramBotTokenFromBreadcrumb', () => {
+    it('removes the bot token from Telegram fetch breadcrumbs', () => {
+        const breadcrumb = {
+            category: 'fetch',
+            type: 'http',
+            data: {
+                method: 'POST',
+                status_code: 500,
+                url: 'https://api.telegram.org/bot123456789:super-secret/sendMessage',
+            },
+        }
+
+        expect(redactTelegramBotTokenFromBreadcrumb(breadcrumb)).toEqual({
+            ...breadcrumb,
+            data: {
+                ...breadcrumb.data,
+                url: 'https://api.telegram.org/bot[REDACTED]/sendMessage',
+            },
+        })
+        expect(breadcrumb.data.url).toContain('super-secret')
+    })
+
+    it('also redacts Telegram bot API URLs rendered in breadcrumb messages', () => {
+        const breadcrumb = {
+            category: 'request',
+            message: 'POST https://api.telegram.org/bot123456789:super-secret/sendMessage failed',
+        }
+
+        expect(redactTelegramBotTokenFromBreadcrumb(breadcrumb).message).toBe(
+            'POST https://api.telegram.org/bot[REDACTED]/sendMessage failed'
+        )
+    })
+
+    it('leaves unrelated breadcrumbs unchanged', () => {
+        const breadcrumb = {
+            category: 'fetch',
+            data: { url: 'https://api.telegram.org.evil.example/bot123456789:super-secret/sendMessage' },
+        }
+
+        expect(redactTelegramBotTokenFromBreadcrumb(breadcrumb)).toBe(breadcrumb)
+    })
+})
+
+describe('redactTelegramBotTokenFromSpan', () => {
+    it('removes the bot token from traced Telegram requests', () => {
+        const span = {
+            data: {
+                'http.request.method': 'POST',
+                'url.full': 'https://api.telegram.org/bot123456789:super-secret/sendMessage',
+            },
+            description: 'POST https://api.telegram.org/bot123456789:super-secret/sendMessage',
+            span_id: '1234567890abcdef',
+            start_timestamp: 1,
+            trace_id: '1234567890abcdef1234567890abcdef',
+        }
+
+        expect(redactTelegramBotTokenFromSpan(span)).toEqual({
+            ...span,
+            data: {
+                ...span.data,
+                'url.full': 'https://api.telegram.org/bot[REDACTED]/sendMessage',
+            },
+            description: 'POST https://api.telegram.org/bot[REDACTED]/sendMessage',
+        })
+    })
+})


### PR DESCRIPTION
## What changed

- Redact Telegram Bot API credentials from Sentry fetch breadcrumbs before they are attached to error events.
- Redact the same token-bearing URL from outgoing Sentry span descriptions and string attributes so performance traces cannot retain it either.
- Preserve unrelated breadcrumbs and spans unchanged.
- Add regression coverage for the exact `data.url` shape observed in the production timeout event, breadcrumb messages, traced requests, and lookalike non-Telegram hosts.

## Why

Telegram's Bot API places the bot token in the request path. Sentry's automatic fetch instrumentation recorded that full URL when a Telegram request timed out, which put the credential in the event breadcrumb metadata. Because this repository is public, the implementation and tests use only obviously fake credentials and never include the live token.

## User and operator impact

Telegram delivery behavior is unchanged. Sentry retains the request method, status, host, endpoint, and timing needed for debugging, but replaces the credential-bearing path segment with `[REDACTED]`.

## Validation

- `bun run test` — 69 tests passed
- `bun run typecheck`
- Prettier check for all changed files
- `git diff --check`
