### PR TITLE
fix: send a relative Location for version redirects

### DIFF
--- a/packages/api-worker/src/common/router.ts
+++ b/packages/api-worker/src/common/router.ts
@@ -97,10 +97,16 @@ export const registerVersionedRoutes = <E extends Env>(
 
     // Redirect unversioned requests to the latest version.
     // 307 preserves the original HTTP method and body
+    /*
+     * The Location is relative on purpose. Behind the edge, `c.req.url` can carry the scheme of the
+     * internal hop rather than the client's, so re-serialising it emitted `http://` for HTTPS
+     * requests and instructed clients to downgrade — and because 307 replays the method and body,
+     * an unversioned POST /reports would have been replayed over plaintext. A relative Location is
+     * resolved by the client against the URL it actually requested, so the scheme cannot be wrong.
+     */
     const redirect = (c: Context) => {
-        const url = new URL(c.req.url)
-        url.pathname = `/${latestVersion}${url.pathname}`
-        return c.redirect(url.toString(), 307)
+        const { pathname, search } = new URL(c.req.url)
+        return c.redirect(`/${latestVersion}${pathname}${search}`, 307)
     }
     app.all(`/${basePath}/*`, redirect)
     app.all(`/${basePath}`, redirect)

--- a/packages/api-worker/tests/generalAPI.test.ts
+++ b/packages/api-worker/tests/generalAPI.test.ts
@@ -12,13 +12,13 @@ describe('Versioning', () => {
     it('redirects GET /reports to /v0/reports with 307', async () => {
         const response = await app.request('/reports', undefined, testEnv())
         expect(response.status).toBe(307)
-        expect(new URL(response.headers.get('Location')!).pathname).toBe('/v0/reports')
+        expect(response.headers.get('Location')).toBe('/v0/reports')
     })
 
     it('redirects POST /reports to /v0/reports with 307', async () => {
         const response = await app.request('/reports', { method: 'POST' }, testEnv())
         expect(response.status).toBe(307)
-        expect(new URL(response.headers.get('Location')!).pathname).toBe('/v0/reports')
+        expect(response.headers.get('Location')).toBe('/v0/reports')
     })
 
     it('preserves query params through redirects', async () => {
@@ -29,11 +29,27 @@ describe('Versioning', () => {
         )
         expect(response.status).toBe(307)
 
-        const location = new URL(response.headers.get('Location')!)
+        const location = new URL(response.headers.get('Location')!, 'http://localhost')
         expect(location.pathname).toBe('/v0/reports')
         expect(location.searchParams.get('from')).toBe('2024-01-01T00:00:00Z')
         expect(location.searchParams.get('to')).toBe('2024-01-02T00:00:00Z')
     })
+
+    // An absolute Location rebuilt from `c.req.url` emitted `http://` for HTTPS requests in
+    // production, instructing clients to downgrade. 307 replays method and body, so an
+    // unversioned POST /reports would have been replayed over plaintext. Keeping the Location
+    // relative makes the scheme the client's concern, so it cannot be wrong.
+    it.each(['/reports', '/transit/lines', '/insights/lines/U8'])(
+        'sends a scheme-less relative Location for %s',
+        async (path) => {
+            const response = await app.request(`https://api.freifahren.org${path}`, { method: 'GET' }, testEnv())
+
+            expect(response.status).toBe(307)
+            const location = response.headers.get('Location')!
+            expect(location.startsWith('/v0/')).toBe(true)
+            expect(location).not.toMatch(/^https?:/)
+        }
+    )
 
     it('does not set deprecation headers on the latest version', async () => {
         const response = await appRequestWithRedirect('/v0/reports')

--- a/packages/api-worker/tests/test-utils.ts
+++ b/packages/api-worker/tests/test-utils.ts
@@ -54,7 +54,8 @@ export const appRequestWithRedirect = async (path: string, init?: RequestInit, t
     if (response.status === 307) {
         const location = response.headers.get('Location')
         if (location) {
-            const url = new URL(location)
+            // The version redirect sends a relative Location, so resolving it needs a base.
+            const url = new URL(location, 'http://localhost')
             return targetApp.request(url.pathname + url.search, init, testEnv())
         }
     }


### PR DESCRIPTION
Fixes #874.

## Describe the issue:

Every unversioned API route returned a `307` whose `Location` header used plaintext `http://`, even when the incoming request was HTTPS. Reproduced live against production (all requests made over HTTPS):

```
GET https://api.freifahren.org/insights/lines/U8
  -> HTTP/2 307
     location: http://api.freifahren.org/v0/insights/lines/U8

GET https://api.freifahren.org/transit/lines
  -> HTTP/2 307
     location: http://api.freifahren.org/v0/transit/lines

GET https://api.freifahren.org/reports
  -> HTTP/2 307
     location: http://api.freifahren.org/v0/reports
```

Following the redirect confirmed the downgrade was real rather than a header-display artefact — the client genuinely ended up on plain HTTP:

```
curl -L -o /dev/null -w '%{url_effective} %{scheme}' https://api.freifahren.org/insights/lines/U8
  -> http://api.freifahren.org/v0/insights/lines/U8 HTTP
```

**Why it mattered most for `POST /reports`.** A `307` preserves both method and body, so an unversioned report submission was being replayed to a plaintext URL. Whether the bytes actually crossed the network in cleartext depended on the client and on HSTS state, but the API was explicitly instructing clients to downgrade. Native/Capacitor clients and any non-browser consumer without HSTS state had no protection. Secondary cost: every unversioned request paid an extra redirect hop, and these redirects are `cache-control: no-store` / `cf-cache-status: BYPASS`, so they reach the worker on every single request.

**Root cause.** The redirect handler rebuilt an absolute URL from `c.req.url`:

```ts
const url = new URL(c.req.url)
url.pathname = `/${latestVersion}${url.pathname}`
return c.redirect(url.toString(), 307)
```

`url.toString()` re-serialises the scheme as the worker observed it. Behind the edge that can be the scheme of the internal hop rather than the client's, so `toString()` emitted `http://` and the absolute `Location` carried the downgrade.

## Explain how you solved the issue:

Emit a **relative** `Location`, which is valid per RFC 7231 §7.1.2 and is resolved by the client against the URL it actually requested:

```ts
const { pathname, search } = new URL(c.req.url)
return c.redirect(`/${latestVersion}${pathname}${search}`, 307)
```

This was chosen over the alternative fix of forcing `url.protocol = 'https:'`. Pinning the scheme would correct this symptom, but the redirect would still be reconstructing an absolute URL from a request URL that the edge does not guarantee matches what the client sent — the same class of bug is available via host, port, or a future proxy hop. Going relative removes the reconstruction entirely: there is no scheme or authority in the header, so neither can be wrong. `search` is included so query params still survive the hop, and it is `''` when absent, so the unversioned no-query case is unchanged.

**Test helper change.** `new URL(location)` throws on a relative URL, so `appRequestWithRedirect` in `tests/test-utils.ts` — which nearly every test in the suite routes through — now resolves the header against a base. This is a test-only concern; real clients resolve relative `Location` headers natively.

**Regression coverage.** Added a parameterised test asserting the `Location` is relative and scheme-less across three route families (`/reports`, `/transit/lines`, `/insights/lines/U8`). The invariant asserted is *relativity* rather than "scheme is https", because relativity is what structurally prevents the bug — the test env can't reproduce the edge's internal plaintext hop, so asserting on the scheme would pass vacuously. The two existing redirect assertions were tightened from comparing a parsed `.pathname` to comparing the header verbatim, which now also pins the absence of a scheme.

## Additional notes or considerations:

**Verification performed:**

- Full `api-worker` suite: **159 tests / 15 files pass** (`bun run test`).
- **Confirmed the new tests actually catch the bug** by reverting only `router.ts` and re-running: 5 failures, all in the redirect group. Restored, all pass. The tests fail for the right reason rather than passing by construction.
- `typecheck`: diffed output against a stashed baseline — **981 pre-existing errors before and after, zero introduced**. (The baseline errors are unresolvable optional wrangler deps and `cloudflare:test`, unrelated to this change.)
- `lint`: 0 errors. Warnings went 6 → 3; the 3 remaining are pre-existing in `error-handler.ts` and `db/index.ts`. The multi-line rationale uses a `/* */` block, matching `reference-cache.ts`, because the repo's `capitalized-comments` rule flags every `//` continuation line.
- `prettier --check`: clean on all three files.

**Not verified:** the production behaviour itself. The fix can only be confirmed against the deployed worker, since the plaintext hop that triggered the bug is an edge behaviour that the local Miniflare/D1 test environment does not reproduce. Worth re-running the `curl -L -w '%{scheme}'` check above against `api.freifahren.org` after deploy — expected result is `HTTPS`.

**Scope note:** this branch is named for FRE-769 (line-insights query performance) because that is the issue the session started on, but this PR deliberately contains **only** the redirect fix. The bug was found while profiling that endpoint and is unrelated to it, so it is filed and fixed separately. No performance work is included here.

@codex please review.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5V527syD3Ma7QWTY23qjo

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5V527syD3Ma7QWTY23qjo)_