### PR TITLE
fix: improve Leipzig extraction with non-report and vague-direction prompt examples

### DIFF
--- a/packages/cities/src/leipzig.ts
+++ b/packages/cities/src/leipzig.ts
@@ -10,6 +10,12 @@ Message: "linie 1 hbf richt lausen 3 kontrolleure"
 Message: "lvb kontrolle in der 16 messe richtung lößnig"
 {"stationName": "Messegelände", "directionName": "Lößnig"}
 
+Message: "2k in der 11 nach wahren, jetzt goerdelerring"
+{"stationName": "goerdelerring", "directionName": "wahren"}
+
+Message: "7 richtung böhlitz-ehrenberg, gerade augustusplatz"
+{"stationName": "augustusplatz", "directionName": "böhlitz-ehrenberg"}
+
 Message: "s3 am bayerischen bahnhof prüfer eingestiegen"
 {"stationName": "Bayerischer Bahnhof", "directionName": null}
 
@@ -18,6 +24,24 @@ Message: "11 connewitz 2 fahrkartenkontrolleure"
 
 Message: "hbf clean"
 {"stationName": "Hauptbahnhof", "directionName": null}
+
+Message: "3k stieglitzstraße richtung innenstadt"
+{"stationName": "stieglitzstraße", "directionName": null}
+
+Message: "2k südplatz stadteinwärts"
+{"stationName": "südplatz", "directionName": null}
+
+Message: "automat im ersten wagen kaputt, gerade johannisplatz"
+{"stationName": null, "directionName": null}
+
+Message: "fährt die 70 wieder übers kreuz?"
+{"stationName": null, "directionName": null}
+
+Message: "weiß jemand ob heute noch kontrolliert wird?"
+{"stationName": null, "directionName": null}
+
+Message: "denny ist übelst nass"
+{"stationName": null, "directionName": null}
 `
 
 export const LEIPZIG: CityConfig = {


### PR DESCRIPTION
## Describe the issue:

Leipzig inspector reports differ from Berlin's, and the extractor mis-handles two Leipzig-specific patterns, measured on 299 labeled real Leipzig messages (`CITY_NAME=Leipzig`, prod backend):

- **Non-report messages** (broken ticket machines, questions, off-topic chatter) still get a station extracted.
- **Vague civic directions** ("Richtung Innenstadt/Zentrum", "stadteinwärts") get resolved onto a concrete central station, producing a misleading direction pin. Direction precision was only 22.9% (104 false-positive directions, 56 of them from these vague words).

## Explain how you solved the issue:

City-config-only change: the Leipzig `promptExamples` in `packages/cities/src/leipzig.ts` are expanded from 6 to 13 few-shot examples that teach the model to

- return `null`/`null` for clear non-reports (broken machine, questions, chit-chat),
- leave vague civic directions empty (`directionName: null`),
- pick the current station in "jetzt"/"gerade" phrasings.

No shared code is touched; Berlin reads its own config and is unaffected.

Evaluation (telegram-worker eval, `CITY_NAME=Leipzig`, 299 messages), before → after:

| Field | Before | After |
|---|---|---|
| Direction accuracy | 59.2% | **63.2%** |
| Direction false-positives | 118 | **105** |
| Station accuracy | 75.3% | **76.3%** |
| Fully correct | 31.1% | **33.1%** |

No regression in any field.

## Additional notes or considerations:

- **Line accuracy is unchanged (0%)**: Leipzig's numeric lines aren't detected by the shared `buildLinePattern` — tracked separately in #865. This PR only improves prompt-level extraction and does not touch that.
- The two vague-direction examples overlap in purpose with #867; if #867 adds a resolver-level guard, they may later be trimmed as redundant.
- The Leipzig `seed` (currently tram + S-Bahn) will switch to tram + bus once #866 lands — a separate follow-up, not part of this PR.
- Verified locally: `tsc --noEmit` and Prettier pass. The `@cloudflare/vitest-pool-workers` suite could not start in my local sandbox (workerd networking); CI will exercise it. No test asserts on prompt content.
