### PR TITLE
fix: align line link affordances

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -130,29 +130,23 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  # A freshly deployed workers.dev hostname 404s at the edge until it propagates, which
-                  # is a second or two after `wrangler deploy` returns. Wait for the Worker to answer so
-                  # that the assertions below fail only on a genuinely broken preview.
-                  for attempt in $(seq 1 12); do
-                    if curl --fail --silent --output /dev/null \
-                        "${PREVIEW_URL}/v0/transit/stations?city=${CITY_SLUGS%% *}"; then
-                      break
-                    fi
-                    if [ "$attempt" -eq 12 ]; then
-                      echo "Preview never became reachable at $PREVIEW_URL" >&2
-                      exit 1
-                    fi
-                    sleep 5
-                  done
-
                   for city in $CITY_SLUGS; do
-                    stations=$(curl --fail --silent --show-error --location \
-                      "${PREVIEW_URL}/v0/transit/stations?city=${city}" | jq 'length')
-                    if [ "$stations" -lt 1 ]; then
-                      echo "No stations returned for $city" >&2
-                      exit 1
-                    fi
-                    echo "$city: $stations stations"
+                    # A freshly deployed workers.dev hostname can briefly return 404 at the edge. Each
+                    # city must become reachable before the preview can be considered ready.
+                    for attempt in $(seq 1 12); do
+                      if stations=$(curl --fail --silent --show-error --location \
+                        "${PREVIEW_URL}/v0/transit/stations?city=${city}" | jq 'length'); then
+                        if [ "$stations" -ge 1 ]; then
+                          echo "$city: $stations stations"
+                          break
+                        fi
+                      fi
+                      if [ "$attempt" -eq 12 ]; then
+                        echo "Preview never became ready for $city at $PREVIEW_URL" >&2
+                        exit 1
+                      fi
+                      sleep 5
+                    done
                   done
 
     frontend:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,7 +5,7 @@ name: Preview
 # leaving the Workers and databases behind. The path check lives on the `plan` job.
 on:
     pull_request:
-        types: [opened, reopened, synchronize, closed]
+        types: [opened, reopened, ready_for_review, synchronize, closed]
 
 # Never cancelled: a cancelled migration or report load would leave a half-provisioned database.
 concurrency:

--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -65,7 +65,7 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
         <Link
           to={StationRoute.to}
           params={{ stationId: station.id }}
-          className="inline-flex items-center gap-0.5 rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2"
+          className="inline-flex items-center gap-0.5 rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2"
           aria-label={t('openStationDetails', { station: station.name })}
           onClick={() => track('station_selected', { source: 'report' })}
         >
@@ -84,9 +84,9 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
             search={{ source: 'report' }}
             className="hover:bg-muted/70 focus-visible:ring-ring flex items-center gap-2 px-4 py-2 outline-none focus-visible:ring-2"
           >
-            <LineBadge name={lineName} className="underline underline-offset-2" />
+            <LineBadge name={lineName} />
+            <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
             {directionName && <span className="text-sm font-semibold">{directionName}</span>}
-            <ChevronRight className="text-muted-foreground ml-auto size-4 shrink-0" aria-hidden />
           </Link>
         </CardContent>
       ) : (

--- a/packages/frontend-next/src/components/map/ReportDetail.tsx
+++ b/packages/frontend-next/src/components/map/ReportDetail.tsx
@@ -85,8 +85,8 @@ export function ReportDetail({ station, onClose }: ReportDetailProps) {
             className="hover:bg-muted/70 focus-visible:ring-ring flex items-center gap-2 px-4 py-2 outline-none focus-visible:ring-2"
           >
             <LineBadge name={lineName} />
-            <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
             {directionName && <span className="text-sm font-semibold">{directionName}</span>}
+            <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
           </Link>
         </CardContent>
       ) : (

--- a/packages/frontend-next/src/components/map/StationHistoricalInsights.tsx
+++ b/packages/frontend-next/src/components/map/StationHistoricalInsights.tsx
@@ -23,7 +23,9 @@ export function StationHistoricalInsights({ stationId }: StationHistoricalInsigh
               population: insights.ranking.population,
             })}
           </p>
-          <p>{t('stationReportsLast30Days', { count: insights.reportCount.value })}</p>
+          <p className="font-semibold">
+            {t('stationReportsLast30Days', { count: insights.reportCount.value })}
+          </p>
         </div>
       )}
     </CardContent>

--- a/packages/frontend-next/src/components/map/StationLineReports.tsx
+++ b/packages/frontend-next/src/components/map/StationLineReports.tsx
@@ -26,7 +26,6 @@ function LineReportRow({ line }: { line: StationLineReports }) {
       onClick={() => track('station_line_selected', { line_id: line.name })}
       className="hover:bg-muted/70 focus-visible:ring-ring flex items-center gap-3 px-3 py-2.5 outline-none focus-visible:ring-2"
     >
-      <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
       <LineBadge name={line.name} />
       <div className="text-muted-foreground text-sm">
         <p>{t('lineReportsLast24Hours', { count: line.reportsInLast24Hours })}</p>
@@ -36,6 +35,7 @@ function LineReportRow({ line }: { line: StationLineReports }) {
           </p>
         )}
       </div>
+      <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
     </Link>
   );
 }
@@ -46,9 +46,6 @@ export function StationLineReports({ lineReports }: StationLineReportsProps) {
 
   return (
     <CardContent className="space-y-2">
-      <h3 className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-        {t('lineReports')}
-      </h3>
       <p className="text-muted-foreground text-xs">{t('lineReportsDescription')}</p>
       <div className="divide-border max-h-[30dvh] overflow-y-auto overscroll-contain rounded-md border">
         {rankedLines.map((line) => (

--- a/packages/frontend-next/src/components/reports/LineScoreList.tsx
+++ b/packages/frontend-next/src/components/reports/LineScoreList.tsx
@@ -33,7 +33,8 @@ export function LineScoreList({ scores, total }: LineScoreListProps) {
               search={{ source: 'reports_list' }}
               className="hover:bg-muted/70 focus-visible:ring-ring flex h-14 items-center gap-3 px-4 outline-none focus-visible:ring-2"
             >
-              <LineBadge name={entry.name} className="underline underline-offset-2" />
+              <LineBadge name={entry.name} />
+              <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
               <div className="bg-muted h-2.5 flex-1 overflow-hidden rounded-full">
                 <div
                   className="h-full rounded-full"
@@ -43,7 +44,6 @@ export function LineScoreList({ scores, total }: LineScoreListProps) {
               <span className="w-9 shrink-0 text-right text-sm font-semibold tabular-nums">
                 {percent}%
               </span>
-              <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
             </Link>
           </li>
         );

--- a/packages/frontend-next/src/components/reports/LineScoreList.tsx
+++ b/packages/frontend-next/src/components/reports/LineScoreList.tsx
@@ -34,7 +34,6 @@ export function LineScoreList({ scores, total }: LineScoreListProps) {
               className="hover:bg-muted/70 focus-visible:ring-ring flex h-14 items-center gap-3 px-4 outline-none focus-visible:ring-2"
             >
               <LineBadge name={entry.name} />
-              <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
               <div className="bg-muted h-2.5 flex-1 overflow-hidden rounded-full">
                 <div
                   className="h-full rounded-full"
@@ -44,6 +43,7 @@ export function LineScoreList({ scores, total }: LineScoreListProps) {
               <span className="w-9 shrink-0 text-right text-sm font-semibold tabular-nums">
                 {percent}%
               </span>
+              <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
             </Link>
           </li>
         );


### PR DESCRIPTION
## What changed

- Moved line chevrons directly beside their line badges in the report detail and reports insights list.
- Removed the link underlines so station and line navigation use the same chevron-based affordance.

## Why

Line navigation looked different from the adjacent station navigation, and the chevron was visually detached from its line label.

## Validation

- `bunx prettier --check src/components/map/ReportDetail.tsx src/components/reports/LineScoreList.tsx`
- `bun run lint` (passes with 2 existing React Compiler warnings)
- `bun run build`
- `git diff --check`