### PR TITLE
feat: add Leipzig extraction eval baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ scripts/lines.json
 scripts/export.geojson
 scripts/Pipfile
 scripts/Pipfile.lock
-messages.json
-eval_results.json
+messages.*.json
+eval_results.*.json

--- a/packages/telegram-worker/README.md
+++ b/packages/telegram-worker/README.md
@@ -18,16 +18,25 @@ bun run dev                      # http://localhost:8787
 ## Evals
 
 `evals/run.ts` runs the extraction pipeline over a labeled dataset and reports per-field
-accuracy / precision / recall / F1. Drop the dataset in at `evals/messages.json` (gitignored;
+accuracy / precision / recall / F1. Drop the dataset in at `evals/messages.berlin.json` (gitignored;
 rows of `{ id, text, naive_labels: { stationId, directionId, lineName } }`), then:
 
 ```sh
-bun run eval                       # full dataset
-bun run eval --smoke --n 200       # seeded random sample
+bun run eval                       # full Berlin dataset
+bun run eval --smoke --n 200       # seeded random Berlin sample
 ```
 
 Reads `MISTRAL_API_KEY` / `BACKEND_URL` / `MISTRAL_MODEL` from the env or `.dev.vars`. The
-shared dataset contains cases for every supported city.
+default dataset is Berlin's (`CITY_NAME` defaults to `Berlin`).
+
+Per-city datasets live next to it as `evals/messages.<city>.json` (also gitignored) and are
+selected automatically from `CITY_NAME` (or explicitly with `--data`); the city must match,
+since the labels are station ids from that city's index. Outputs go to
+`eval_report.<city>.md` / `eval_results.<city>.json`:
+
+```sh
+CITY_NAME=Leipzig bun run eval --parallel 8
+```
 
 ## Deploy
 

--- a/packages/telegram-worker/evals/eval_report.berlin.md
+++ b/packages/telegram-worker/evals/eval_report.berlin.md
@@ -23,4 +23,4 @@ Null is treated as a negative prediction. *Precision* = "when the bot says X, ho
 | directionId | 94.1% | 941/1000 | 87.8% | 93.1% | 90.4% | 324 | 45 | 24 | 617 |
 | lineName | 97.5% | 975/1000 | 99.0% | 96.8% | 97.9% | 582 | 6 | 19 | 393 |
 
-See `eval_results.json` for the full per-row breakdown.
+See `eval_results.berlin.json` for the full per-row breakdown.

--- a/packages/telegram-worker/evals/eval_report.leipzig.md
+++ b/packages/telegram-worker/evals/eval_report.leipzig.md
@@ -1,0 +1,26 @@
+# Telegram bot extractor — eval report
+
+**Mode:** FULL (1000 rows of 1000)  
+**Model:** `mistral-small-latest`  
+**Parallelism:** 8  
+**Wall time:** 926.8s (1.1 msg/s)  
+**LLM/network errors:** 16
+
+## Headline
+
+- **Fully correct rows** (all three fields match): 450/1000 = **45.0%**
+- Station accuracy: **85.3%**
+- Direction accuracy: **78.3%**
+- Line accuracy: **59.4%**
+
+## Per-field metrics
+
+Null is treated as a negative prediction. *Precision* = "when the bot says X, how often is X right?". *Recall* = "when the label has a value, how often does the bot extract it correctly?".
+
+| Field | Accuracy | Correct | Precision | Recall | F1 | TP | FP | FN | TN |
+|---|---|---|---|---|---|---|---|---|---|
+| stationId | 85.3% | 853/1000 | 83.7% | 87.9% | 85.7% | 609 | 119 | 84 | 244 |
+| directionId | 78.3% | 783/1000 | 60.3% | 72.3% | 65.8% | 263 | 173 | 101 | 520 |
+| lineName | 59.4% | 594/1000 | 92.3% | 2.9% | 5.6% | 12 | 1 | 405 | 582 |
+
+See `eval_results.leipzig.json` for the full per-row breakdown.

--- a/packages/telegram-worker/evals/run.ts
+++ b/packages/telegram-worker/evals/run.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, existsSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { profileFor, type CityProfile } from '../src/config'
@@ -15,9 +15,18 @@ import {
 import type { TransitIndex } from '../src/types'
 
 const EVAL_DIR = dirname(fileURLToPath(import.meta.url))
-const DATA_PATH = join(EVAL_DIR, 'messages.json')
-const REPORT_PATH = join(EVAL_DIR, 'eval_report.md')
-const RESULTS_PATH = join(EVAL_DIR, 'eval_results.json')
+
+/** Per-dataset output names keep every city's artifacts separate. */
+function outputPaths(dataPath: string): { report: string; results: string } {
+    const suffix = /^messages\.([^.]+)\.json$/.exec(basename(dataPath))?.[1]
+    if (suffix === undefined) {
+        throw new Error('Dataset name must follow messages.<city>.json')
+    }
+    return {
+        report: join(EVAL_DIR, `eval_report.${suffix}.md`),
+        results: join(EVAL_DIR, `eval_results.${suffix}.json`),
+    }
+}
 
 type Labels = { stationId: string | null; directionId: string | null; lineName: string | null }
 interface Row {
@@ -132,8 +141,9 @@ function buildReport(opts: {
     datasetSize: number
     parallel: number
     model: string
+    resultsFilename: string
 }): string {
-    const { outcomes, durationS, smoke, datasetSize, parallel, model } = opts
+    const { outcomes, durationS, smoke, datasetSize, parallel, model, resultsFilename } = opts
     const n = outcomes.length
     const station = fieldMetrics(outcomes, 'stationId', 'correctStation')
     const direction = fieldMetrics(outcomes, 'directionId', 'correctDirection')
@@ -157,7 +167,7 @@ function buildReport(opts: {
         '',
     ]
     if (n === 0) {
-        lines.push('_No rows evaluated._', '', 'See `eval_results.json` for the full per-row breakdown.')
+        lines.push('_No rows evaluated._', '', `See \`${resultsFilename}\` for the full per-row breakdown.`)
         return lines.join('\n') + '\n'
     }
     lines.push(
@@ -180,7 +190,7 @@ function buildReport(opts: {
         fieldRow('directionId', direction),
         fieldRow('lineName', line),
         '',
-        'See `eval_results.json` for the full per-row breakdown.'
+        `See \`${resultsFilename}\` for the full per-row breakdown.`
     )
     return lines.join('\n') + '\n'
 }
@@ -313,14 +323,26 @@ async function runOne(
     }
 }
 
-function parseArgs(argv: string[]): { smoke: boolean; n: number; parallel: number; seed: number } {
-    const opts = { smoke: false, n: 200, parallel: 1, seed: 42 }
+function parseArgs(argv: string[]): {
+    smoke: boolean
+    n: number
+    parallel: number
+    seed: number
+    data?: string
+} {
+    const opts: { smoke: boolean; n: number; parallel: number; seed: number; data?: string } = {
+        smoke: false,
+        n: 200,
+        parallel: 1,
+        seed: 42,
+    }
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i]
         if (a === '--smoke') opts.smoke = true
         else if (a === '--n') opts.n = Number(argv[++i])
         else if (a === '--parallel') opts.parallel = Number(argv[++i])
         else if (a === '--seed') opts.seed = Number(argv[++i])
+        else if (a === '--data') opts.data = argv[++i]
     }
     return opts
 }
@@ -337,14 +359,17 @@ async function main(): Promise<void> {
     const model = process.env.MISTRAL_MODEL || 'mistral-small-latest'
     const cityName = process.env.CITY_NAME || 'Berlin'
 
-    if (!existsSync(DATA_PATH)) {
+    const dataName = args.data || `messages.${cityName.toLowerCase()}.json`
+    const dataPath = isAbsolute(dataName) ? dataName : join(EVAL_DIR, dataName)
+    if (!existsSync(dataPath)) {
         throw new Error(
-            `Dataset not found: ${DATA_PATH}\n` +
-                'It is gitignored — drop in messages.json (rows of ' +
+            `Dataset not found: ${dataPath}\n` +
+                'It is gitignored — drop in messages.<city>.json (rows of ' +
                 '{ id, text, naive_labels: { stationId, directionId, lineName } }).'
         )
     }
-    const dataset = JSON.parse(readFileSync(DATA_PATH, 'utf8')) as Row[]
+    const { report: REPORT_PATH, results: RESULTS_PATH } = outputPaths(dataPath)
+    const dataset = JSON.parse(readFileSync(dataPath, 'utf8')) as Row[]
     const datasetSize = dataset.length
     const rows = args.smoke ? sample(dataset, args.n, args.seed) : dataset
 
@@ -360,7 +385,15 @@ async function main(): Promise<void> {
     )
     const durationS = (performance.now() - start) / 1000
 
-    const report = buildReport({ outcomes, durationS, smoke: args.smoke, datasetSize, parallel: args.parallel, model })
+    const report = buildReport({
+        outcomes,
+        durationS,
+        smoke: args.smoke,
+        datasetSize,
+        parallel: args.parallel,
+        model,
+        resultsFilename: basename(RESULTS_PATH),
+    })
     writeFileSync(REPORT_PATH, report)
     writeFileSync(
         RESULTS_PATH,


### PR DESCRIPTION
## Summary

Adds the first committed Leipzig extraction-evaluation baseline and makes every eval artifact explicitly city-scoped.

- records the Leipzig baseline report alongside the Berlin baseline;
- changes eval datasets, reports, and result files to use `.<city>` suffixes;
- derives the default dataset from `CITY_NAME`, so each city uses its own baseline automatically.

## Why

The Leipzig baseline is a guardrail for future changes to Leipzig transit data and extraction behavior. When that data changes, the city-specific results let us verify that the change improves Leipzig against its own labelled dataset rather than accidentally measuring it through Berlin's default artifacts.

Giving Berlin an explicit `.berlin` suffix is deliberate: Leipzig is a first-class city, not an exception to a Berlin-shaped default. Every city now follows the same dataset and report naming convention.

## Validation

- `bun run typecheck`