### PR TITLE
fix: reduce slow station-scoped report queries

### DIFF
--- a/packages/api-worker/src/modules/reports/reports-service.ts
+++ b/packages/api-worker/src/modules/reports/reports-service.ts
@@ -142,12 +142,15 @@ export class ReportsService {
         if (result.length < predictedReportsThreshold) {
             const numberOfReportsToFetch = predictedReportsThreshold - result.length
             const reportedStationIds = new Set(result.map((r) => r.stationId as StationId))
+
+            if (stationId !== undefined && reportedStationIds.has(stationId)) return result
+
             // The allowed-station lookup may read the full station list and the historic
             // Candidate fetch reads recent reports; the two are independent, so issue
             // Them concurrently rather than as back-to-back D1 round-trips.
             const [allowedStationIds, candidateRows] = await Promise.all([
                 this.resolveAllowedStationIds(stationId, reportedStationIds),
-                this.loadPredictionCandidates(),
+                this.loadPredictionCandidates(stationId),
             ])
             const historicReports = this.predictReports(
                 numberOfReportsToFetch,
@@ -179,10 +182,11 @@ export class ReportsService {
 
     // Recent reports used as the historic sample for prediction. Fetched separately
     // So getReports can run it concurrently with resolveAllowedStationIds.
-    private async loadPredictionCandidates() {
+    private async loadPredictionCandidates(stationId?: StationId) {
         return this.db
             .select({ stationId: reports.stationId, timestamp: reports.timestamp })
             .from(reports)
+            .where(stationId !== undefined ? eq(reports.stationId, stationId) : undefined)
             .orderBy(desc(reports.timestamp))
             .limit(1000)
     }

--- a/packages/api-worker/tests/getReports.test.ts
+++ b/packages/api-worker/tests/getReports.test.ts
@@ -707,6 +707,12 @@ describe('Reports by station route', () => {
             await sendReportAt(historicalTime.minus({ minutes: 10 }).toJSDate(), stationOneId, lineId)
         }
 
+        // City-wide history favors another station. A scoped lookup must still use the
+        // requested station's history rather than predict globally and discard the result.
+        for (let reportIndex = 0; reportIndex < 8; reportIndex++) {
+            await sendReportAt(mondayNoon.minus({ weeks: 1, minutes: reportIndex }).toJSDate(), stationTwoId, lineId)
+        }
+
         setSystemTime(mondayNoon.toJSDate())
 
         // No real reports for stationOneId exist in the query timeframe


### PR DESCRIPTION
Fixes #873
Linear: FRE-770

## Summary

Station-scoped report requests now avoid city-wide prediction work:

- return real station reports immediately when the prediction rules cannot add another report for that station
- filter historical prediction candidates by the requested station when prediction is needed
- preserve the existing concurrent city-wide lookup for unscoped `GET /reports`

## Root cause

The prediction path starts whenever the real result count is below the time-dependent display threshold. It previously launched these operations together:

1. determine which stations may receive a prediction
2. fetch the latest 1,000 reports across the city

For a station-scoped request with any real report, the first operation returns an empty allowed set because the response must not contain the same station as both real and predicted. The city-wide D1 read nevertheless completed, transferred 1,000 rows, and was discarded immediately.

For a station-scoped request without a real report, the global sample was still wasteful and could hide the requested station behind busier stations. The route already knows the only station it may return, so prediction should use that station's history directly.

Production query-plan inspection showed that the real station/time-window lookup already uses `reports_station_ts_idx`. This is therefore a query-scope/control-flow problem, not a missing-index problem.

## Decision

Keep the reports lookup simple and reuse the existing prediction pipeline:

- add one early return when a scoped station already exists in the real results
- let the existing candidate loader accept the optional station ID and add `WHERE station_id = ?`
- leave the unscoped path unchanged, including its existing `Promise.all`

The scoped historical query is covered by the existing `(station_id, timestamp)` index, so no migration is required.

This is preferable to adding caching, read replicas, cancellation machinery, or a second prediction implementation. Those options would add operational or code complexity without removing the unnecessary work at its source.

## User and operational impact

Station pages now perform:

- one indexed D1 query when a real report already represents the station
- one indexed window query plus one station-indexed historical query when prediction is required

Unscoped report behavior and its concurrent lookup remain unchanged. Filtering candidates also fixes quiet-station predictions that the global sample previously discarded.

## Performance verification

The PR preview uses an isolated Worker and D1 database populated with the latest 30 days of production reports. Requests were warmed five times, then alternated between production and preview from the same Berlin client so request order was balanced.

### D1 work

For station `BKW`, which has 100 historical reports:

| Candidate query | Rows returned | Rows read | Mean SQLite time (10 runs) |
|---|---:|---:|---:|
| Production/global shape | 1,000 | 1,000 | 2.78 ms |
| PR/station-scoped shape | 100 | 101 | 0.86 ms |

That is 90% fewer returned rows, approximately 90% fewer rows read, and 69% less SQLite execution time. `EXPLAIN QUERY PLAN` reports `SEARCH reports USING COVERING INDEX reports_station_ts_idx (station_id=?)`.

When a real station report already exists, the PR removes the candidate query entirely rather than optimizing it.

### End-to-end Worker requests

Two independent alternating batches of 15 requests per environment exercised `GET /v0/reports/BKW?city=berlin`:

| Batch | Environment | Median | p90 | Slowest |
|---|---|---:|---:|---:|
| 1 | Production | 362 ms | 439 ms | 1,486 ms |
| 1 | PR preview | 405 ms | 430 ms | 491 ms |
| 2 | Production | 357 ms | 394 ms | 2,540 ms |
| 2 | PR preview | 400 ms | 412 ms | 413 ms |

The preview has roughly 40 ms of fixed median overhead relative to production, so this cross-environment measurement should not be read as a controlled median comparison. It does reproduce the issue's latency-tail shape: production produced 1.49 s and 2.54 s requests, while every preview request stayed below 0.50 s.

An additional 15-request identical-response check used station `n29190907`, where both environments returned the same single real report. Production measured 211 ms median and preview 240 ms median, consistent with approximately 29 ms of preview-environment overhead. The code-path improvement in this case is deterministic: production still starts and discards the 1,000-row candidate query below the threshold, while the PR returns after the indexed real-report query.

### Behavior

For quiet stations such as `BKW`, production returned no prediction because the global predictor selected another station and then rejected it. The preview returned a prediction for `BKW` from its own historical rows. The integration test reproduces this by making another station dominate city-wide history.

## Validation

- GitHub API Worker CI: lint and test jobs passed
- GitHub isolated preview: API deployment, database copy, migrations, and city smoke tests passed
- `TZ=UTC bun run test` locally: 159/159 API tests passed
- focused public-route station tests: 2/2 passed
- `bun run lint`: passed (three pre-existing comment warnings)
- `bun run format:check`: passed