### PR TITLE
chore: export native Worker traces to Sentry

### DIFF
--- a/packages/api-worker/src/worker.ts
+++ b/packages/api-worker/src/worker.ts
@@ -34,6 +34,10 @@ export default withSentry(
         },
     }),
     {
-        fetch: app.fetch,
+        fetch: (request, env, ctx) => {
+            const rayId = request.headers.get('cf-ray')
+            if (rayId !== null) setTag('cloudflare.ray_id', rayId)
+            return app.fetch(request, env, ctx)
+        },
     } satisfies ExportedHandler<Bindings>
 )

--- a/packages/api-worker/wrangler.jsonc
+++ b/packages/api-worker/wrangler.jsonc
@@ -7,6 +7,14 @@
     "cache": {
         "enabled": true,
     },
+    "observability": {
+        "traces": {
+            "enabled": true,
+            "destinations": ["sentry-traces"],
+            // Slow D1 calls are frequent enough for 10% sampling to capture several each day.
+            "head_sampling_rate": 0.1,
+        },
+    },
     "workers_dev": true,
     "routes": [
         {


### PR DESCRIPTION
## Context

FRE-770 remains open because Sentry issue `API-WORKER-A` continues to report station-scoped D1 calls as slow even though the query plan and D1's SQL execution metrics are inexpensive. The existing `@sentry/cloudflare` span measures the full binding call, so it cannot distinguish SQLite execution from D1 retries, routing, or queueing.

## Decision

Enable Cloudflare's native Worker tracing at 10% sampling and export it to the existing Sentry `api-worker` project through the account-level `sentry-traces` OTLP destination.

Native D1 spans expose the evidence needed for the follow-up:

- SQL execution duration
- total attempts/retries
- serving region
- whether the primary served the request
- rows read and written

Cloudflare-native traces and Sentry SDK transactions currently use independent trace contexts. The Worker therefore copies the incoming Cloudflare Ray ID into the existing Sentry scope as `cloudflare.ray_id`, allowing an `API-WORKER-A` occurrence to be matched to the corresponding native trace.

We keep the 10% sample intentionally simple. At July's production volume it is expected to produce roughly 567,000 spans per month, comfortably below Cloudflare's included allowance while capturing several slow occurrences each day.

The Cloudflare destination has already been provisioned and the configuration deployed. This PR keeps that production setting in source control so later deployments do not remove it.

## Impact

There is no change to report lookup behavior or preload UX. Trace collection and OTLP delivery are handled by Cloudflare's platform instrumentation.

## Validation

- Wrangler production deployment and configuration readback succeeded
- `sentry-traces` is enabled for native OpenTelemetry traces
- 30 station-scoped production requests returned HTTP 200 after deployment
- ESLint: no errors (three unrelated existing comment warnings)
- Wrangler dry-run: passed
- API integration suite: 157 passed; two existing clock-sensitive prediction-threshold assertions failed
- Repository typecheck remains blocked by existing Cloudflare/Bun/DOM declaration conflicts

Linear: FRE-770