### PR TITLE
feat: edge-cache station-scoped report reads

### DIFF
--- a/packages/api-worker/src/index.ts
+++ b/packages/api-worker/src/index.ts
@@ -12,6 +12,7 @@ import {
     VERSIONED_INSIGHTS_CACHEABLE_PATHS,
 } from './modules/insights/insights-cache-middleware'
 import { getReports, getReportsByStation, postReport } from './modules/reports/'
+import { reportsCacheMiddleware, VERSIONED_REPORTS_CACHEABLE_PATHS } from './modules/reports/reports-cache-middleware'
 import { getRisk } from './modules/risk/risk-routes'
 import {
     transitCacheMiddleware,
@@ -60,6 +61,9 @@ export const createApp = () => {
     }
     for (const path of VERSIONED_INSIGHTS_CACHEABLE_PATHS) {
         app.use(path, insightsCacheMiddleware)
+    }
+    for (const path of VERSIONED_REPORTS_CACHEABLE_PATHS) {
+        app.use(path, reportsCacheMiddleware)
     }
     app.use('*', async (c, next) => {
         await next()

--- a/packages/api-worker/src/modules/reports/reports-cache-middleware.ts
+++ b/packages/api-worker/src/modules/reports/reports-cache-middleware.ts
@@ -1,0 +1,89 @@
+/// <reference types="@cloudflare/workers-types" />
+import type { MiddlewareHandler } from 'hono'
+
+import type { Env } from '../../app-env'
+
+export const VERSIONED_REPORTS_CACHEABLE_PATHS = ['/:version{v\\d+}/reports/:stationId'] as const
+
+export const REPORTS_CACHE_TAG_PREFIX = 'reports'
+
+/*
+ * Per-city, per-station Cache-Tag. Not what keeps entries fresh today — the explicit delete below
+ * is — but it costs nothing and lets a tag purge drop a whole station at once, the way the transit
+ * module already purges on reseed.
+ */
+export const stationReportsCacheTag = (citySlug: string, stationId: string): string =>
+    `${REPORTS_CACHE_TAG_PREFIX}-${citySlug}-${stationId}`
+
+/*
+ * Split TTL, matching the transit and insights modules: the edge holds the response while browsers
+ * revalidate on every use. A client therefore never paints a stale count out of its own HTTP cache,
+ * and the revalidation it does send is absorbed by the edge instead of reaching D1.
+ */
+export const REPORTS_CACHE_CONTROL = 'public, max-age=0, must-revalidate'
+
+/*
+ * Five minutes rather than the hour the only consumer tolerates (`staleTime: HOUR_MS` in the app's
+ * station report count). The explicit invalidation on write reaches just the colo that served the
+ * write, so this cap — not the delete — is what bounds staleness for every other colo.
+ */
+export const REPORTS_EDGE_TTL_SECONDS = 300
+
+export const reportsCacheMiddleware: MiddlewareHandler<Env> = async (c, next) => {
+    await next()
+
+    if (c.req.method !== 'GET' || c.res.status >= 400) return
+
+    const stationId = c.req.param('stationId')
+    if (stationId === undefined) return
+
+    c.header('Cache-Control', REPORTS_CACHE_CONTROL)
+    c.header('Cloudflare-CDN-Cache-Control', `public, max-age=${REPORTS_EDGE_TTL_SECONDS}`)
+    c.header('Cache-Tag', stationReportsCacheTag(c.get('city').slug, stationId))
+}
+
+// The global CacheStorage type (DOM lib) lacks the Cloudflare-specific `default` cache.
+interface EdgeCache {
+    delete(request: Request): Promise<boolean>
+}
+
+const HOUR_MS = 60 * 60 * 1000
+const WEEK_MS = 7 * HOUR_MS * 24
+
+/*
+ * The app requests a station's week with `to` rounded up to the next hour, which is what lets every
+ * client share one cache entry per station per hour. Rebuilding that exact URL is how a new report
+ * drops the entry it has just made wrong.
+ *
+ * This mirrors a frontend decision, so it can drift. When it does, the delete misses and the edge
+ * TTL becomes the only bound — stale for at most that TTL, never wrong for longer.
+ */
+export const stationReportsCacheKey = (reportsUrl: URL, citySlug: string, stationId: string, now: number): URL => {
+    const toMs = Math.ceil(now / HOUR_MS) * HOUR_MS
+    const key = new URL(`${reportsUrl.origin}${reportsUrl.pathname.replace(/\/$/, '')}/${stationId}`)
+    key.searchParams.set('from', new Date(toMs - WEEK_MS).toISOString())
+    key.searchParams.set('to', new Date(toMs).toISOString())
+    key.searchParams.set('city', citySlug)
+    return key
+}
+
+/*
+ * Best effort by construction: the Cache API only reaches the colo running this request, and the
+ * responses are split by `Vary: Origin`, so the delete targets the variant belonging to the client
+ * that just submitted — the one about to refetch its own count. Other colos and other origins fall
+ * back to the TTL.
+ */
+export const invalidateStationReportsCache = async (
+    requestUrl: string,
+    requestOrigin: string | null,
+    citySlug: string,
+    stationId: string,
+    now: number = Date.now()
+): Promise<void> => {
+    const cache = typeof caches !== 'undefined' ? (caches as unknown as { default: EdgeCache }).default : undefined
+    if (cache === undefined) return
+
+    const key = stationReportsCacheKey(new URL(requestUrl), citySlug, stationId, now)
+    const headers = requestOrigin === null ? undefined : { Origin: requestOrigin }
+    await cache.delete(new Request(key.toString(), { headers }))
+}

--- a/packages/api-worker/src/modules/reports/reports-routes.ts
+++ b/packages/api-worker/src/modules/reports/reports-routes.ts
@@ -7,6 +7,7 @@ import { defineRoute } from '../../common/router'
 import { insertReportSchema } from '../../db'
 
 import { getDefaultReportsRange, MAX_REPORTS_TIMEFRAME } from './constants'
+import { invalidateStationReportsCache } from './reports-cache-middleware'
 
 const reportsQuerySchema = z
     .object({
@@ -102,6 +103,23 @@ export const postReport = defineRoute<Env>()({
         })
 
         const report = await reportsService.createReport(postProcessedReportData)
+
+        /*
+         * Awaited, not deferred: the app invalidates and refetches this station's count as soon as
+         * it sees the 200, so the entry has to be gone before we send it. A colo-local delete is
+         * cheap, and a cache miss must never fail a report that is already committed.
+         */
+        try {
+            await invalidateStationReportsCache(
+                c.req.url,
+                c.req.header('Origin') ?? null,
+                c.get('city').slug,
+                report.stationId
+            )
+        } catch (error) {
+            logger.warn({ stationId: report.stationId }, 'Failed to invalidate station reports cache')
+            reportError(error, { tags: { task: 'reports-cache-invalidation' } })
+        }
 
         // Fire-and-forget: the report is already saved, and a slow Telegram call must not block the response.
         const forward = reportsService.forwardReportToTelegram(postProcessedReportData).catch((error) => {

--- a/packages/api-worker/tests/reportsCache.test.ts
+++ b/packages/api-worker/tests/reportsCache.test.ts
@@ -1,0 +1,122 @@
+import { eq } from 'drizzle-orm'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+    REPORTS_CACHE_CONTROL,
+    REPORTS_EDGE_TTL_SECONDS,
+    stationReportsCacheKey,
+    stationReportsCacheTag,
+} from '../src/modules/reports/reports-cache-middleware'
+import { db, lineStations, lines } from './test-db'
+import { appRequestWithRedirect, resetTestEnv, sendReportRequest, setSystemTime } from './test-utils'
+
+// The Workers pool provides a real caches.default (the DOM CacheStorage type lacks it).
+const cache = (
+    caches as unknown as {
+        default: {
+            match(request: Request): Promise<Response | undefined>
+            put(request: Request, response: Response): Promise<void>
+            delete(request: Request): Promise<boolean>
+        }
+    }
+).default
+
+// The app builds this URL from its own origin; tests reach the worker on localhost.
+const REQUEST_URL = new URL('http://localhost/v0/reports')
+const FROZEN_NOW = new Date('2026-08-06T12:34:56.000Z')
+
+let stationA: string
+let stationB: string
+
+// Storage is shared across suites (isolatedStorage: false), so every key this file seeds is
+// removed again rather than left for another suite to read.
+const seededKeys: Request[] = []
+
+const seedCacheEntry = async (stationId: string): Promise<Request> => {
+    const key = new Request(stationReportsCacheKey(REQUEST_URL, 'berlin', stationId, FROZEN_NOW.getTime()).toString())
+    seededKeys.push(key)
+    await cache.put(
+        key,
+        new Response('[]', {
+            headers: {
+                'Content-Type': 'application/json',
+                'Cache-Control': `public, max-age=${REPORTS_EDGE_TTL_SECONDS}`,
+            },
+        })
+    )
+    return key
+}
+
+beforeAll(async () => {
+    const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
+    const stationsOnLine = await db
+        .select({ id: lineStations.stationId })
+        .from(lineStations)
+        .where(eq(lineStations.lineId, line!.id))
+        .limit(2)
+
+    stationA = stationsOnLine[0]!.id
+    stationB = stationsOnLine[1]!.id
+})
+
+afterEach(async () => {
+    setSystemTime()
+    for (const key of seededKeys.splice(0)) {
+        await cache.delete(key)
+    }
+})
+
+afterAll(() => {
+    resetTestEnv()
+})
+
+describe('station reports cache headers', () => {
+    it('marks a station response cacheable at the edge while keeping browsers revalidating', async () => {
+        const response = await appRequestWithRedirect(`/reports/${stationA}`)
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Cache-Control')).toBe(REPORTS_CACHE_CONTROL)
+        expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBe(`public, max-age=${REPORTS_EDGE_TTL_SECONDS}`)
+        expect(response.headers.get('Cache-Tag')).toBe(stationReportsCacheTag('berlin', stationA))
+    })
+
+    it('leaves the unscoped reports list uncached', async () => {
+        const response = await appRequestWithRedirect('/reports')
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Cache-Control')).toBe('no-store')
+        expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBeNull()
+    })
+
+    it('does not cache a rejected time range', async () => {
+        const response = await appRequestWithRedirect(
+            `/reports/${stationA}?from=2026-01-01T00:00:00.000Z&to=2026-06-01T00:00:00.000Z`
+        )
+
+        expect(response.status).toBeGreaterThanOrEqual(400)
+        expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBeNull()
+    })
+})
+
+describe('station reports cache invalidation', () => {
+    it('drops the cached entry for the station a new report was filed at', async () => {
+        setSystemTime(FROZEN_NOW)
+        const key = await seedCacheEntry(stationA)
+        expect(await cache.match(key)).toBeDefined()
+
+        expect((await sendReportRequest({ stationId: stationA, source: 'telegram' })).status).toBe(200)
+
+        expect(await cache.match(key)).toBeUndefined()
+    })
+
+    it('leaves other stations cached', async () => {
+        setSystemTime(FROZEN_NOW)
+        const keyA = await seedCacheEntry(stationA)
+        const keyB = await seedCacheEntry(stationB)
+
+        expect((await sendReportRequest({ stationId: stationA, source: 'telegram' })).status).toBe(200)
+
+        expect(await cache.match(keyA)).toBeUndefined()
+        expect(await cache.match(keyB)).toBeDefined()
+    })
+})


### PR DESCRIPTION
## Describe the issue:

`GET /v0/reports/:stationId` is the busiest read on the API and reaches D1 on every request. The route inherits the app-wide `no-store`, so nothing between the client and the database holds the result and the same answer is recomputed continuously.

It is cacheable by construction. `stationReportCountQueryOptions` asks for a fixed weekly window whose `to` bound is rounded **up to the next hour**, and sets `staleTime: HOUR_MS`. Every client therefore requests a byte-identical URL for the whole hour, and the client has already decided an hour-old answer is acceptable.

This is not an index problem. #883 scoped the query and confirmed the lookup uses `reports_station_ts_idx`; `EXPLAIN QUERY PLAN` still reports a covering-index search. That change reduced the work inside a single request. This one is complementary: it stops identical requests from repeating the work at all.

## Explain how you solved the issue:

**`reports-cache-middleware.ts`** — a third cache middleware next to the existing transit and insights ones, applied only to the station-scoped path:

- `Cache-Control: public, max-age=0, must-revalidate` — browsers revalidate on every use, so a client never paints a stale count out of its own HTTP cache. The revalidation is absorbed by the edge instead of reaching D1.
- `Cloudflare-CDN-Cache-Control: public, max-age=300`
- A per-city, per-station `Cache-Tag`

The unscoped `GET /v0/reports` list keeps `no-store`. It is the live map feed and is polled every 30s; caching it would delay reports appearing.

**Invalidation.** A cached weekly count that ignores a report the user just filed is a visible regression — the app invalidates `['reports', …]` on submit and refetches immediately. So `postReport` deletes the affected entry before returning 200, rebuilding the exact hour-aligned URL the app asks for. The delete is awaited rather than deferred, because the client's refetch races the response; a colo-local delete is sub-millisecond, and a failure is logged and swallowed rather than failing a report that is already committed.

Two limits, both documented at the call site:

- The Cache API only reaches the colo that served the write. That is the colo the submitting client will refetch from, which is the case that matters. Others fall back to the TTL.
- Rebuilding the URL mirrors a frontend decision, so it can drift. If it does, the delete misses and the TTL becomes the only bound — stale for at most 5 minutes, never wrong for longer.

**Why 300s rather than the full hour the consumer tolerates.** A longer TTL would cut origin reads further, but the delete is colo-local, so the TTL is what bounds staleness everywhere the delete does not reach. Five minutes keeps that bound tight while still collapsing the overwhelming majority of repeat reads.

`Vary: Origin` splits the cache per allowed origin. Verified against the existing transit endpoints, which return independent MISS/HIT per origin with the correct `Access-Control-Allow-Origin`, so the split behaves correctly — it just means one entry per station per origin.

## Additional notes or considerations:

### Verification

Local:

- `TZ=UTC bun run test` — 164/164 pass (159 before this change, plus 5 new)
- `bun run lint` — 0 errors, 3 warnings, all pre-existing
- `bun run format:check` — clean
- `bun run typecheck` — output byte-identical to `main`; all remaining errors pre-existing

The new tests run against the Workers runtime's real `caches.default` rather than a mock, so the put/match/delete path is genuinely exercised.

The two invalidation tests were mutation-checked: replacing the `invalidateStationReportsCache` call with a no-op fails both, and they pass again once it is restored. The three header tests still pass under that mutation, which is correct — they cover different behaviour.

New tests in `tests/reportsCache.test.ts`, driven through the public API per AGENTS.md:

- station response carries the edge TTL, revalidation directive, and cache tag
- unscoped list stays `no-store`
- a rejected time range is not cached
- filing a report drops that station's cached entry
- filing a report leaves other stations' entries intact

Preview verification is still outstanding — no CI has triggered on this PR.
