### PR TITLE
fix: recognise the not-found code wrangler actually returns

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -310,10 +310,16 @@ jobs:
                       echo "Deleted preview worker $worker_name."
                       continue
                     fi
-                    # A PR that never deployed this preview (or was already cleaned up) has no Worker to
-                    # delete — Cloudflare returns script_not_found (code 10007). That is expected, not a
-                    # failure. Any other error (auth, network) must fail loudly so a real leak is noticed.
-                    if echo "$output" | grep -qiE 'code: *10007|script_not_found|workers\.api\.error\.not_found'; then
+                    # A PR that never deployed this preview (or was already cleaned up) has no Worker
+                    # to delete. That is expected, not a failure; any other error (auth, network) must
+                    # fail loudly so a real leak is noticed.
+                    #
+                    # Which code says "no such Worker" has already changed once: wrangler 4.105 returns
+                    # 10090 "This Worker does not exist on this account", not the 10007 script_not_found
+                    # this originally matched. Since that moves under us, the human-readable sentence is
+                    # matched too — belt and braces, because the cost of missing it is a failed cleanup
+                    # that strands Workers and skips the database teardown entirely.
+                    if echo "$output" | grep -qiE 'code: *(10007|10090)|script_not_found|workers\.api\.error\.not_found|Worker does not exist'; then
                       echo "No preview worker named $worker_name exists; nothing to clean up."
                       continue
                     fi


### PR DESCRIPTION
## Describe the issue:

Cleanup failed on #908 when it merged. The useful part is that it failed *loudly* — #903 fixed the errexit that had been swallowing the reason, so for the first time the log says what went wrong:

```
✘ [ERROR] A request to the Cloudflare API (/accounts/***/workers/services/api-pr-908) failed.

  This Worker does not exist on this account. [code: 10090]

Failed to delete preview worker api-pr-908 (exit 1).
```

That is the expected case — #908 touched only `.claude/` and `.gitignore`, so no preview was ever deployed and there is nothing to delete. The step is written to treat exactly this as a no-op. It doesn't, because it matches the wrong code:

```bash
grep -qiE 'code: *10007|script_not_found|workers\.api\.error\.not_found'
```

wrangler 4.105 returns **10090 "This Worker does not exist on this account"**, not the 10007 `script_not_found` this was built against. So the tolerance branch has still never executed, and cleanup still exits before deleting the frontend Worker or running the database teardown behind it.

#903 fixed the mechanism that hid this. This fixes what it revealed.

## Explain how you solved the issue:

```diff
-'code: *10007|script_not_found|workers\.api\.error\.not_found'
+'code: *(10007|10090)|script_not_found|workers\.api\.error\.not_found|Worker does not exist'
```

Verified against the exact output from the failed run rather than against a guess:

```console
$ old pattern: no match (this is the bug)
$ new pattern: MATCH
```

The human-readable sentence is matched **as well as** the codes, deliberately. The numeric code has now moved under this check once already, and the cost of missing it a second time is a failed cleanup that strands Workers and skips the database teardown — the exact failure this sequence of PRs exists to close. Matching both is cheap; a false positive would need Cloudflare to say "Worker does not exist" about something that does.

## Additional notes or considerations:

**Nothing leaked from #908**, since it deployed no previews. The job failed on a no-op.

**This is the third and last part of #898.** The original diagnosis was that there was no teardown (wrong — there is, and it is well built). Then that the failure output was swallowed by variable capture (wrong — the script echoes it; `bash -e` aborted before it could). Now the actual remaining defect: the tolerance matches a code Cloudflare no longer sends. Each fix made the next one visible, which is roughly what should happen, though it would have been quicker to read the log properly the first time.

**The existing orphans still need a one-off sweep** — `api-pr-885`, `frontend-pr-885`, `frontend-pr-892`, `frontend-pr-904`, and the `pr-885` / `pr-886` databases, the latter holding ~4.2 MB of copied production reports. This stops new ones; it does not collect the old.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEpDXrw268Y24g29sotrWs
