### PR TITLE
feat: warn iOS app users of possible App Store removal

### DIFF
--- a/packages/frontend-next/src/components/AppRemovalBanner.i18n.ts
+++ b/packages/frontend-next/src/components/AppRemovalBanner.i18n.ts
@@ -1,0 +1,17 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'appRemovalBanner';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  title: 'This app may leave the App Store soon',
+  text: 'Apple may remove FreiFahren from the App Store in about 14 days. Use the same app on the web at app.freifahren.org to keep access.',
+  cta: 'Open app.freifahren.org',
+  dismiss: 'Dismiss',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  title: 'Diese App könnte bald aus dem App Store verschwinden',
+  text: 'Apple könnte FreiFahren in etwa 14 Tagen aus dem App Store entfernen. Nutze dieselbe App im Web unter app.freifahren.org, um weiterhin Zugriff zu haben.',
+  cta: 'app.freifahren.org öffnen',
+  dismiss: 'Schließen',
+});

--- a/packages/frontend-next/src/components/AppRemovalBanner.i18n.ts
+++ b/packages/frontend-next/src/components/AppRemovalBanner.i18n.ts
@@ -4,14 +4,14 @@ export const NAMESPACE = 'appRemovalBanner';
 
 i18n.addResourceBundle('en', NAMESPACE, {
   title: 'This app may leave the App Store soon',
-  text: 'Apple may remove FreiFahren from the App Store in about 14 days. Use the same app on the web at app.freifahren.org to keep access.',
+  text: 'Apple may remove FreiFahren from the App Store in a matter of days. Use the same app on the web at app.freifahren.org to keep access.',
   cta: 'Open app.freifahren.org',
   dismiss: 'Dismiss',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
   title: 'Diese App könnte bald aus dem App Store verschwinden',
-  text: 'Apple könnte FreiFahren in etwa 14 Tagen aus dem App Store entfernen. Nutze dieselbe App im Web unter app.freifahren.org, um weiterhin Zugriff zu haben.',
+  text: 'Apple könnte FreiFahren in wenigen Tagen aus dem App Store entfernen. Nutze dieselbe App im Web unter app.freifahren.org, um weiterhin Zugriff zu haben.',
   cta: 'app.freifahren.org öffnen',
   dismiss: 'Schließen',
 });

--- a/packages/frontend-next/src/components/AppRemovalBanner.tsx
+++ b/packages/frontend-next/src/components/AppRemovalBanner.tsx
@@ -1,0 +1,76 @@
+import { Capacitor } from '@capacitor/core';
+import { TriangleAlert, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+
+import { track } from '@/lib/analytics';
+
+import { NAMESPACE } from './AppRemovalBanner.i18n';
+
+export const WEBSITE_URL = 'https://app.freifahren.org';
+
+// iOS-only warning that Apple may pull the app from the App Store, pointing users at the identical
+// web app instead. Deliberately not persisted anywhere: the dismissal only lives in this component's
+// state, so it reappears on every fresh launch (a new JS context) but can still be dismissed for the
+// current session. Reuses AppBanner's #app-banner id / --app-banner-offset wiring so top-anchored UI
+// shifts down the same way; the two banners are mutually exclusive (web-only vs. native-iOS-only), so
+// sharing the id is safe.
+export function AppRemovalBanner() {
+  const { t } = useTranslation(NAMESPACE);
+  const [dismissed, setDismissed] = useState(false);
+  const show = Capacitor.getPlatform() === 'ios' && !dismissed;
+
+  useEffect(() => {
+    if (show) track('app_removal_banner_shown', {});
+  }, [show]);
+
+  useEffect(() => {
+    if (!show) return;
+    const root = document.documentElement;
+    const el = document.getElementById('app-banner');
+    if (!el) return;
+    const apply = () => root.style.setProperty('--app-banner-offset', `${el.offsetHeight}px`);
+    apply();
+    const observer = new ResizeObserver(apply);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      root.style.removeProperty('--app-banner-offset');
+    };
+  }, [show]);
+
+  if (!show) return null;
+
+  return createPortal(
+    <div
+      id="app-banner"
+      className="bg-destructive fixed inset-x-0 top-0 z-50 flex items-start gap-3 px-4 pt-[calc(1rem+env(safe-area-inset-top))] pb-4 text-white shadow-lg"
+    >
+      <TriangleAlert className="mt-0.5 size-6 shrink-0" />
+      <a
+        href={WEBSITE_URL}
+        target="_blank"
+        rel="noreferrer"
+        onClick={() => track('app_removal_banner_clicked', {})}
+        className="min-w-0 flex-1"
+      >
+        <p className="text-base leading-tight font-bold">{t('title')}</p>
+        <p className="mt-1 text-sm leading-snug text-white/90">{t('text')}</p>
+        <p className="mt-2 text-sm font-semibold underline underline-offset-2">{t('cta')}</p>
+      </a>
+      <button
+        type="button"
+        aria-label={t('dismiss')}
+        onClick={() => {
+          track('app_removal_banner_dismissed', {});
+          setDismissed(true);
+        }}
+        className="-mt-1 -mr-1 shrink-0 p-1 text-white/80 hover:text-white"
+      >
+        <X className="size-5" />
+      </button>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -57,6 +57,9 @@ type AnalyticsEvents = {
   app_banner_shown: Record<string, never>;
   app_banner_store_clicked: Record<string, never>;
   app_banner_dismissed: Record<string, never>;
+  app_removal_banner_shown: Record<string, never>;
+  app_removal_banner_clicked: Record<string, never>;
+  app_removal_banner_dismissed: Record<string, never>;
   feedback_sentiment_selected: { sentiment: FeedbackSentiment };
 };
 

--- a/packages/frontend-next/src/routes/__root.tsx
+++ b/packages/frontend-next/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import { createRootRoute, Outlet, useRouterState } from '@tanstack/react-router'
 import { useEffect } from 'react';
 
 import { AppBanner } from '@/components/AppBanner';
+import { AppRemovalBanner } from '@/components/AppRemovalBanner';
 import { ConsentBanner } from '@/components/ConsentBanner';
 import { ContributeCard } from '@/components/contribute/ContributeCard';
 import { FeedbackCard } from '@/components/feedback/FeedbackCard';
@@ -33,6 +34,7 @@ export const Route = createRootRoute({
       <NativeAppReady />
       <PersistentMapView />
       <AppBanner />
+      <AppRemovalBanner />
       <Outlet />
       <Onboarding />
       <LegalDisclaimer />


### PR DESCRIPTION
## Summary
- Adds `AppRemovalBanner`, shown only in the Capacitor **iOS** build (`Capacitor.getPlatform() === 'ios'`), warning that Apple may remove the app from the App Store in ~14 days and pointing users to app.freifahren.org.
- Large, red (`bg-destructive`), dismissable — dismissal is only in-memory component state (not persisted), so it reappears on every fresh app launch but can be dismissed within a session.
- Tapping the banner body opens app.freifahren.org (external browser via `target="_blank"`, matching the existing App Store link pattern).
- Reuses `AppBanner`'s `#app-banner` / `--app-banner-offset` wiring so top-anchored UI shifts down; safe because the two banners are mutually exclusive (web-only vs. native-iOS-only).
- Adds `app_removal_banner_shown/clicked/dismissed` analytics events, following the existing `app_banner_*` pattern.

## Test plan
- [x] `bun run lint` — clean (pre-existing unrelated warnings only)
- [x] `tsr generate && tsc -b` — clean
- [x] `bun run format:check` — clean
- [x] `CAPACITOR=true vite build` — builds successfully
- [ ] Manual check on an iOS device/simulator build: banner shows on launch, is red/large, dismiss hides it for the session, relaunch shows it again, tapping opens app.freifahren.org