### PR TITLE
fix: match region-tagged locales (de-DE etc.) so German users get German

### DIFF
--- a/packages/frontend-next/src/components/map/LanguageSwitcher.i18n.ts
+++ b/packages/frontend-next/src/components/map/LanguageSwitcher.i18n.ts
@@ -1,0 +1,19 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'languageSwitcher';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  language: 'Language',
+  label: 'Switch language',
+  auto: 'Auto',
+  en: 'English',
+  de: 'German',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  language: 'Sprache',
+  label: 'Sprache wechseln',
+  auto: 'Automatisch',
+  en: 'Englisch',
+  de: 'Deutsch',
+});

--- a/packages/frontend-next/src/components/map/LanguageSwitcher.tsx
+++ b/packages/frontend-next/src/components/map/LanguageSwitcher.tsx
@@ -1,0 +1,56 @@
+import { ChevronDown, Languages } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  SUPPORTED_LANGUAGES,
+  setLanguagePreference,
+  useLanguagePreference,
+  type LanguagePreference,
+} from '@/lib/language';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+import { NAMESPACE } from './LanguageSwitcher.i18n';
+
+const OPTIONS: LanguagePreference[] = ['auto', ...SUPPORTED_LANGUAGES];
+
+// A row in the settings card (matches CitySwitcher): the current choice on the right, tapping it
+// opens a menu to switch. "Auto" follows the device/browser locale (see lib/language.ts); picking
+// a language explicitly overrides it until switched back to "Auto".
+export function LanguageSwitcher() {
+  const preference = useLanguagePreference();
+  const { t } = useTranslation(NAMESPACE);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label={t('label')}
+        className="hover:bg-muted focus-visible:bg-muted flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm transition-colors outline-none"
+      >
+        <Languages className="text-muted-foreground size-4" />
+        <span>{t('language')}</span>
+        <span className="text-muted-foreground ml-auto flex items-center gap-1">
+          {t(preference)}
+          <ChevronDown className="size-4" />
+        </span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={preference}
+          onValueChange={(value) => setLanguagePreference(value as LanguagePreference)}
+        >
+          {OPTIONS.map((option) => (
+            <DropdownMenuRadioItem key={option} value={option}>
+              {t(option)}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/frontend-next/src/components/map/SettingsCard.tsx
+++ b/packages/frontend-next/src/components/map/SettingsCard.tsx
@@ -15,6 +15,7 @@ import { Route as PrivacyRoute } from '@/routes/privacy';
 
 import { CitySwitcher } from './CitySwitcher';
 import { DetailCard } from './DetailCard';
+import { LanguageSwitcher } from './LanguageSwitcher';
 import { NAMESPACE } from './SettingsButton.i18n';
 import { SocialLinks } from './SocialLinks';
 
@@ -61,6 +62,7 @@ export function SettingsCard({ onClose }: SettingsCardProps) {
   return (
     <DetailCard title={t('title')} closeLabel={t('close')} onClose={onClose}>
       <div className="flex flex-col px-2">
+        <LanguageSwitcher />
         <CitySwitcher />
         <a
           href={`${WEBSITE_URL}/contact`}

--- a/packages/frontend-next/src/lib/i18n.ts
+++ b/packages/frontend-next/src/lib/i18n.ts
@@ -8,8 +8,21 @@ void i18n
   .init({
     fallbackLng: 'en',
     supportedLngs: ['en', 'de'],
+    // Without this, a detected code like 'de-DE', 'de-AT', or 'de-CH' (which most browsers and
+    // iOS report instead of plain 'de') doesn't exactly match supportedLngs and silently falls
+    // back to 'en' — the cause of German users landing on the English UI. This strips the region
+    // before matching, so any 'de-*' resolves to 'de'.
+    load: 'languageOnly',
     defaultNS: false,
     interpolation: { escapeValue: false },
+    detection: {
+      // Keep detection to what this app actually uses: a persisted user choice (mirrored via
+      // lib/language.ts) or the device/browser locale. No querystring/cookie lookup — this app
+      // has no `?lng=` entry point and no cookie-consent story for one.
+      order: ['localStorage', 'navigator', 'htmlTag'],
+      caches: ['localStorage'],
+      lookupLocalStorage: 'i18nextLng',
+    },
   });
 
 const syncHtmlLang = (lng: string) => {

--- a/packages/frontend-next/src/lib/language.ts
+++ b/packages/frontend-next/src/lib/language.ts
@@ -1,0 +1,67 @@
+import { useSyncExternalStore } from 'react';
+
+import { i18n } from '@/lib/i18n';
+import { removeNativePreference, saveNativePreference } from '@/lib/native-preference';
+import { safeLocalStorage } from '@/lib/safe-storage';
+
+// Explicit override on top of i18next's own auto-detection (browser/WebView locale, see
+// lib/i18n.ts). Stored separately from i18next-browser-languagedetector's own cache (the
+// 'i18nextLng' localStorage key it writes on every languageChanged) so "Auto" can be told apart
+// from "the user explicitly picked the language that happens to match the detected one" — and so
+// switching back to "Auto" can wipe the detector's cache and force a fresh redetection instead of
+// reapplying a stale cached value.
+export const SUPPORTED_LANGUAGES = ['en', 'de'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+export type LanguagePreference = SupportedLanguage | 'auto';
+
+const LANGUAGE_PREFERENCE_KEY = 'freifahren.language';
+const DETECTOR_CACHE_KEY = 'i18nextLng';
+
+function isSupportedLanguage(value: string | null): value is SupportedLanguage {
+  return (SUPPORTED_LANGUAGES as readonly string[]).includes(value ?? '');
+}
+
+function storedPreference(): LanguagePreference {
+  const stored = safeLocalStorage.getItem(LANGUAGE_PREFERENCE_KEY);
+  return isSupportedLanguage(stored) ? stored : 'auto';
+}
+
+let preference = storedPreference();
+// Apply an explicit override at boot; 'auto' leaves i18next's own detected language in place.
+if (preference !== 'auto') void i18n.changeLanguage(preference);
+
+const listeners = new Set<() => void>();
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+export function getLanguagePreference(): LanguagePreference {
+  return preference;
+}
+
+export function useLanguagePreference(): LanguagePreference {
+  return useSyncExternalStore((listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  }, getLanguagePreference);
+}
+
+// Picking 'en'/'de' applies immediately, no reload needed. 'auto' clears both our preference and
+// the language detector's own cache, then reloads so the detector re-derives the language from
+// the current browser/system locale, exactly as at a fresh boot.
+export function setLanguagePreference(next: LanguagePreference): void {
+  if (next === preference) return;
+  preference = next;
+
+  if (next === 'auto') {
+    void Promise.all([
+      removeNativePreference(LANGUAGE_PREFERENCE_KEY),
+      removeNativePreference(DETECTOR_CACHE_KEY),
+    ]).finally(() => window.location.reload());
+    return;
+  }
+
+  void saveNativePreference(LANGUAGE_PREFERENCE_KEY, next);
+  void i18n.changeLanguage(next);
+  notify();
+}

--- a/packages/frontend-next/src/lib/native-preference.ts
+++ b/packages/frontend-next/src/lib/native-preference.ts
@@ -20,6 +20,21 @@ export function saveNativePreference(key: string, value: string): Promise<void> 
   return Capacitor.isNativePlatform() ? mirror(key, value) : Promise.resolve();
 }
 
+async function mirrorRemove(key: string): Promise<void> {
+  try {
+    const { Preferences } = await import('@capacitor/preferences');
+    await Preferences.remove({ key });
+  } catch {
+    /* best-effort mirror */
+  }
+}
+
+// Returns the mirror promise; await it before a reload so the durable copy is gone first.
+export function removeNativePreference(key: string): Promise<void> {
+  safeLocalStorage.removeItem(key);
+  return Capacitor.isNativePlatform() ? mirrorRemove(key) : Promise.resolve();
+}
+
 // Recovers a purged value from native Preferences into localStorage; true means the caller should
 // reload so boot-time readers pick it up.
 export async function restoreNativePreference(key: string): Promise<boolean> {


### PR DESCRIPTION
## Describe the issue:

i18next required an exact supportedLngs match, so a detected 'de-DE'/'de-AT'/ 'de-CH' (what most browsers and iOS actually report, rather than plain 'de') never matched ['en', 'de'] and silently fell back to fallbackLng 'en'. 

## Explain how you solved the issue:

Adding load: 'languageOnly' strips the region before matching.

adds a persistent language setting (Auto/English/German) in Settings, so users can override the detected language; "Auto" clears the override and the detector's own cache and re-derives from the current device/browser locale.



