### PR TITLE
fix: compress the basemap style and keep it in the edge cache

### DIFF
--- a/.github/workflows/tile-server-deploy.yml
+++ b/.github/workflows/tile-server-deploy.yml
@@ -67,11 +67,47 @@ jobs:
                           --content-type application/octet-stream \
                           --cache-control "public, max-age=31536000, immutable" \
                           --remote
-                      # The style is the only mutable pointer — short TTL so a redeploy propagates
-                      # quickly. It already references this build's immutable /v<sha>/ archive.
+                      # Pre-compressed because a custom domain serves R2 objects byte-for-byte — the
+                      # zone's Brotli setting reaches Pages assets but never R2 — and the style is on
+                      # the critical path: MapLibre requests no tile until it resolves. `-n` keeps the
+                      # bytes identical for identical input, so the strong ETag survives a rebuild.
+                      gzip -9 -n -c "dist/styles/$city.json" > "dist/styles/$city.json.gz"
+                      # The style is the only mutable pointer, and it already references this build's
+                      # immutable /v<sha>/ archive. `s-maxage` holds it at the edge for a day (at 60s
+                      # it fell out constantly, so most requests paid a full origin round trip) while
+                      # `max-age` keeps browsers checking back; the purge below propagates a redeploy.
                       bunx wrangler@latest r2 object put "freifahren-tiles/styles/$city.json" \
-                          --file "dist/styles/$city.json" \
+                          --file "dist/styles/$city.json.gz" \
                           --content-type application/json \
-                          --cache-control "public, max-age=60, must-revalidate" \
+                          --content-encoding gzip \
+                          --cache-control "public, max-age=60, s-maxage=86400" \
                           --remote
                   done
+
+            # Only the style needs purging — the archive is immutable under /v<sha>/ and is never
+            # overwritten. A skipped purge degrades gracefully (the edge keeps serving the previous
+            # style, which points at a still-present archive), but a *failed* one is a real problem
+            # worth failing the deploy over, so a bad token can't quietly pin the basemap for a day.
+            - name: Purge basemap style cache
+              env:
+                  CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  TILES_BASE_URL: ${{ vars.TILES_BASE_URL }}
+              run: |
+                  set -euo pipefail
+                  if [ -z "${CLOUDFLARE_ZONE_ID:-}" ] || [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+                      echo "Skipping style cache purge (CLOUDFLARE_ZONE_ID or CLOUDFLARE_API_TOKEN not set)"
+                      exit 0
+                  fi
+                  files=""
+                  for f in dist/*.pmtiles; do
+                      city="$(basename "$f" .pmtiles)"
+                      files="${files:+$files,}\"${TILES_BASE_URL%/}/styles/$city.json\""
+                  done
+                  response="$(curl -sS -X POST \
+                      "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/purge_cache" \
+                      -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+                      -H "Content-Type: application/json" \
+                      --data "{\"files\":[$files]}")"
+                  echo "$response"
+                  echo "$response" | grep -q '"success":true'


### PR DESCRIPTION
## Why

`tiles.freifahren.org/styles/berlin.json` is served **uncompressed at 101,590 bytes, where gzip is 3,834** — a 26× penalty on the one file that gates everything else, since MapLibre requests no tile until the style resolves.

```
$ curl -sH "Accept-Encoding: gzip, br" -D - -o /dev/null https://tiles.freifahren.org/styles/berlin.json
content-type: application/json
content-length: 101590          # no content-encoding at all
```

The zone has Brotli **on**, and it does apply to the Pages assets on the same zone (`content-encoding: br` on `/assets/*.js`). It never reaches R2: a custom domain serves R2 objects byte-for-byte. So compression can only be applied at upload time, which is what this does.

Second problem, same file: `max-age=60, must-revalidate` was also acting as the *edge* TTL, because the `tiles.freifahren.org` cache rule uses `respect_origin`. A 60-second edge TTL falls out of cache constantly — a cold request returned `cf-cache-status: DYNAMIC` — so a large share of requests paid a full origin round trip for all 100 KB.

## What changed

- **gzip the style on upload** with `--content-encoding gzip`. `gzip -n` so identical input produces identical bytes and the strong ETag survives a rebuild (the cache rule sets `respect_strong_etags: true`).
- **Split browser and edge TTL**: `max-age=60, s-maxage=86400`. Browsers keep checking back within the minute; the edge holds it for a day instead of 60s.
- **Purge the style URL on deploy**, so a longer edge TTL doesn't delay propagation. Purge-by-URL, which works on this zone's plan — unlike the tag purge the api-worker uses.

The `.pmtiles` archive is deliberately left alone: range requests need identity encoding, and it is already immutable under `/v<sha>/`.

## Failure modes

The purge skips with a log line if `CLOUDFLARE_ZONE_ID`/`CLOUDFLARE_API_TOKEN` are unset (both are already configured for other workflows), but **fails the deploy** if the API rejects it — otherwise a bad token could quietly pin the basemap for a day. A stale style is benign rather than broken: it points at a `/v<sha>/` archive that is never purged, so the worst case is the previous basemap.

## Verification

Round-tripped the live style through the exact command in the workflow:

```
original : 101590 bytes
gzipped  :   3834 bytes   (26.4x)
json identical: True
archive url preserved: pmtiles://https://tiles.freifahren.org/v37bea362/berlin.pmtiles
```

Exercised the purge step against a stubbed `curl` — correct body for multiple cities and a trailing-slash `TILES_BASE_URL`, exit 0 on `success:true`, non-zero on `success:false`, skip on absent credentials:

```
BODY -> {"files":["https://tiles.freifahren.org/styles/berlin.json","https://tiles.freifahren.org/styles/leipzig.json"]}
```

## Measured impact (Sentry RUM, 30 days)

This is a **tail fix, not a median fix**, and the resource spans say so clearly. Comparing the 101 KB style against a ~30 KB range read of the archive — same host, same users, same connections:

| span | p50 | p90 | p95 | p99 |
| --- | --- | --- | --- | --- |
| `styles/berlin.json` (101 KB) | 72 ms | 244 ms | 443 ms | **2700 ms** |
| `berlin.pmtiles` range (~30 KB) | 69 ms | 276 ms | 430 ms | 1023 ms |

Up to p95 the two are indistinguishable: those requests are latency-bound and the payload size is irrelevant. At p99 the style is **2.6× worse than a tile read**, which is the 26× size difference finally showing up on throughput-limited connections. Broken out by device class, the p99 style fetch is 3702 ms on `high` and 5324 ms on `medium`.

So the expected win is seconds off the slowest ~1% of loads and approximately nothing for the median. For an app opened on a phone at a station entrance, that is the case worth optimising.

Page-level vitals are healthy and this change should not move them: LCP p75 **1069 ms**, FCP p75 **824 ms** — both inside Google's "good" band. This is not a fix for a broadly slow app.

The edge-TTL half of the change is not independently validated by this data; a p50 of 72 ms suggests the edge cache mostly works today, and the `s-maxage` split reduces origin round trips rather than anything visible in these percentiles.

## Not addressed here

Cold tile loads are also slowed by something outside this repo: Deutsche Telekom hands Cloudflare-bound traffic for our prefixes to Telia in **London** (`lon-sb2-i.lon.gb.net.dtag.de`), ~103 ms RTT, where Cloudflare's own prefixes stay domestic at ~28 ms. That is ~85 ms on every request for T-Online users and is not fixable by a plan change below Enterprise BYOIP. Other German ISPs peer at DE-CIX Frankfurt and should be unaffected.

That ~85 ms figure is synthetic, from a single T-Online line. Sentry has the real-user distribution but records no ISP or country dimension, so how much of the audience takes the London path is not measurable from what we collect today.
