### PR TITLE
feat: add bus route type and enable tram + bus for Leipzig

### DIFF
--- a/packages/cities/src/leipzig.ts
+++ b/packages/cities/src/leipzig.ts
@@ -63,9 +63,13 @@ export const LEIPZIG: CityConfig = {
     },
     seed: {
         adminLevel: '^6$',
-        operators: ['Leipziger Verkehrsbetriebe', 'DB Regio Südost'],
+        // LVB only. S-Bahn ("DB Regio Südost") is intentionally dropped — a separate
+        // operator, routinely inspected anyway, and of little added value here.
+        operators: ['Leipziger Verkehrsbetriebe'],
         stationBounds: [12.18, 51.24, 12.56, 51.45],
-        routeTypePriority: ['tram', 'train', 'light_rail', 'subway'],
+        // LVB is a tram + bus network. Bus is last so that where a stop serves both,
+        // tram stays the station's representative type (and wins the proximate-merge pick).
+        routeTypePriority: ['tram', 'bus'],
         // Empty on purpose: keep each line's own OSM colour (official LVB per-line
         // colors) instead of forcing one shared color per vehicle type.
         colors: {},

--- a/packages/cities/src/types.ts
+++ b/packages/cities/src/types.ts
@@ -3,7 +3,7 @@
 // Worker bundles, and the seed scripts). Do not import runtime dependencies here.
 
 /** The transit route types the pipeline understands, in no particular order. */
-export const ROUTE_TYPES = ['subway', 'tram', 'light_rail', 'train'] as const
+export const ROUTE_TYPES = ['subway', 'tram', 'light_rail', 'train', 'bus'] as const
 
 export type RouteType = (typeof ROUTE_TYPES)[number]
 

--- a/packages/frontend-next/src/api/transit.ts
+++ b/packages/frontend-next/src/api/transit.ts
@@ -18,13 +18,14 @@ type StationResponse = {
 export type Station = StationResponse & { id: StationId };
 export type Stations = Record<StationId, Station>;
 
-export type LineType = 'subway' | 'light_rail' | 'tram';
+export type LineType = 'subway' | 'light_rail' | 'tram' | 'bus';
 
-// Display ordering for line types (U-Bahn → S-Bahn → Tram).
+// Display ordering for line types (U-Bahn → S-Bahn → Tram → Bus).
 export const LINE_TYPE_PRIORITY: Record<LineType, number> = {
   subway: 0,
   light_rail: 1,
   tram: 2,
+  bus: 3,
 };
 
 // Canonical display order: U-Bahn → S-Bahn → Tram, then ascending within a group (U1 before U9).

--- a/packages/frontend-next/src/components/map/LineDetail.tsx
+++ b/packages/frontend-next/src/components/map/LineDetail.tsx
@@ -21,7 +21,7 @@ import { RhythmChart } from './RhythmChart';
 
 export type LineDetailLine = {
   name: string;
-  type: 'subway' | 'light_rail' | 'tram';
+  type: 'subway' | 'light_rail' | 'tram' | 'bus';
   isCircular: boolean;
   color: string;
   stations: string[];


### PR DESCRIPTION
## Describe the issue:

The Leipzig profile approximates the LVB network as tram + S-Bahn, so LVB's bus lines (60s/70s/80s, 89, 90, …) are missing from the map and from line attribution. `ROUTE_TYPES` in `@freifahren/cities` did not include `'bus'`, so bus could not be expressed in any city profile.

## Explain how you solved the issue:

- I add `'bus'` to `ROUTE_TYPES` (`packages/cities/src/types.ts`). This is additive: a city only seeds bus when its `routeTypePriority` lists it, so every other city is unchanged.
- I switch the Leipzig seed profile to `routeTypePriority: ['tram', 'bus']` and narrow `operators` to `Leipziger Verkehrsbetriebe`, dropping DB Regio Südost (S-Bahn). Bus is last, so a stop served by both keeps tram as its representative type.
- I extend the frontend `LineType` and its display ordering (`packages/frontend-next/src/api/transit.ts`) and `LineDetailLine.type` (`LineDetail.tsx`) to include `'bus'`; without this the frontend fails to type-check once a line can be a bus.

I keep the scope minimal — only what is required for Leipzig bus to seed, serve and render. There are no seed-pipeline, schema or Berlin changes; `lines.type` is unconstrained text, so no migration is required.

## Additional notes or considerations:

Deliberately out of scope here, planned as separate PRs. Most of this is already prototyped in the existing `bus-support` investigation branch, which I would build on rather than redo:

- **Bus display treatment** — the investigation already designs and prototypes this (buses in their own zoom-gated, de-emphasised layer; a report or elevated risk promotes the line to full prominence; the risk layer stays rail-first). I would carry it over for Leipzig.
- **Optional per-line scoping** — the same branch adds a `routeRefPatterns` mechanism (Berlin scoped to MetroBus). For Leipzig I would raise it as an open trade-off, e.g. dropping rail-replacement (SEV) while keeping night buses.
- **`loadGraph` caching** — the investigation recommends putting `loadGraph` behind `cachedReference` to remove the only per-request D1 read; I would keep that as a separate, bus-independent change.
- **Leipzig bus colour** — the Berlin prototype uses one muted purple for all bus lines; I propose the same for Leipzig (purple).
- **Report-form line-type filter** — extend it to bus (no prior work on this yet).
