### PR TITLE
fix: don't apply report decay to historical report queries

### DIFF
--- a/packages/api-worker/src/modules/reports/reports-cache-middleware.ts
+++ b/packages/api-worker/src/modules/reports/reports-cache-middleware.ts
@@ -77,6 +77,7 @@ export const stationReportsCacheKey = (reportsUrl: URL, citySlug: string, statio
     const key = new URL(`${reportsUrl.origin}${reportsUrl.pathname.replace(/\/$/, '')}/${stationId}`)
     key.searchParams.set('from', new Date(toMs - WEEK_MS).toISOString())
     key.searchParams.set('to', new Date(toMs).toISOString())
+    key.searchParams.set('decay', 'false')
     key.searchParams.set('city', citySlug)
     return key
 }

--- a/packages/api-worker/src/modules/reports/reports-routes.ts
+++ b/packages/api-worker/src/modules/reports/reports-routes.ts
@@ -24,6 +24,17 @@ const reportsQuerySchema = z
             .datetime()
             .transform((str) => DateTime.fromISO(str))
             .optional(),
+        /*
+         * Decay drops reports once they age past the burst-adaptive ttl (at most 60 minutes) — a
+         * fit for the live map's rolling window, but not for callers explicitly browsing history
+         * (a day-, week-, or station-scoped lookback), where "too old to still be relevant on the
+         * map" isn't the question being asked. Defaults to on so the live/default window keeps its
+         * existing behaviour; historical lookbacks opt out with `decay=false`.
+         */
+        decay: z
+            .string()
+            .optional()
+            .transform((value) => value !== 'false'),
     })
     .refine(({ to, from }) => {
         if (isNil(to) && isNil(from)) return true
@@ -40,10 +51,11 @@ const reportsQuerySchema = z
             return {
                 from: query.from,
                 to: query.to,
+                decay: query.decay,
             }
         }
 
-        return getDefaultReportsRange(DateTime.now())
+        return { ...getDefaultReportsRange(DateTime.now()), decay: query.decay }
     })
 
 export const getReports = defineRoute<Env>()({
@@ -64,6 +76,7 @@ export const getReports = defineRoute<Env>()({
             await reportsService.getReports({
                 from: query.from,
                 to: query.to,
+                decay: query.decay,
                 currentTime: now,
                 viewer: await resolveViewer(c),
             })
@@ -90,6 +103,7 @@ export const getReportsByStation = defineRoute<Env>()({
             await reportsService.getReports({
                 from: query.from,
                 to: query.to,
+                decay: query.decay,
                 stationId,
                 currentTime: DateTime.now(),
                 viewer: await resolveViewer(c),

--- a/packages/api-worker/src/modules/reports/reports-service.ts
+++ b/packages/api-worker/src/modules/reports/reports-service.ts
@@ -227,12 +227,14 @@ export class ReportsService {
         stationId,
         currentTime,
         viewer,
+        decay = true,
     }: {
         from: DateTime
         to: DateTime
         stationId?: StationId
         currentTime: DateTime
         viewer?: ViewerContext
+        decay?: boolean
     }): Promise<ReportSummary[]> {
         const realReports = await this.getRealReports({ from, to, stationId, viewer })
 
@@ -242,9 +244,16 @@ export class ReportsService {
          * shared burst rate, rather than each client deriving its own from a locally-ticking
          * clock. Reports that decayed to full transparency are dropped here rather than shipped
          * with opacity 0, so the threshold below reacts to what is actually still visible.
+         *
+         * This only fits the live/default window: a caller explicitly browsing history (a day,
+         * a week, a station's past reports) wants what was actually reported in that range, not
+         * that range with anything the burst-adaptive ttl (at most 60 minutes) would already have
+         * faded off today's map. Those callers pass `decay: false` to skip the drop and get every
+         * real report back at full opacity, same as a predicted report.
          */
-        const lines = await this.transitNetworkDataService.getLines()
-        const result: ReportSummary[] = applyReportDecay(realReports, lines, currentTime.toMillis())
+        const result: ReportSummary[] = decay
+            ? applyReportDecay(realReports, await this.transitNetworkDataService.getLines(), currentTime.toMillis())
+            : realReports.map((report) => ({ ...report, opacity: 1 }))
 
         // Predict reports if we don't have enough, so that users always see at least some data
         const predictedReportsThreshold = calculatePredictedReportsThreshold(currentTime)

--- a/packages/api-worker/tests/getReports.test.ts
+++ b/packages/api-worker/tests/getReports.test.ts
@@ -868,6 +868,30 @@ describe('Report decay', () => {
         expect(fresh.opacity).toBeLessThanOrEqual(1)
     })
 
+    it('returns every real report at full opacity when decay=false, even far outside the burst-adaptive ttl', async () => {
+        const now = DateTime.utc(2024, 1, 15, 12, 0, 0)
+
+        // Well within the burst-adaptive ttl (max 60min in a quiet period)
+        await sendReportAt(now.minus({ minutes: 10 }).toJSDate())
+        // Old enough to have fully decayed regardless of burst rate (ttl caps at 60min) — this is
+        // exactly the report a 24h/7d history view needs back, unlike the live map.
+        await sendReportAt(now.minus({ hours: 3 }).toJSDate())
+
+        setSystemTime(now.toJSDate())
+        const from = now.minus({ hours: 4 })
+        const to = now.plus({ minutes: 1 })
+
+        const response = await appRequestWithRedirect(
+            `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}&decay=false`
+        )
+
+        expect(response.status).toBe(200)
+        const realReports = await getRealReports(response)
+
+        expect(realReports.length).toBe(2)
+        expect(realReports.every((report) => report.opacity === 1)).toBe(true)
+    })
+
     it('gives predicted reports full opacity', async () => {
         const mondayNoon = DateTime.utc(2024, 1, 15, 12, 0) // peak hours -> high predicted threshold
 

--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -109,6 +109,11 @@ export const reportsSliceQueryOptions = (fromAgo: number, toAgo: number) => {
         from: new Date(now - fromAgo).toISOString(),
         to: new Date(now - toAgo).toISOString(),
       });
+      // The live slice is the map's rolling window, so the API's burst-adaptive decay (which
+      // drops anything older than ~60 min) applies. The older slice is explicit history — a
+      // report doesn't stop having happened just because it would have faded off the map by
+      // now — so it opts out and gets every real report in range back.
+      if (toAgo !== 0) params.set('decay', 'false');
       return fetchJson<Report[]>(`/v0/reports?${params.toString()}`);
     },
     ...(isLiveSlice ? LIVE_SLICE_POLLING : OLDER_SLICE_POLLING),
@@ -165,7 +170,8 @@ export const stationReportCountQueryOptions = (stationId: string) => {
   return {
     queryKey: ['reports', stationId, from, to] as const,
     queryFn: () => {
-      const params = new URLSearchParams({ from, to });
+      // A 7-day lookback is explicit history, not the live map, so it opts out of decay too.
+      const params = new URLSearchParams({ from, to, decay: 'false' });
       return fetchJson<Report[]>(`/v0/reports/${stationId}?${params.toString()}`);
     },
     staleTime: HOUR_MS,


### PR DESCRIPTION
applyReportDecay drops any report older than the burst-adaptive ttl
(at most 60 minutes), which is right for the live map but was being
applied to every /v0/reports query. The web app's 24h reports page and
7-day station report count both fetch historical ranges through the
same endpoint, so anything older than ~1h was silently dropped —
appearing as if only the last hour of reports existed.

getReports now takes a `decay` flag (query param, default true) that
historical lookbacks can opt out of to get every real report in range
back at full opacity, while the live/default window keeps its existing
decay behaviour. The frontend's older 1h-24h slice and the station's
7-day count now request decay=false; the cache-invalidation key for
the by-station route was updated to match.