### PR TITLE
fix: key report visibility on an expiry instant, not a fade level

### DIFF
--- a/packages/api-worker/src/modules/reports/report-decay.ts
+++ b/packages/api-worker/src/modules/reports/report-decay.ts
@@ -1,10 +1,16 @@
 /**
- * A report's on-map visibility (`opacity`) shrinks over time, but not at a fixed rate: the more
- * reports are coming in right now (the "burst rate"), the faster old ones become stale, since a
- * moving inspection can render a report irrelevant within minutes instead of an hour. On top of
- * that, a later report further along the same line's stop order counts as having "overtaken" an
- * earlier one — that earlier report then fades out fast on its own clock instead of riding out
- * its normal ttl.
+ * How long a report stays *live* — that is, how long it counts as current evidence that someone is
+ * being checked right now. Not a fixed hour: the more reports are coming in (the "burst rate"), the
+ * faster an old one becomes stale, since a moving inspection can make a report irrelevant within
+ * minutes. On top of that, a later report further along the same line's stop order counts as having
+ * "overtaken" an earlier one, which then expires shortly after instead of riding out its full ttl.
+ *
+ * The output is a single `expiresAt` per report — an absolute instant, not a fade level. That is
+ * what makes it safe to cache and safe to share: every consumer (the map, the risk model, the
+ * report counter) decides "is this live?" by comparing one timestamp against its own clock, so they
+ * cannot drift apart, and a cached response stays correct as it ages instead of carrying a
+ * fade value that was only true at the moment it was computed. How a live report *looks* while it
+ * runs down — the opacity ramp — is presentation and belongs to whoever is drawing it.
  */
 
 export type DecayableReport = {
@@ -17,7 +23,6 @@ export const BURST_WINDOW_MS = 15 * 60 * 1000
 export const BURST_REFERENCE_RATE_PER_MIN = 0.5
 export const TTL_MIN_MS = 15 * 60 * 1000
 export const TTL_MAX_MS = 60 * 60 * 1000
-export const MIN_OPACITY = 0.4
 
 export const AVG_HOP_TRAVEL_MS = 3 * 60 * 1000
 export const CHAIN_SLACK_FACTOR = 2.5
@@ -115,57 +120,53 @@ export const computeChainInfo = <T extends DecayableReport>(
     return info
 }
 
-export type DecayResult = {
-    opacity: number
-    ttlMs: number
-    dropped: boolean
-}
-
-export const computeReportDecay = (
+/*
+ * When a report stops being live. Being overtaken can only ever shorten a report's life, never
+ * extend it, so the two candidate instants are combined with a min rather than by branching on
+ * which case applies.
+ */
+export const computeExpiresAtMs = (
     reportTimestampMs: number,
-    nowMs: number,
     ratePerMinute: number,
     chain: ChainInfo = NOT_CHAINED
-): DecayResult => {
+): number => {
     const baseTtl = burstAdaptiveTtlMs(ratePerMinute)
     const ttlMs = chain.isChainHead ? baseTtl * CHAIN_HEAD_TTL_BOOST : baseTtl
+    const ttlExpiry = reportTimestampMs + ttlMs
 
-    if (chain.supersededAtMs !== null && nowMs >= chain.supersededAtMs) {
-        const sinceSuperseded = nowMs - chain.supersededAtMs
-        if (sinceSuperseded >= SUPERSEDED_FADE_MS) return { opacity: 0, ttlMs, dropped: true }
-        const opacity = MIN_OPACITY * (1 - sinceSuperseded / SUPERSEDED_FADE_MS)
-        return { opacity, ttlMs, dropped: false }
-    }
-
-    const age = nowMs - reportTimestampMs
-    if (age >= ttlMs) return { opacity: 0, ttlMs, dropped: true }
-    const opacity = Math.max(MIN_OPACITY, 1 - age / ttlMs)
-    return { opacity, ttlMs, dropped: false }
+    if (chain.supersededAtMs === null) return ttlExpiry
+    return Math.min(ttlExpiry, chain.supersededAtMs + SUPERSEDED_FADE_MS)
 }
 
 const decayKey = (report: DecayableReport): string =>
     `${report.stationId}|${report.lineId ?? ''}|${report.timestamp.getTime()}`
 
+// A `null` expiry never expires — see the `ReportSummary` note on predicted reports.
+export const isLive = (report: { expiresAt: Date | null }, nowMs: number): boolean =>
+    report.expiresAt === null || report.expiresAt.getTime() > nowMs
+
 /*
- * Runs the full pipeline (burst rate -> chain detection -> per-report decay) over one batch of
- * reports and drops whichever ones decayed to zero opacity, so callers get back exactly the set
- * that should still be visible, each carrying the opacity it should be rendered at.
+ * Runs the full pipeline (burst rate -> chain detection -> per-report expiry) over one batch and
+ * stamps every report with when it stops being live.
+ *
+ * Nothing is filtered out here. A report past its expiry is still a report that happened, and the
+ * same endpoint serves both the live map and plain history (the 24h line/station panels, the 7d
+ * station counter) — dropping the expired ones would empty those views out. Callers that only want
+ * what is live right now say so with `isLive`.
  */
-export const applyReportDecay = <T extends DecayableReport>(
+export const annotateReportExpiry = <T extends DecayableReport>(
     reports: readonly T[],
     lines: readonly { id: string; stations: readonly string[] }[],
     nowMs: number
-): (T & { opacity: number })[] => {
+): (T & { expiresAt: Date })[] => {
     const lineTopologies = buildLineTopologies(lines)
     const chainByKey = computeChainInfo(reports, lineTopologies, decayKey)
     const ratePerMinute = burstRatePerMinute(reports, nowMs)
 
-    const visible: (T & { opacity: number })[] = []
-    for (const report of reports) {
-        const chain = chainByKey.get(decayKey(report))
-        const { opacity, dropped } = computeReportDecay(report.timestamp.getTime(), nowMs, ratePerMinute, chain)
-        if (dropped) continue
-        visible.push({ ...report, opacity })
-    }
-    return visible
+    return reports.map((report) => ({
+        ...report,
+        expiresAt: new Date(
+            computeExpiresAtMs(report.timestamp.getTime(), ratePerMinute, chainByKey.get(decayKey(report)))
+        ),
+    }))
 }

--- a/packages/api-worker/src/modules/reports/reports-cache-middleware.ts
+++ b/packages/api-worker/src/modules/reports/reports-cache-middleware.ts
@@ -77,7 +77,6 @@ export const stationReportsCacheKey = (reportsUrl: URL, citySlug: string, statio
     const key = new URL(`${reportsUrl.origin}${reportsUrl.pathname.replace(/\/$/, '')}/${stationId}`)
     key.searchParams.set('from', new Date(toMs - WEEK_MS).toISOString())
     key.searchParams.set('to', new Date(toMs).toISOString())
-    key.searchParams.set('decay', 'false')
     key.searchParams.set('city', citySlug)
     return key
 }

--- a/packages/api-worker/src/modules/reports/reports-routes.ts
+++ b/packages/api-worker/src/modules/reports/reports-routes.ts
@@ -24,17 +24,6 @@ const reportsQuerySchema = z
             .datetime()
             .transform((str) => DateTime.fromISO(str))
             .optional(),
-        /*
-         * Decay drops reports once they age past the burst-adaptive ttl (at most 60 minutes) — a
-         * fit for the live map's rolling window, but not for callers explicitly browsing history
-         * (a day-, week-, or station-scoped lookback), where "too old to still be relevant on the
-         * map" isn't the question being asked. Defaults to on so the live/default window keeps its
-         * existing behaviour; historical lookbacks opt out with `decay=false`.
-         */
-        decay: z
-            .string()
-            .optional()
-            .transform((value) => value !== 'false'),
     })
     .refine(({ to, from }) => {
         if (isNil(to) && isNil(from)) return true
@@ -51,11 +40,10 @@ const reportsQuerySchema = z
             return {
                 from: query.from,
                 to: query.to,
-                decay: query.decay,
             }
         }
 
-        return { ...getDefaultReportsRange(DateTime.now()), decay: query.decay }
+        return getDefaultReportsRange(DateTime.now())
     })
 
 export const getReports = defineRoute<Env>()({
@@ -76,7 +64,6 @@ export const getReports = defineRoute<Env>()({
             await reportsService.getReports({
                 from: query.from,
                 to: query.to,
-                decay: query.decay,
                 currentTime: now,
                 viewer: await resolveViewer(c),
             })
@@ -103,7 +90,6 @@ export const getReportsByStation = defineRoute<Env>()({
             await reportsService.getReports({
                 from: query.from,
                 to: query.to,
-                decay: query.decay,
                 stationId,
                 currentTime: DateTime.now(),
                 viewer: await resolveViewer(c),

--- a/packages/api-worker/src/modules/reports/reports-service.ts
+++ b/packages/api-worker/src/modules/reports/reports-service.ts
@@ -19,7 +19,7 @@ import {
     clearDirectionIfStationAndDirectionAreTheSame,
     ifDirectionPresentWithoutLineClearDirection,
 } from './post-process-report'
-import { applyReportDecay } from './report-decay'
+import { annotateReportExpiry, isLive } from './report-decay'
 
 const MIN_PREDICTED_REPORTS_THRESHOLD = 1
 const MAX_PREDICTED_REPORTS_THRESHOLD = 7
@@ -84,9 +84,14 @@ type RawReportSummary = Pick<typeof reports.$inferSelect, 'timestamp' | 'station
     isPredicted: boolean
 }
 
-// `opacity` is how faded the report should render right now (see report-decay.ts); reports that
-// decayed all the way to 0 are dropped before this type is reached, so it never carries a 0 here.
-type ReportSummary = RawReportSummary & { opacity: number }
+/*
+ * `expiresAt` is when the report stops counting as live (see report-decay.ts), serialised as an ISO
+ * instant like `timestamp`. It can be in the past: a historical query returns reports that expired
+ * long ago, and whether that matters is the caller's business. `null` means the report never
+ * expires — only predicted reports, which stand in for missing data rather than describing an event
+ * that ages.
+ */
+type ReportSummary = RawReportSummary & { expiresAt: Date | null }
 
 /*
  * Who is asking. `clientHash` is the requester's own signature, computed the same way intake
@@ -227,35 +232,31 @@ export class ReportsService {
         stationId,
         currentTime,
         viewer,
-        decay = true,
     }: {
         from: DateTime
         to: DateTime
         stationId?: StationId
         currentTime: DateTime
         viewer?: ViewerContext
-        decay?: boolean
     }): Promise<ReportSummary[]> {
-        const realReports = await this.getRealReports({ from, to, stationId, viewer })
+        const result: ReportSummary[] = await this.getReportsWithExpiry({
+            from,
+            to,
+            stationId,
+            currentTime,
+            viewer,
+        })
 
         /*
-         * Decay is computed from the same batch the caller sees, so opacity/ttl is identical for
-         * every viewer looking at this station/timeframe right now — one shared "now" and one
-         * shared burst rate, rather than each client deriving its own from a locally-ticking
-         * clock. Reports that decayed to full transparency are dropped here rather than shipped
-         * with opacity 0, so the threshold below reacts to what is actually still visible.
+         * Predict reports if we don't have enough, so that users always see at least some data.
          *
-         * This only fits the live/default window: a caller explicitly browsing history (a day,
-         * a week, a station's past reports) wants what was actually reported in that range, not
-         * that range with anything the burst-adaptive ttl (at most 60 minutes) would already have
-         * faded off today's map. Those callers pass `decay: false` to skip the drop and get every
-         * real report back at full opacity, same as a predicted report.
+         * The threshold counts every report in range, not just the ones still live. An expired
+         * report is not a gap in the data to paper over — decay hiding a stale report is a
+         * deliberate statement that it is stale, and answering that with synthesised reports would
+         * replace "we hid something stale" with "here is something invented". It also keeps
+         * historical windows honest: a 24h range full of expired reports has plenty of data and
+         * must not be backfilled with predictions.
          */
-        const result: ReportSummary[] = decay
-            ? applyReportDecay(realReports, await this.transitNetworkDataService.getLines(), currentTime.toMillis())
-            : realReports.map((report) => ({ ...report, opacity: 1 }))
-
-        // Predict reports if we don't have enough, so that users always see at least some data
         const predictedReportsThreshold = calculatePredictedReportsThreshold(currentTime)
         if (result.length < predictedReportsThreshold) {
             const numberOfReportsToFetch = predictedReportsThreshold - result.length
@@ -277,12 +278,65 @@ export class ReportsService {
                 allowedStationIds,
                 candidateRows
             )
-            // Predicted reports are a synthesised stand-in for missing data, not something that
-            // was actually reported, so they don't age via the decay model — full opacity always.
-            result.push(...historicReports.map((report) => ({ ...report, opacity: 1 })))
+            // Predicted reports stand in for missing data rather than describing an event that
+            // ages, so they have no expiry — see the `ReportSummary` note.
+            result.push(...historicReports.map((report) => ({ ...report, expiresAt: null })))
         }
 
         return result
+    }
+
+    /**
+     * Real reports in range, each stamped with when it stops being live.
+     *
+     * Expiry is computed once per request from the whole batch, so every viewer looking at this
+     * station/timeframe right now agrees on it: one shared "now", one shared burst rate, one shared
+     * view of which reports overtook which. A client deriving it from its own slice would compute a
+     * different burst rate from a different set of reports.
+     */
+    private async getReportsWithExpiry({
+        from,
+        to,
+        stationId,
+        currentTime,
+        viewer,
+    }: {
+        from: DateTime
+        to: DateTime
+        stationId?: StationId
+        currentTime: DateTime
+        viewer?: ViewerContext
+    }): Promise<(RawReportSummary & { expiresAt: Date })[]> {
+        const [realReports, lines] = await Promise.all([
+            this.getRealReports({ from, to, stationId, viewer }),
+            this.transitNetworkDataService.getLines(),
+        ])
+        return annotateReportExpiry(realReports, lines, currentTime.toMillis())
+    }
+
+    /**
+     * Only the reports that are live right now — the set the map is showing.
+     *
+     * The risk model reads through here rather than through `getRealReports` so that risk and
+     * markers cannot disagree: a report that has expired off the map paints no risk, which is what
+     * makes "a coloured line with no marker on it" impossible by construction rather than by two
+     * decay models happening to agree.
+     */
+    async getLiveReports({
+        from,
+        to,
+        stationId,
+        currentTime,
+        viewer,
+    }: {
+        from: DateTime
+        to: DateTime
+        stationId?: StationId
+        currentTime: DateTime
+        viewer?: ViewerContext
+    }): Promise<RawReportSummary[]> {
+        const annotated = await this.getReportsWithExpiry({ from, to, stationId, currentTime, viewer })
+        return annotated.filter((report) => isLive(report, currentTime.toMillis()))
     }
 
     // Determines which stations the prediction algorithm may emit reports for.

--- a/packages/api-worker/src/modules/risk/risk-service.ts
+++ b/packages/api-worker/src/modules/risk/risk-service.ts
@@ -27,9 +27,15 @@ export class RiskService {
     }: { now?: DateTime; viewer?: ViewerContext } = {}): Promise<RiskData> {
         const oneHourAgo = now.minus({ hours: 1 })
 
-        const [segmentCollection, realReports, stations, lines] = await Promise.all([
+        /*
+         * Live reports only, the same set the map draws markers for. Risk spreads a report's weight
+         * several segments along its line, so feeding it reports that have already expired off the
+         * map is what paints a red line with no marker anywhere near it. The model still applies
+         * its own temporal decay on top; expiry only decides which reports it gets to see at all.
+         */
+        const [segmentCollection, liveReports, stations, lines] = await Promise.all([
             this.transitNetworkDataService.getSegments(),
-            this.reportsService.getRealReports({ from: oneHourAgo, to: now, viewer }),
+            this.reportsService.getLiveReports({ from: oneHourAgo, to: now, currentTime: now, viewer }),
             this.transitNetworkDataService.getStations(),
             this.transitNetworkDataService.getLines(),
         ])
@@ -43,7 +49,7 @@ export class RiskService {
             toStationId: feature.properties.to,
         }))
 
-        const reports: RiskModelReport[] = realReports.flatMap((r) => {
+        const reports: RiskModelReport[] = liveReports.flatMap((r) => {
             const lines = r.lineId !== null ? [r.lineId] : stations[r.stationId].lines
             if (lines.length === 0) return []
             return [

--- a/packages/api-worker/tests/getReports.test.ts
+++ b/packages/api-worker/tests/getReports.test.ts
@@ -26,7 +26,7 @@ const getRealReports = async (response: Response) => {
         timestamp: string
         stationId: string
         isPredicted: boolean
-        opacity: number
+        expiresAt: string | null
     }>
 
     return body.filter((report) => !report.isPredicted)
@@ -841,13 +841,13 @@ describe('Report decay', () => {
         setSystemTime()
     })
 
-    it('attaches an opacity to real reports and omits fully-decayed ones from the response', async () => {
+    it('stamps real reports with an expiry, in the past once they are no longer live', async () => {
         const now = DateTime.utc(2024, 1, 15, 12, 0, 0)
 
         // Well within the burst-adaptive ttl (max 60min in a quiet period)
         await sendReportAt(now.minus({ minutes: 10 }).toJSDate())
-        // Old enough to have fully decayed regardless of burst rate (ttl caps at 60min)
-        await sendReportAt(now.minus({ hours: 3 }).toJSDate())
+        // Past its ttl, so it is no longer live — but still returned
+        await sendReportAt(now.minus({ minutes: 70 }).toJSDate())
 
         setSystemTime(now.toJSDate())
         const from = now.minus({ hours: 4 })
@@ -860,39 +860,63 @@ describe('Report decay', () => {
         expect(response.status).toBe(200)
         const realReports = await getRealReports(response)
 
-        // Only the fresh report survives decay; the 3h-old one was dropped.
-        expect(realReports.length).toBe(1)
+        expect(realReports.length).toBe(2)
 
-        const fresh = realReports[0]!
-        expect(fresh.opacity).toBeGreaterThan(0)
-        expect(fresh.opacity).toBeLessThanOrEqual(1)
+        const expiries = realReports.map((report) => new Date(report.expiresAt!).getTime() > now.toMillis()).sort()
+        expect(expiries).toEqual([false, true])
     })
 
-    it('returns every real report at full opacity when decay=false, even far outside the burst-adaptive ttl', async () => {
+    // The line/station panels ask for the last 24h and the station counter for the last 7d, through
+    // this same endpoint. Every report in those windows is long expired, so annotating rather than
+    // dropping is what keeps them populated.
+    it('returns long-expired reports so historical windows are not emptied', async () => {
         const now = DateTime.utc(2024, 1, 15, 12, 0, 0)
 
-        // Well within the burst-adaptive ttl (max 60min in a quiet period)
-        await sendReportAt(now.minus({ minutes: 10 }).toJSDate())
-        // Old enough to have fully decayed regardless of burst rate (ttl caps at 60min) — this is
-        // exactly the report a 24h/7d history view needs back, unlike the live map.
-        await sendReportAt(now.minus({ hours: 3 }).toJSDate())
+        for (const hoursAgo of [2, 6, 20]) {
+            await sendReportAt(now.minus({ hours: hoursAgo }).toJSDate())
+        }
 
         setSystemTime(now.toJSDate())
-        const from = now.minus({ hours: 4 })
-        const to = now.plus({ minutes: 1 })
+        // The older 24h-to-1h remainder slice the frontend fetches alongside the live last hour.
+        const from = now.minus({ hours: 24 })
+        const to = now.minus({ hours: 1 })
 
         const response = await appRequestWithRedirect(
-            `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}&decay=false`
+            `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
         )
 
         expect(response.status).toBe(200)
         const realReports = await getRealReports(response)
 
-        expect(realReports.length).toBe(2)
-        expect(realReports.every((report) => report.opacity === 1)).toBe(true)
+        expect(realReports.length).toBe(3)
+        expect(realReports.every((report) => new Date(report.expiresAt!).getTime() <= now.toMillis())).toBe(true)
     })
 
-    it('gives predicted reports full opacity', async () => {
+    // Predictions exist to fill a genuine hole in the data. A window full of expired reports is not
+    // a hole — decay hiding stale reports is a statement about them, not missing data — so it must
+    // not be answered with synthesised ones.
+    it('does not backfill a historical window that already has real reports', async () => {
+        const now = DateTime.utc(2024, 1, 15, 12, 0)
+
+        for (const hoursAgo of [2, 6, 20]) {
+            await sendReportAt(now.minus({ hours: hoursAgo }).toJSDate())
+        }
+
+        setSystemTime(now.toJSDate())
+        const from = now.minus({ hours: 24 })
+        const to = now.minus({ hours: 1 })
+
+        const response = await appRequestWithRedirect(
+            `/reports?from=${encodeURIComponent(from.toISO()!)}&to=${encodeURIComponent(to.toISO()!)}`
+        )
+
+        expect(response.status).toBe(200)
+        const body = (await response.json()) as Array<{ isPredicted: boolean }>
+
+        expect(body.filter((report) => report.isPredicted)).toHaveLength(0)
+    })
+
+    it('gives predicted reports no expiry at all', async () => {
         const mondayNoon = DateTime.utc(2024, 1, 15, 12, 0) // peak hours -> high predicted threshold
 
         // Historic reports at the same time-of-day in past weeks so the prediction algorithm has
@@ -913,10 +937,10 @@ describe('Report decay', () => {
         )
 
         expect(response.status).toBe(200)
-        const body = (await response.json()) as Array<{ isPredicted: boolean; opacity: number }>
+        const body = (await response.json()) as Array<{ isPredicted: boolean; expiresAt: string | null }>
         const predicted = body.filter((report) => report.isPredicted)
 
         expect(predicted.length).toBeGreaterThan(0)
-        expect(predicted.every((report) => report.opacity === 1)).toBe(true)
+        expect(predicted.every((report) => report.expiresAt === null)).toBe(true)
     })
 })

--- a/packages/api-worker/tests/getRisk.test.ts
+++ b/packages/api-worker/tests/getRisk.test.ts
@@ -205,6 +205,72 @@ describe('GET /v0/risk timeframe filtering', () => {
     })
 })
 
+/*
+ * Risk spreads a report's weight several segments along its line, so a report the map has already
+ * stopped showing used to keep painting colour across a stretch of line with no marker anywhere on
+ * it. Risk now reads the same live set the map draws, so an expired report contributes nothing.
+ */
+describe('GET /v0/risk expiry', () => {
+    let chainLineId: string
+    let earlyStationId: string
+    let laterStationId: string
+
+    beforeAll(async () => {
+        // A line with at least three stations in travel order, so a later report two hops along it
+        // supersedes an earlier one (2 hops * 3min * 2.5 slack = a 15min budget).
+        const [line] = await db.select({ id: lines.id }).from(lines).limit(1)
+        chainLineId = line!.id
+
+        const stationsInOrder = await db
+            .select({ stationId: lineStations.stationId })
+            .from(lineStations)
+            .where(eq(lineStations.lineId, chainLineId))
+            .orderBy(asc(lineStations.order))
+            .limit(3)
+
+        earlyStationId = stationsInOrder[0]!.stationId
+        laterStationId = stationsInOrder[2]!.stationId
+    })
+
+    beforeEach(async () => {
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        await db.delete(reports)
+    })
+
+    it('an expired report adds no risk on top of the live one that superseded it', async () => {
+        const now = Date.now()
+        const supersededReport = {
+            stationId: earlyStationId,
+            lineId: chainLineId,
+            directionId: null,
+            // 10min before the later report, inside the 15min travel budget, so it is superseded and
+            // expires 3min after being overtaken — 7min ago.
+            timestamp: new Date(now - 20 * 60 * 1000),
+            source: 'telegram' as const,
+        }
+        const liveReport = {
+            stationId: laterStationId,
+            lineId: chainLineId,
+            directionId: null,
+            timestamp: new Date(now - 10 * 60 * 1000),
+            source: 'telegram' as const,
+        }
+
+        await db.insert(reports).values([supersededReport, liveReport])
+        const withBoth = (await (await getRisk()).json()) as RiskResponse
+
+        await db.delete(reports)
+        await db.insert(reports).values([liveReport])
+        const withLiveOnly = (await (await getRisk()).json()) as RiskResponse
+
+        expect(Object.keys(withLiveOnly.segments_risk).length).toBeGreaterThan(0)
+        expect(withBoth.segments_risk).toEqual(withLiveOnly.segments_risk)
+    })
+})
+
 describe('GET /v0/risk segment targeting', () => {
     let segmentLineId: string
     let stationOnSegmentLine: string

--- a/packages/api-worker/tests/report-decay.test.ts
+++ b/packages/api-worker/tests/report-decay.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-    applyReportDecay,
+    annotateReportExpiry,
     BURST_REFERENCE_RATE_PER_MIN,
     burstAdaptiveTtlMs,
     burstRatePerMinute,
     CHAIN_HEAD_TTL_BOOST,
     computeChainInfo,
-    computeReportDecay,
-    MIN_OPACITY,
+    computeExpiresAtMs,
+    isLive,
     SUPERSEDED_FADE_MS,
     TTL_MAX_MS,
     TTL_MIN_MS,
@@ -86,105 +86,93 @@ describe('computeChainInfo', () => {
     })
 })
 
-describe('computeReportDecay', () => {
-    it('is fully opaque for a brand-new, unchained report', () => {
+describe('computeExpiresAtMs', () => {
+    it('expires an unchained report one full ttl after it was reported', () => {
         const now = new Date('2024-01-15T12:00:00Z')
-        const { opacity, dropped } = computeReportDecay(now.getTime(), now.getTime(), 0)
+        const chain = { supersededAtMs: null, isChainHead: false } // no chain-head boost
 
-        expect(opacity).toBe(1)
-        expect(dropped).toBe(false)
+        // Quiet period -> base ttl == TTL_MAX_MS
+        expect(computeExpiresAtMs(now.getTime(), 0, chain)).toBe(now.getTime() + TTL_MAX_MS)
     })
 
-    it('drops a report once its age reaches the ttl', () => {
+    it('boosts a chain head by CHAIN_HEAD_TTL_BOOST', () => {
         const now = new Date('2024-01-15T12:00:00Z')
-        const ratePerMinute = 0 // quiet -> base ttl == TTL_MAX_MS
-        const chain = { supersededAtMs: null, isChainHead: false } // no chain-head boost, so ttl == TTL_MAX_MS
-        const timestampMs = now.getTime() - TTL_MAX_MS
+        const baseTtl = burstAdaptiveTtlMs(0)
 
-        const { opacity, dropped } = computeReportDecay(timestampMs, now.getTime(), ratePerMinute, chain)
+        const expiresAt = computeExpiresAtMs(now.getTime(), 0, { supersededAtMs: null, isChainHead: true })
 
-        expect(dropped).toBe(true)
-        expect(opacity).toBe(0)
+        expect(expiresAt).toBeCloseTo(now.getTime() + baseTtl * CHAIN_HEAD_TTL_BOOST)
     })
 
-    it('never fades below MIN_OPACITY while still inside its ttl', () => {
+    it('cuts a superseded report short, one fade window after it was overtaken', () => {
         const now = new Date('2024-01-15T12:00:00Z')
-        const ratePerMinute = 0
-        const almostExpiredMs = now.getTime() - (TTL_MAX_MS - 1)
+        const reportedAtMs = minutesAgo(now, 10).getTime()
+        const supersededAtMs = minutesAgo(now, 4).getTime()
 
-        const { opacity, dropped } = computeReportDecay(almostExpiredMs, now.getTime(), ratePerMinute)
+        const expiresAt = computeExpiresAtMs(reportedAtMs, 0, { supersededAtMs, isChainHead: false })
 
-        expect(dropped).toBe(false)
-        expect(opacity).toBeGreaterThanOrEqual(MIN_OPACITY)
+        expect(expiresAt).toBe(supersededAtMs + SUPERSEDED_FADE_MS)
     })
 
-    it('boosts the ttl of a chain head by CHAIN_HEAD_TTL_BOOST', () => {
+    /*
+     * Being overtaken is evidence a report is stale, so it can only ever shorten a report's life.
+     * A report already near the end of its ttl when it is overtaken must not have its life extended
+     * out to the fade window.
+     */
+    it('never lets being superseded extend a report past its own ttl', () => {
         const now = new Date('2024-01-15T12:00:00Z')
-        const ratePerMinute = 0
-        const baseTtl = burstAdaptiveTtlMs(ratePerMinute)
+        const chain = { supersededAtMs: now.getTime(), isChainHead: false }
+        // Reported a full ttl ago, so its own expiry is now — before the fade window would end.
+        const reportedAtMs = now.getTime() - TTL_MAX_MS
 
-        const { ttlMs } = computeReportDecay(now.getTime(), now.getTime(), ratePerMinute, {
-            supersededAtMs: null,
-            isChainHead: true,
-        })
-
-        expect(ttlMs).toBeCloseTo(baseTtl * CHAIN_HEAD_TTL_BOOST)
-    })
-
-    it('fades a superseded report out quickly, independent of its normal ttl', () => {
-        const now = new Date('2024-01-15T12:00:00Z')
-        const supersededAtMs = now.getTime() - SUPERSEDED_FADE_MS / 2
-
-        const { opacity, dropped } = computeReportDecay(now.getTime() - 60_000, now.getTime(), 0, {
-            supersededAtMs,
-            isChainHead: false,
-        })
-
-        expect(dropped).toBe(false)
-        expect(opacity).toBeCloseTo(MIN_OPACITY * 0.5)
-        expect(opacity).toBeLessThan(MIN_OPACITY)
-    })
-
-    it('drops a superseded report once the fade window has fully elapsed', () => {
-        const now = new Date('2024-01-15T12:00:00Z')
-        const supersededAtMs = now.getTime() - SUPERSEDED_FADE_MS
-
-        const { opacity, dropped } = computeReportDecay(now.getTime() - 60_000, now.getTime(), 0, {
-            supersededAtMs,
-            isChainHead: false,
-        })
-
-        expect(dropped).toBe(true)
-        expect(opacity).toBe(0)
+        expect(computeExpiresAtMs(reportedAtMs, 0, chain)).toBe(now.getTime())
     })
 })
 
-describe('applyReportDecay', () => {
-    it('drops expired reports and attaches opacity to the ones that survive', () => {
+describe('annotateReportExpiry', () => {
+    it('stamps every report with its expiry without dropping any of them', () => {
         const now = new Date('2024-01-15T12:00:00Z')
         const reports = [
             { stationId: 'a0', lineId: null, timestamp: minutesAgo(now, 0) },
-            { stationId: 'a1', lineId: null, timestamp: minutesAgo(now, 120) }, // well past TTL_MAX_MS
+            { stationId: 'a1', lineId: null, timestamp: minutesAgo(now, 70) }, // long past any ttl
         ]
 
-        const result = applyReportDecay(reports, [LINE_A], now.getTime())
+        const result = annotateReportExpiry(reports, [LINE_A], now.getTime())
 
-        expect(result).toHaveLength(1)
-        expect(result[0]!.stationId).toBe('a0')
-        expect(result[0]!.opacity).toBeGreaterThan(0)
+        expect(result).toHaveLength(2)
+        expect(isLive(result[0]!, now.getTime())).toBe(true)
+        expect(isLive(result[1]!, now.getTime())).toBe(false)
     })
 
-    it('fades out the earlier report of a chain faster than an equally-aged, unchained one', () => {
+    /*
+     * The 24h line/station panels and the 7d station counter read the same endpoint as the map.
+     * Every report in those windows is older than any ttl, so annotating (rather than dropping)
+     * is what keeps those views populated.
+     */
+    it('returns long-expired reports so historical windows stay populated', () => {
+        const now = new Date('2024-01-15T12:00:00Z')
+        const reports = [
+            { stationId: 'a0', lineId: LINE_A.id, timestamp: minutesAgo(now, 120) },
+            { stationId: 'a2', lineId: LINE_A.id, timestamp: minutesAgo(now, 126) },
+        ]
+
+        const result = annotateReportExpiry(reports, [LINE_A], now.getTime())
+
+        expect(result).toHaveLength(2)
+        expect(result.every((report) => isLive(report, now.getTime()))).toBe(false)
+    })
+
+    it('expires the earlier report of a chain sooner than an equally-aged, unchained one', () => {
         const now = new Date('2024-01-15T12:00:00Z')
         const supersededStation = { stationId: 'a0', lineId: LINE_A.id, timestamp: minutesAgo(now, 6) }
         const chainHead = { stationId: 'a2', lineId: LINE_A.id, timestamp: minutesAgo(now, 0) }
         const unchained = { stationId: 'a0', lineId: null, timestamp: minutesAgo(now, 6) }
 
-        const result = applyReportDecay([supersededStation, chainHead, unchained], [LINE_A], now.getTime())
+        const result = annotateReportExpiry([supersededStation, chainHead, unchained], [LINE_A], now.getTime())
 
-        const supersededOpacity = result.find((r) => r.lineId === LINE_A.id && r.stationId === 'a0')!.opacity
-        const unchainedOpacity = result.find((r) => r.lineId === null)!.opacity
+        const supersededExpiry = result.find((r) => r.lineId === LINE_A.id && r.stationId === 'a0')!.expiresAt
+        const unchainedExpiry = result.find((r) => r.lineId === null)!.expiresAt
 
-        expect(supersededOpacity).toBeLessThan(unchainedOpacity)
+        expect(supersededExpiry.getTime()).toBeLessThan(unchainedExpiry.getTime())
     })
 })

--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -16,7 +16,19 @@ export type Report = {
   directionId: string | null;
   lineId: string | null;
   isPredicted: boolean;
+  /*
+   * When this report stops counting as live — the API's call, since it takes the whole city's
+   * reports to spot a burst or a controller moving down a line. Everything that asks "is this
+   * current?" compares this one instant against the clock, so the map, the risk overlay and the
+   * counter cannot drift apart. It is often in the past: a 24h or 7d window is mostly reports that
+   * expired long ago, and they still happened. `null` means it never expires (predicted reports).
+   */
+  expiresAt: string | null;
 };
+
+/** Whether a report is still current, as opposed to something that merely happened in the window. */
+export const isReportLive = (report: Report, nowMs: number): boolean =>
+  report.expiresAt === null || new Date(report.expiresAt).getTime() > nowMs;
 
 /**
  * Human-readable "time since" for a report timestamp, using the caller's i18n `t`. The
@@ -109,11 +121,6 @@ export const reportsSliceQueryOptions = (fromAgo: number, toAgo: number) => {
         from: new Date(now - fromAgo).toISOString(),
         to: new Date(now - toAgo).toISOString(),
       });
-      // The live slice is the map's rolling window, so the API's burst-adaptive decay (which
-      // drops anything older than ~60 min) applies. The older slice is explicit history — a
-      // report doesn't stop having happened just because it would have faded off the map by
-      // now — so it opts out and gets every real report in range back.
-      if (toAgo !== 0) params.set('decay', 'false');
       return fetchJson<Report[]>(`/v0/reports?${params.toString()}`);
     },
     ...(isLiveSlice ? LIVE_SLICE_POLLING : OLDER_SLICE_POLLING),
@@ -170,8 +177,7 @@ export const stationReportCountQueryOptions = (stationId: string) => {
   return {
     queryKey: ['reports', stationId, from, to] as const,
     queryFn: () => {
-      // A 7-day lookback is explicit history, not the live map, so it opts out of decay too.
-      const params = new URLSearchParams({ from, to, decay: 'false' });
+      const params = new URLSearchParams({ from, to });
       return fetchJson<Report[]>(`/v0/reports/${stationId}?${params.toString()}`);
     },
     staleTime: HOUR_MS,

--- a/packages/frontend-next/src/components/debug/ReportDecayDebugPanel.tsx
+++ b/packages/frontend-next/src/components/debug/ReportDecayDebugPanel.tsx
@@ -7,10 +7,11 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { useReportSimulation } from '@/contexts/ReportSimulation.context';
 import {
+  annotateReportExpiry,
   burstRatePerMinute,
   buildLineTopologies,
   computeChainInfo,
-  computeReportDecay,
+  reportOpacity,
 } from '@/lib/report-decay';
 import {
   buildBurstReports,
@@ -96,9 +97,16 @@ export function ReportDecayDebugPanel() {
     return buildBurstReports(stations, count, rangeStartMs + totalRangeMs, totalRangeMs);
   }, [stations, burstIntensity, scenarioStartMs]);
 
+  const simulatedNowMs = scenarioStartMs + simMinutes * 60_000;
+
+  /*
+   * The API stamps real reports with an `expiresAt`; here the same model runs client-side so the
+   * scenario can be played forward without a backend. Downstream — the map layer included — sees
+   * simulated and real reports in exactly the same shape.
+   */
   const combinedReports = useMemo(
-    () => [...burstReports, ...walkReports],
-    [burstReports, walkReports],
+    () => annotateReportExpiry([...burstReports, ...walkReports], lines, simulatedNowMs, reportKey),
+    [burstReports, walkReports, lines, simulatedNowMs],
   );
 
   const generateWalk = () => {
@@ -115,8 +123,6 @@ export function ReportDecayDebugPanel() {
     );
   };
 
-  const simulatedNowMs = scenarioStartMs + simMinutes * 60_000;
-
   useEffect(() => {
     setSimulation({
       reports: active ? combinedReports : null,
@@ -129,6 +135,17 @@ export function ReportDecayDebugPanel() {
   const lineTopologies = buildLineTopologies(lines);
   const chainByKey = computeChainInfo(walkReports, lineTopologies, reportKey);
   const ratePerMinute = burstRatePerMinute(combinedReports, simulatedNowMs);
+  // Read back the expiry the simulation assigned, so this readout and the map agree exactly.
+  const expiresAtMsByKey = new Map(
+    combinedReports.map((report) => [reportKey(report), new Date(report.expiresAt).getTime()]),
+  );
+
+  const walkReportOpacity = (report: (typeof walkReports)[number]): number | null =>
+    reportOpacity(
+      new Date(report.timestamp).getTime(),
+      expiresAtMsByKey.get(reportKey(report)) ?? null,
+      simulatedNowMs,
+    );
   const lineColorById = new Map(lines.map((line) => [line.id, line.color]));
 
   return (
@@ -231,12 +248,8 @@ export function ReportDecayDebugPanel() {
               <div className="flex flex-wrap items-center gap-1.5 py-1">
                 {walkReports.map((report) => {
                   const chain = chainByKey.get(reportKey(report));
-                  const { opacity, dropped } = computeReportDecay(
-                    new Date(report.timestamp).getTime(),
-                    simulatedNowMs,
-                    ratePerMinute,
-                    chain,
-                  );
+                  const opacity = walkReportOpacity(report);
+                  const dropped = opacity === null;
                   return (
                     <span
                       key={reportKey(report)}
@@ -248,7 +261,7 @@ export function ReportDecayDebugPanel() {
                       )}
                       style={{
                         backgroundColor: report.lineId ? lineColorById.get(report.lineId) : '#999',
-                        opacity: dropped ? 0.08 : Math.max(opacity, 0.08),
+                        opacity: opacity === null ? 0.08 : Math.max(opacity, 0.08),
                       }}
                     />
                   );
@@ -257,12 +270,8 @@ export function ReportDecayDebugPanel() {
             )}
             {walkReports.map((report) => {
               const chain = chainByKey.get(reportKey(report));
-              const { opacity, dropped } = computeReportDecay(
-                new Date(report.timestamp).getTime(),
-                simulatedNowMs,
-                ratePerMinute,
-                chain,
-              );
+              const opacity = walkReportOpacity(report);
+              const dropped = opacity === null;
               const ageMin = Math.round(
                 (simulatedNowMs - new Date(report.timestamp).getTime()) / 60_000,
               );

--- a/packages/frontend-next/src/components/map/ReportsOverviewButton.i18n.ts
+++ b/packages/frontend-next/src/components/map/ReportsOverviewButton.i18n.ts
@@ -2,10 +2,12 @@ import { i18n } from '@/lib/i18n';
 
 export const NAMESPACE = 'reportsOverviewButton';
 
+// The count is of reports still live on the map, not of everything reported in the last hour, so
+// the label says "current" rather than naming a time window it no longer matches.
 i18n.addResourceBundle('en', NAMESPACE, {
-  lastHour: 'Reports · last 1 h',
+  currentReports: 'Current reports',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
-  lastHour: 'Meldungen · letzte Std.',
+  currentReports: 'Aktuelle Meldungen',
 });

--- a/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
+++ b/packages/frontend-next/src/components/map/ReportsOverviewButton.tsx
@@ -1,10 +1,12 @@
 import { Link } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
-import { HOUR_MS, useReports } from '@/api/reports';
+import { HOUR_MS, isReportLive, useReports } from '@/api/reports';
 import { useLines, useStations } from '@/api/transit';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Button } from '@/components/ui/button';
+import { useNow } from '@/hooks/useNow';
+import { REPORT_RECOMPUTE_INTERVAL_MS } from '@/hooks/useReportsLayer';
 import { markReportViewed, useReportViewed } from '@/lib/viewed-reports';
 import { Route as ReportsSummaryRoute } from '@/routes/reports/index';
 
@@ -16,12 +18,17 @@ export function ReportsOverviewButton() {
   const { data: reports } = useReports(HOUR_MS);
   const { data: lines } = useLines();
   const { data: stations } = useStations();
+  // Matches the map layer's cadence, so the count and the markers roll over together.
+  const now = useNow(REPORT_RECOMPUTE_INTERVAL_MS);
 
-  // useReports(HOUR_MS) already scopes the data to the last hour, so the count is just the
-  // number of reports and the latest is the newest by timestamp.
-  const allReports = reports ?? [];
-  const recentCount = allReports.length;
-  const latest = allReports.slice().sort((a, b) => b.timestamp.localeCompare(a.timestamp))[0];
+  /*
+   * Counts the reports that are still live, not every report in the last hour — this button sits on
+   * the map, and a count that disagreed with the markers next to it ("17" over six dots) reads as a
+   * bug rather than as two different questions being answered.
+   */
+  const liveReports = (reports ?? []).filter((report) => isReportLive(report, now));
+  const recentCount = liveReports.length;
+  const latest = liveReports.slice().sort((a, b) => b.timestamp.localeCompare(a.timestamp))[0];
   // Called before the early return to keep hook order stable; empty keys match nothing.
   const latestViewed = useReportViewed(latest?.stationId ?? '', latest?.timestamp ?? '');
 
@@ -47,7 +54,7 @@ export function ReportsOverviewButton() {
           onClick={() => markReportViewed(latest.stationId, latest.timestamp)}
         >
           <div className="flex items-center justify-between gap-3">
-            <span className="text-muted-foreground text-xs">{t('lastHour')}</span>
+            <span className="text-muted-foreground text-xs">{t('currentReports')}</span>
             <span className="text-sm font-semibold">{recentCount}</span>
           </div>
           <div className="flex items-center gap-2">

--- a/packages/frontend-next/src/hooks/useNow.ts
+++ b/packages/frontend-next/src/hooks/useNow.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * The current time, re-read every `intervalMs`, or frozen at mount when passed `null`.
+ *
+ * Anything that renders "is this still current?" needs a clock that advances on its own — a report
+ * expires while the page sits there, with no fetch and no interaction to trigger a re-render.
+ * Reading `Date.now()` during render would be impure and would not update on its own anyway.
+ */
+export function useNow(intervalMs: number | null): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (intervalMs === null) return;
+    const id = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs]);
+
+  return now;
+}

--- a/packages/frontend-next/src/hooks/useReportsLayer.ts
+++ b/packages/frontend-next/src/hooks/useReportsLayer.ts
@@ -1,21 +1,19 @@
 import { useRouter } from '@tanstack/react-router';
 import type { FeatureCollection, Point } from 'geojson';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { HOUR_MS, type Report, useReports } from '@/api/reports';
-import { type Line, type Stations, useLines, useStations } from '@/api/transit';
+import { type Stations, useStations } from '@/api/transit';
 import { useReportSimulation } from '@/contexts/ReportSimulation.context';
-import {
-  buildLineTopologies,
-  burstRatePerMinute,
-  computeChainInfo,
-  computeReportDecay,
-} from '@/lib/report-decay';
+import { useNow } from '@/hooks/useNow';
+import { MIN_OPACITY, reportOpacity } from '@/lib/report-decay';
 import { useIsReportViewed } from '@/lib/viewed-reports';
 import { Route as ReportDetailRoute } from '@/routes/_map/reports/$stationId';
 
 const PULSE_AGE_MS = 60 * 15 * 1000;
-const RECOMPUTE_INTERVAL_MS = 30 * 1000;
+
+/** How often anything showing live reports re-reads the clock to roll expiry and fade forward. */
+export const REPORT_RECOMPUTE_INTERVAL_MS = 30 * 1000;
 
 export const REPORTS_HIT_LAYER_ID = 'reports-hit';
 export const REPORTS_CIRCLE_LAYER_ID = 'reports-circle';
@@ -27,37 +25,29 @@ export type ReportPointProps = {
   pulse: boolean;
 };
 
-function reportKey(report: Report): string {
-  return `${report.stationId}-${report.timestamp}`;
-}
-
+/*
+ * The map draws the reports that are still live, at the opacity they have run down to. Which ones
+ * those are is the API's call — it stamps every report with an `expiresAt` computed from the whole
+ * city's reports, which is also what the risk overlay and the report counter read, so the three
+ * cannot disagree about what is current. All that is left here is the fade.
+ */
 function reportsToGeoJSON(
   reports: Report[],
   stations: Stations,
-  lines: Line[] | undefined,
   isViewed: (stationId: string, timestamp: string) => boolean,
   nowMs: number,
 ): FeatureCollection<Point, ReportPointProps> {
-  const lineTopologies = buildLineTopologies(lines ?? []);
-  const chainByKey = computeChainInfo(reports, lineTopologies, reportKey);
-  const ratePerMinute = burstRatePerMinute(reports, nowMs);
-
   const features = reports.flatMap((report) => {
     const station = stations[report.stationId];
     if (!station) return [];
-    const chain = chainByKey.get(reportKey(report));
-    const { opacity, dropped } = computeReportDecay(
-      new Date(report.timestamp).getTime(),
-      nowMs,
-      ratePerMinute,
-      chain,
-    );
-    if (dropped) return [];
+    const expiresAtMs = report.expiresAt === null ? null : new Date(report.expiresAt).getTime();
+    const opacity = reportOpacity(new Date(report.timestamp).getTime(), expiresAtMs, nowMs);
+    if (opacity === null) return [];
     const age = nowMs - new Date(report.timestamp).getTime();
+    // A report on its way out has stopped being news, so it stops pulsing before it stops showing.
+    const isFadingOut = opacity < MIN_OPACITY;
     const pulse =
-      age < PULSE_AGE_MS &&
-      (chain?.supersededAtMs ?? null) === null &&
-      !isViewed(report.stationId, report.timestamp);
+      age < PULSE_AGE_MS && !isFadingOut && !isViewed(report.stationId, report.timestamp);
     return [
       {
         type: 'Feature' as const,
@@ -80,23 +70,16 @@ function reportsToGeoJSON(
 export function useReportsLayer(): FeatureCollection<Point, ReportPointProps> | null {
   const { data: liveReports } = useReports(HOUR_MS);
   const { data: stations } = useStations();
-  const { data: lines } = useLines();
   const isViewed = useIsReportViewed();
   const router = useRouter();
   const simulation = useReportSimulation();
-  const [wallNow, setWallNow] = useState(() => Date.now());
-
-  useEffect(() => {
-    if (simulation.nowMs !== null) return;
-    const id = window.setInterval(() => setWallNow(Date.now()), RECOMPUTE_INTERVAL_MS);
-    return () => window.clearInterval(id);
-  }, [simulation.nowMs]);
+  // The simulation drives its own clock, so the wall clock stops ticking while it is active.
+  const wallNow = useNow(simulation.nowMs !== null ? null : REPORT_RECOMPUTE_INTERVAL_MS);
 
   const reports = simulation.reports ?? liveReports;
   const now = simulation.nowMs ?? wallNow;
 
-  const data =
-    reports && stations ? reportsToGeoJSON(reports, stations, lines, isViewed, now) : null;
+  const data = reports && stations ? reportsToGeoJSON(reports, stations, isViewed, now) : null;
 
   // Warm the report-detail route for every visible report. Reports navigate imperatively, so the
   // router's viewport preloading never sees them. Keyed on the station-id set so it only re-runs

--- a/packages/frontend-next/src/lib/report-decay-simulation.ts
+++ b/packages/frontend-next/src/lib/report-decay-simulation.ts
@@ -3,6 +3,14 @@ import type { Line, Stations } from '@/api/transit';
 
 import { AVG_HOP_TRAVEL_MS, BURST_WINDOW_MS } from './report-decay';
 
+/*
+ * Scenario builders produce the reports themselves; the expiry that follows from them is stamped on
+ * afterwards by `annotateReportExpiry`, in one pass over the whole scenario — a report's ttl depends
+ * on how many others are around it and on what came later down the line, so it cannot be decided
+ * one report at a time as they are built.
+ */
+type UnexpiredReport = Omit<Report, 'expiresAt'>;
+
 export const FALLBACK_LINES: Line[] = [
   {
     id: 'debug-line-a',
@@ -51,11 +59,11 @@ export function buildBurstReports(
   count: number,
   nowMs: number,
   windowMs: number = BURST_WINDOW_MS,
-): Report[] {
+): UnexpiredReport[] {
   const stationIds = Object.keys(stations);
   if (stationIds.length === 0) return [];
 
-  const reports: Report[] = [];
+  const reports: UnexpiredReport[] = [];
   for (let i = 0; i < count; i++) {
     const stationId = stationIds[Math.floor(Math.random() * stationIds.length)]!;
     const offsetMs = Math.random() * windowMs;
@@ -88,13 +96,13 @@ export function buildControllerWalk({
   hopCount,
   hopMs = AVG_HOP_TRAVEL_MS,
   allowLineSwitch,
-}: ControllerWalkOptions): Report[] {
+}: ControllerWalkOptions): UnexpiredReport[] {
   const lineById = new Map(lines.map((line) => [line.id, line]));
   const startLine = lineById.get(startLineId);
   if (!startLine) return [];
   let currentLine: Line = startLine;
 
-  const reports: Report[] = [];
+  const reports: UnexpiredReport[] = [];
   let cursor = currentLine.stations.length > 0 ? 0 : -1;
   let switched = false;
   let timestampMs = startMs;

--- a/packages/frontend-next/src/lib/report-decay.ts
+++ b/packages/frontend-next/src/lib/report-decay.ts
@@ -1,3 +1,13 @@
+/**
+ * How a report fades while it runs down, and — for the debug simulation only — a client-side mirror
+ * of the API's expiry model.
+ *
+ * The split matters: *when* a report stops being live is the API's call (`expiresAt`), because it
+ * takes the whole city's reports to see a burst or spot a controller moving down a line, and
+ * because the map, the risk model and the report counter have to agree on the answer. *How* a live
+ * report looks on its way out is purely presentation, and lives here.
+ */
+
 export type DecayableReport = {
   stationId: string;
   lineId: string | null;
@@ -9,12 +19,39 @@ export const BURST_WINDOW_MS = 15 * 60 * 1000;
 export const BURST_REFERENCE_RATE_PER_MIN = 0.5;
 export const TTL_MIN_MS = 15 * 60 * 1000;
 export const TTL_MAX_MS = 60 * 60 * 1000;
-export const MIN_OPACITY = 0.4;
 
 export const AVG_HOP_TRAVEL_MS = 3 * 60 * 1000;
 export const CHAIN_SLACK_FACTOR = 2.5;
 export const SUPERSEDED_FADE_MS = 3 * 60 * 1000;
 export const CHAIN_HEAD_TTL_BOOST = 1.25;
+
+/** Faintest a report gets while it is still live; it fades from here to nothing as it expires. */
+export const MIN_OPACITY = 0.4;
+/** How long before expiry a report starts fading out completely, rather than snapping away. */
+export const FADE_OUT_MS = 3 * 60 * 1000;
+
+/**
+ * How opaque a report should render right now, or `null` if it is no longer live and should not be
+ * drawn at all. Reports with no expiry (predicted ones) never fade.
+ *
+ * The ramp runs from full opacity at the moment of reporting down to `MIN_OPACITY`, where it holds
+ * until the last `FADE_OUT_MS` before expiry and then fades to nothing.
+ */
+export function reportOpacity(
+  timestampMs: number,
+  expiresAtMs: number | null,
+  nowMs: number,
+): number | null {
+  if (expiresAtMs === null) return 1;
+
+  const remaining = expiresAtMs - nowMs;
+  if (remaining <= 0) return null;
+  if (remaining < FADE_OUT_MS) return MIN_OPACITY * (remaining / FADE_OUT_MS);
+
+  const lifetime = expiresAtMs - timestampMs;
+  if (lifetime <= 0) return MIN_OPACITY;
+  return Math.max(MIN_OPACITY, 1 - (nowMs - timestampMs) / lifetime);
+}
 
 export function burstRatePerMinute(
   reports: readonly DecayableReport[],
@@ -105,30 +142,42 @@ export function computeChainInfo<T extends DecayableReport>(
   return info;
 }
 
-export type DecayResult = {
-  opacity: number;
-  ttlMs: number;
-  dropped: boolean;
-};
-
-export function computeReportDecay(
+/**
+ * When a report stops being live. Mirrors `computeExpiresAtMs` in the API's `report-decay.ts` —
+ * kept in step by hand so the debug page can play the model forward without a backend round-trip.
+ * Nothing on the live map path calls this: there, `expiresAt` comes from the API.
+ */
+export function computeExpiresAtMs(
   reportTimestampMs: number,
-  nowMs: number,
   ratePerMinute: number,
   chain: ChainInfo = NOT_CHAINED,
-): DecayResult {
+): number {
   const baseTtl = burstAdaptiveTtlMs(ratePerMinute);
   const ttlMs = chain.isChainHead ? baseTtl * CHAIN_HEAD_TTL_BOOST : baseTtl;
+  const ttlExpiry = reportTimestampMs + ttlMs;
 
-  if (chain.supersededAtMs !== null && nowMs >= chain.supersededAtMs) {
-    const sinceSuperseded = nowMs - chain.supersededAtMs;
-    if (sinceSuperseded >= SUPERSEDED_FADE_MS) return { opacity: 0, ttlMs, dropped: true };
-    const opacity = MIN_OPACITY * (1 - sinceSuperseded / SUPERSEDED_FADE_MS);
-    return { opacity, ttlMs, dropped: false };
-  }
+  if (chain.supersededAtMs === null) return ttlExpiry;
+  return Math.min(ttlExpiry, chain.supersededAtMs + SUPERSEDED_FADE_MS);
+}
 
-  const age = nowMs - reportTimestampMs;
-  if (age >= ttlMs) return { opacity: 0, ttlMs, dropped: true };
-  const opacity = Math.max(MIN_OPACITY, 1 - age / ttlMs);
-  return { opacity, ttlMs, dropped: false };
+/** Stamps simulated reports with an expiry, the way the API does for real ones. */
+export function annotateReportExpiry<T extends DecayableReport>(
+  reports: readonly T[],
+  lines: readonly { id: string; stations: readonly string[] }[],
+  nowMs: number,
+  keyOf: (report: T) => string,
+): (T & { expiresAt: string })[] {
+  const chainByKey = computeChainInfo(reports, buildLineTopologies(lines), keyOf);
+  const ratePerMinute = burstRatePerMinute(reports, nowMs);
+
+  return reports.map((report) => ({
+    ...report,
+    expiresAt: new Date(
+      computeExpiresAtMs(
+        new Date(report.timestamp).getTime(),
+        ratePerMinute,
+        chainByKey.get(keyOf(report)),
+      ),
+    ).toISOString(),
+  }));
 }


### PR DESCRIPTION
Supersedes #930 — that shipped a `decay=false` query param for historical lookbacks; this removes the need for it, and the param along with it.

### warum

#928 gave each report an `opacity` and dropped the ones that reached zero. Two problems followed.

**The drop ran on every `/v0/reports` query**, but decay measures age against *now*, so it only means something for the live map window. The 24h line/station panels fetch a 24h→1h slice through the same endpoint, where every report is older than any ttl, and the 7d station counter likewise. Both came back empty — and the emptiness then fell under the predicted-reports threshold and got backfilled with *synthesised* reports.

**The risk model never saw decay at all.** `risk-service.ts` reads `getRealReports` directly and applies its own temporal decay over a wider horizon, spreading each report's weight several segments along its line. So a report that had expired off the map kept painting colour across a stretch of line with no marker anywhere on it — visible on prod as red lines with nothing on them.

There was a third variant: the map's report counter read `reports.length` over the raw hour, so it showed "17" over six markers. Three consumers, three different notions of "live".

### was sich ändert

Decay now answers *when a report stops being live*, as one absolute instant:

```
expiresAt = min(timestamp + ttl, supersededAt + fade)
```

An instant is cacheable and shareable in a way a fade level is not — it stays correct as a response ages (the older slice has `staleTime: 1h`, so an opacity computed at fetch time would arrive an hour stale), and every consumer decides "is this live?" with the same comparison against its own clock. Expressing supersede as a `min` also fixes a latent bug: being overtaken could previously *extend* a report past its own ttl.

**Nothing is filtered server-side any more.** A report past its expiry is still a report that happened, so historical windows stay populated without anyone opting out. Callers that want only what is current say so with `isLive` — and the risk model now reads through `getLiveReports`, which makes a coloured line with no marker on it impossible by construction rather than by two decay models happening to agree.

**Opacity moves to the client.** When a report dies is a judgement about the whole city's reports; how it looks on the way out is presentation. The two fade modes collapse into one ramp that reproduces the superseded fade exactly and drops the old hard snap from `MIN_OPACITY` to zero. `useReportsLayer` had been recomputing decay locally and ignoring the server's `opacity` entirely — it now just fades what the API marked live.

Predicted reports carry `expiresAt: null`: they stand in for missing data rather than describing an event that ages.

### zwei entscheidungen, die review verdienen

**The predicted-reports threshold counts every report in range, not just the live ones.** Gating on the live count would re-break history: a 24h window of expired reports would look like a data gap and get backfilled. It also means decay hiding a stale report no longer triggers predictions to replace it — which I think is right (that would swap "we hid something stale" for "here is something invented"), but it is a change from #928's stated intent.

**The map counter's label changed** from "Reports · last 1 h" to "Current reports" / "Aktuelle Meldungen", because it now counts live reports rather than a time window.

### getestet

Unit + integration tests for the expiry model, the historical window, the no-backfill rule, and a `getRisk` test that an expired report adds no risk on top of the live one that superseded it.

Beyond that, run locally against a seeded Berlin D1 with a controller walking up U8 (each report overtakes the one before) plus history:

| | vorher | nachher |
|---|---|---|
| 24h→1h slice | 0 real reports | all history returned |
| reports page | last hour only | "7 reports · last 24 h" |
| `/v0/risk` with 2 expired reports present | painted from them | byte-identical to live-only |
| map / counter | 17 vs 6 markers | 2 markers, "Current reports 2" |

The risk check is the decisive one: `/v0/risk` diffed with the expired reports in the database against the same query with them deleted — identical, 8 segments either way.