### PR TITLE
feat: name the layer the map is showing and key the risk colours

### DIFF
--- a/packages/frontend-next/src/components/map/LayerToggleButton.i18n.ts
+++ b/packages/frontend-next/src/components/map/LayerToggleButton.i18n.ts
@@ -4,12 +4,18 @@ export const NAMESPACE = 'layerToggle';
 
 i18n.addResourceBundle('en', NAMESPACE, {
   risk: 'Risk',
+  lines: 'Lines',
   showRiskLayer: 'Show risk layer',
-  hideRiskLayer: 'Hide risk layer',
+  hideRiskLayer: 'Show line colours instead of risk',
+  riskLow: 'Low',
+  riskHigh: 'High',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
   risk: 'Risiko',
+  lines: 'Linien',
   showRiskLayer: 'Risiko-Ebene anzeigen',
-  hideRiskLayer: 'Risiko-Ebene ausblenden',
+  hideRiskLayer: 'Linienfarben statt Risiko anzeigen',
+  riskLow: 'Gering',
+  riskHigh: 'Hoch',
 });

--- a/packages/frontend-next/src/components/map/LayerToggleButton.tsx
+++ b/packages/frontend-next/src/components/map/LayerToggleButton.tsx
@@ -5,7 +5,6 @@ import { RISK_COLORS } from '@/api/risk';
 import { Button } from '@/components/ui/button';
 import { useRiskLayer } from '@/hooks/useRiskLayer';
 import { selectionTap } from '@/lib/haptics';
-import { cn } from '@/lib/utils';
 
 import { NAMESPACE } from './LayerToggleButton.i18n';
 
@@ -26,12 +25,11 @@ export function LayerToggleButton() {
         }}
         aria-pressed={visible}
         aria-label={visible ? t('hideRiskLayer') : t('showRiskLayer')}
-        className={cn(
-          'bg-card hover:bg-card/80 pointer-events-auto h-11 w-[4.5rem] flex-col gap-0.5 rounded-lg px-3 shadow-[0_6px_16px_rgba(0,0,0,0.28)]',
-          // Risk is the default and switching is rare, so keep the states quiet: full-strength
-          // when on, dimmed when off. The fixed width keeps the two labels from reflowing the row.
-          visible ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
-        )}
+        // Both states stay full-strength: dimming the control in the lines state made the only way
+        // back to risk read as unavailable (grey is the disabled convention). State is carried by
+        // the label, the legend below, and aria-pressed instead. The fixed width keeps the two
+        // labels from reflowing the row.
+        className="bg-card text-foreground hover:bg-card/80 pointer-events-auto h-11 w-[4.5rem] flex-col gap-0.5 rounded-lg px-3 shadow-[0_6px_16px_rgba(0,0,0,0.28)]"
       >
         <Layers className="size-5" />
         <span className="text-[11px] leading-none font-semibold">

--- a/packages/frontend-next/src/components/map/LayerToggleButton.tsx
+++ b/packages/frontend-next/src/components/map/LayerToggleButton.tsx
@@ -1,6 +1,7 @@
 import { Layers } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { RISK_COLORS } from '@/api/risk';
 import { Button } from '@/components/ui/button';
 import { useRiskLayer } from '@/hooks/useRiskLayer';
 import { selectionTap } from '@/lib/haptics';
@@ -8,12 +9,14 @@ import { cn } from '@/lib/utils';
 
 import { NAMESPACE } from './LayerToggleButton.i18n';
 
+const RISK_SCALE = [RISK_COLORS.clear, RISK_COLORS.moderate, RISK_COLORS.high, RISK_COLORS.severe];
+
 export function LayerToggleButton() {
   const { t } = useTranslation(NAMESPACE);
   const { visible, toggle } = useRiskLayer();
 
   return (
-    <div className="top-safe-14 pointer-events-none fixed right-0 z-20 p-3 sm:top-0">
+    <div className="top-safe-14 pointer-events-none fixed right-0 z-20 flex flex-col items-end gap-1.5 p-3 sm:top-0">
       <Button
         type="button"
         variant="secondary"
@@ -24,15 +27,36 @@ export function LayerToggleButton() {
         aria-pressed={visible}
         aria-label={visible ? t('hideRiskLayer') : t('showRiskLayer')}
         className={cn(
-          'bg-card hover:bg-card/80 pointer-events-auto h-11 flex-col gap-0.5 rounded-lg px-3 shadow-[0_6px_16px_rgba(0,0,0,0.28)]',
+          'bg-card hover:bg-card/80 pointer-events-auto h-11 w-[4.5rem] flex-col gap-0.5 rounded-lg px-3 shadow-[0_6px_16px_rgba(0,0,0,0.28)]',
           // Risk is the default and switching is rare, so keep the states quiet: full-strength
-          // when on, dimmed when off. The label stays put in both states, so it never reflows.
+          // when on, dimmed when off. The fixed width keeps the two labels from reflowing the row.
           visible ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
         )}
       >
         <Layers className="size-5" />
-        <span className="text-[11px] leading-none font-semibold">{t('risk')}</span>
+        <span className="text-[11px] leading-none font-semibold">
+          {visible ? t('risk') : t('lines')}
+        </span>
       </Button>
+      {/*
+       * The risk shading had no key, so users couldn't tell what the colours meant (in-app
+       * feedback: "the risk button is unclear", "Was bedeuten die Farben der Gleise?"). Only the
+       * risk scale needs one — in the other state the button reads "Lines" and the segments carry
+       * the network's own colours.
+       */}
+      {visible && (
+        <div className="bg-card text-card-foreground pointer-events-none w-[4.5rem] rounded-lg p-1.5 shadow-[0_6px_16px_rgba(0,0,0,0.28)]">
+          <div className="flex overflow-hidden rounded-full">
+            {RISK_SCALE.map((color) => (
+              <span key={color} className="h-1.5 flex-1" style={{ backgroundColor: color }} />
+            ))}
+          </div>
+          <div className="text-muted-foreground mt-1 flex justify-between text-[9px] leading-none">
+            <span>{t('riskLow')}</span>
+            <span>{t('riskHigh')}</span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Why

The layer toggle read **Risk** in both states, so nothing on the map told users which layer was active, and nothing said what the coloured segments meant. This is the most repeated confusion in the in-app feedback survey:

- *"the risk button is unclear. I suppose the intention is to show which lines are safer or not? Not sure then what eg blue signifies."* — blue is a line colour, seen while risk was off.
- *"Was bedeuten die Farben der Gleise?"*
- *"Give us a legend for the red and blue dots mean. A general overview legend at the layer button or somewhere there."*
- *"Nanu, das ist ja alles rot. Xd"*

The last two point at the same gap: the risk scale is never named anywhere in the app.

## What changed

- **The button names the active layer** — `Risk` / `Lines` instead of a constant `Risk`. Switching the layer off now visibly lands on "Lines", which is what the map is actually showing: the network's own line colours. The button keeps a fixed width so the two labels don't reflow the row, and `aria-label` still describes the *action*, not the state.
- **A colour key under the button, only while risk is on.** Four swatches in the `RISK_COLORS` order (clear → severe) with `Low` / `High` end labels. It reuses `RISK_COLORS` so it can't drift from the layer's paint. In the lines state there is no legend — the button already says `Lines` and the segment colours are the network's, not ours to explain.

Kept deliberately small: 4.5rem wide, tucked under the existing button in the same fixed stack, `pointer-events-none` so it never eats a map tap.

## Verification

Ran locally against the local api-worker in both states (screenshots in the branch discussion): risk on → button reads `Risk` with the scale beneath it; risk off → button reads `Lines`, no legend. `tsc -b`, eslint and prettier are clean.