### PR TITLE
fix: keep location prompts consistent across platforms

### DIFF
--- a/packages/frontend-next/src/hooks/use-location-sharing.ts
+++ b/packages/frontend-next/src/hooks/use-location-sharing.ts
@@ -29,12 +29,13 @@ export function useMapLocationSharing({
   enabled: boolean;
   canDisplay: boolean;
 }) {
-  const { notifyError, requestLocation } = useGeolocation();
+  const { notifyError, position, requestLocation, status } = useGeolocation();
   const [showPrompt, setShowPrompt] = useState(false);
   const evaluatedRef = useRef(false);
   const promptTrackedRef = useRef(false);
   const requestLocationRef = useRef(requestLocation);
   const notifyErrorRef = useRef(notifyError);
+  const hasLocation = position !== null || status === 'tracking';
 
   useEffect(() => {
     requestLocationRef.current = requestLocation;
@@ -42,7 +43,14 @@ export function useMapLocationSharing({
   }, [requestLocation, notifyError]);
 
   useEffect(() => {
-    if (!enabled || evaluatedRef.current) return;
+    if (hasLocation) {
+      evaluatedRef.current = true;
+      closeLocationPrompt('map');
+    }
+  }, [hasLocation]);
+
+  useEffect(() => {
+    if (!enabled || hasLocation || evaluatedRef.current) return;
 
     let cancelled = false;
     let timer = 0;
@@ -67,9 +75,9 @@ export function useMapLocationSharing({
       cancelled = true;
       window.clearTimeout(timer);
     };
-  }, [enabled]);
+  }, [enabled, hasLocation]);
 
-  const visible = showPrompt && canDisplay;
+  const visible = showPrompt && canDisplay && !hasLocation;
   useEffect(() => {
     if (!visible) {
       closeLocationPrompt('map');


### PR DESCRIPTION
## Why

Location sharing can start from the delayed map prompt or the first report-form step. Both paths need to share one completion state, and the native build must surface the same soft ask followed by the operating-system permission dialog as the web build.

Two regressions were found after the original flow shipped:

1. Sharing from the report form before the map delay expired could still produce a redundant map prompt after returning.
2. Capacitor Geolocation v8 requires both iOS location usage descriptions, but the native target declared only the when-in-use key. That left the native permission request incompletely configured.

## Implementation

The map location-sharing hook now treats an existing position or active tracking state as completion. It skips or cancels prompt scheduling, closes any coordinated map prompt, and gates rendering against shared state.

The iOS target now declares both required usage-description keys with the same foreground-location explanation. This does not add background tracking; the Capacitor plugin requires the additional declaration because of its native iOS dependency.

## Validation

- Reproduced report-to-map navigation after sharing location and confirmed no second prompt appears after the 10-second threshold.
- Built and synchronized the Capacitor iOS project with bun run build:ios.
- Built the native target through Xcode for a fresh iPhone 16e Simulator.
- Reset Simulator location permission and launched a fresh install.
- Confirmed the in-app soft ask appears after 10 seconds.
- Confirmed tapping Use location opens the native iOS permission dialog.
- bun run lint
- bun run build
- git diff --check

The existing React Compiler warnings for TanStack Virtual remain unchanged.
