### PR TITLE
fix: keep native location soft ask reliable

### DIFF
--- a/packages/frontend-next/src/hooks/use-location-sharing.ts
+++ b/packages/frontend-next/src/hooks/use-location-sharing.ts
@@ -9,6 +9,7 @@ import {
   LOCATION_PROMPT_DELAY_MS,
   openLocationPrompt,
   queryGeolocationPermission,
+  type GeolocationPermissionState,
 } from '@/lib/location-prompt';
 
 function useMountedRef() {
@@ -29,53 +30,50 @@ export function useMapLocationSharing({
   enabled: boolean;
   canDisplay: boolean;
 }) {
-  const { notifyError, position, requestLocation, status } = useGeolocation();
+  const { position, requestLocation, status } = useGeolocation();
   const [showPrompt, setShowPrompt] = useState(false);
-  const evaluatedRef = useRef(false);
+  const [permission, setPermission] = useState<GeolocationPermissionState | null>(null);
   const promptTrackedRef = useRef(false);
   const requestLocationRef = useRef(requestLocation);
-  const notifyErrorRef = useRef(notifyError);
   const hasLocation = position !== null || status === 'tracking';
 
   useEffect(() => {
     requestLocationRef.current = requestLocation;
-    notifyErrorRef.current = notifyError;
-  }, [requestLocation, notifyError]);
+  }, [requestLocation]);
 
   useEffect(() => {
     if (hasLocation) {
-      evaluatedRef.current = true;
       closeLocationPrompt('map');
     }
   }, [hasLocation]);
 
   useEffect(() => {
-    if (!enabled || hasLocation || evaluatedRef.current) return;
+    if (!enabled || hasLocation || permission !== null) return;
 
     let cancelled = false;
-    let timer = 0;
-
-    void queryGeolocationPermission().then((permission) => {
-      if (cancelled || evaluatedRef.current) return;
-      evaluatedRef.current = true;
-      track('location_permission_evaluated', { state: permission });
-
-      if (permission === 'granted') {
-        void requestLocationRef.current('auto');
-      } else if (permission === 'denied') {
-        notifyErrorRef.current(1);
-      } else {
-        timer = window.setTimeout(() => {
-          if (!cancelled && !isMapLocationPromptDismissed()) setShowPrompt(true);
-        }, LOCATION_PROMPT_DELAY_MS);
-      }
+    void queryGeolocationPermission().then((result) => {
+      if (cancelled) return;
+      track('location_permission_evaluated', { state: result });
+      setPermission(result);
     });
-
     return () => {
       cancelled = true;
-      window.clearTimeout(timer);
     };
-  }, [enabled, hasLocation]);
+  }, [enabled, hasLocation, permission]);
+
+  useEffect(() => {
+    if (!enabled || hasLocation || permission === null) return;
+
+    if (permission === 'granted') {
+      void requestLocationRef.current('auto');
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      if (!isMapLocationPromptDismissed()) setShowPrompt(true);
+    }, LOCATION_PROMPT_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [enabled, hasLocation, permission]);
 
   const visible = showPrompt && canDisplay && !hasLocation;
   useEffect(() => {
@@ -112,33 +110,28 @@ export function useMapLocationSharing({
 export function useReportLocationSharing() {
   const { position, requestLocation, status } = useGeolocation();
   const [phase, setPhase] = useState<'checking' | 'prompt' | 'complete'>(
-    position || status === 'denied' ? 'complete' : 'checking',
+    position ? 'complete' : 'checking',
   );
   const mountedRef = useMountedRef();
   const promptTrackedRef = useRef(false);
   const initialPositionRef = useRef(position);
-  const initialStatusRef = useRef(status);
   const requestLocationRef = useRef(requestLocation);
 
   useEffect(() => {
     let cancelled = false;
 
     const prepare = async () => {
-      if (initialPositionRef.current || initialStatusRef.current === 'denied') {
-        setPhase('complete');
-        return;
-      }
+      if (initialPositionRef.current) return;
 
       const permission = await queryGeolocationPermission();
       if (cancelled) return;
       if (permission === 'granted') {
-        await requestLocationRef.current('report');
-        if (!cancelled) setPhase('complete');
-        return;
-      }
-      if (permission === 'denied') {
-        setPhase('complete');
-        return;
+        const coords = await requestLocationRef.current('report');
+        if (cancelled) return;
+        if (coords) {
+          setPhase('complete');
+          return;
+        }
       }
 
       setPhase('prompt');


### PR DESCRIPTION
## Why

The location flow must support two distinct cases on both web and native:

1. If location permission is already granted, acquire the position automatically without interrupting the user.
2. If permission is not granted, wait 10 seconds, show the in-app explanation, and touch the browser or iOS location API only after the user taps **Use location**.

The first implementation coupled permission evaluation and its delayed action in one effect. Cleanup could cancel the timer after permission had already been marked as evaluated, preventing a replacement timer. It also treated a denied permission as if the report location step were complete, even though no position had been acquired.

This remains an over-the-air web-bundle fix. The installed iOS binary already supports foreground location, so no plist or native project change is required.

## Implementation

- Store the evaluated permission result as React state.
- Separate permission evaluation from the action taken for that result.
- Automatically acquire location only when permission is explicitly `granted`.
- For `prompt`, `denied`, or unsupported states, schedule the restartable 10-second soft ask.
- In Reports, skip step 1 only after an actual position is acquired; otherwise show the inline location card.
- Keep the browser or iOS permission request behind the **Use location** click.
- Leave the iOS plist and native project unchanged.

## Validation

- `bun run build`
- `bun run build:ios`
- `bun run lint` (passes with two pre-existing TanStack Virtual compiler warnings)
- `bun run format:check`
- Clean iPhone 16 Pro Simulator build using the original plist
- Reset permission while the app was stopped: confirmed no native permission sheet appears before the soft ask
- Confirmed the soft ask appears after 10 seconds and its button opens the iOS permission sheet
- Granted permission, supplied a Berlin Simulator GPS fix, and confirmed the blue location dot renders
- Relaunched with permission already granted and confirmed location is acquired automatically
- Confirmed users without an acquired position remain on report step 1

No native files are changed, so this can ship through the existing OTA bundle channel without a new iOS review.