### PR TITLE
fix: handle denied location permission

### DIFF
--- a/packages/frontend-next/src/components/map/UserLocationControl.tsx
+++ b/packages/frontend-next/src/components/map/UserLocationControl.tsx
@@ -25,6 +25,7 @@ const analyticsEnabled = optionalEnv('VITE_POSTHOG_KEY') != null;
 type LocationPermissionPromptProps = {
   source: 'map' | 'report';
   inline?: boolean;
+  denied?: boolean;
   loading?: boolean;
   onAllow: () => void;
   onDismiss: () => void;
@@ -33,6 +34,7 @@ type LocationPermissionPromptProps = {
 function LocationPermissionPrompt({
   source,
   inline = false,
+  denied = false,
   loading = false,
   onAllow,
   onDismiss,
@@ -48,23 +50,36 @@ function LocationPermissionPrompt({
         )}
         <h2 className="font-heading flex items-center gap-2 text-lg font-semibold">
           <MapPin className="text-accent-bright size-5" />
-          {t(source === 'map' ? 'mapTitle' : 'reportTitle')}
+          {t(denied ? 'deniedTitle' : source === 'map' ? 'mapTitle' : 'reportTitle')}
         </h2>
         <p className="text-muted-foreground text-sm">
-          {t(source === 'map' ? 'mapDescription' : 'reportDescription')}
+          {t(
+            denied
+              ? 'deniedDescription'
+              : source === 'map'
+                ? 'mapDescription'
+                : 'reportDescription',
+          )}
         </p>
       </CardContent>
       <CardFooter className="gap-2">
-        <Button variant="outline" className="flex-1" disabled={loading} onClick={onDismiss}>
+        <Button
+          variant={denied ? 'default' : 'outline'}
+          className="flex-1"
+          disabled={loading}
+          onClick={onDismiss}
+        >
           {t(source === 'map' ? 'notNow' : 'continueWithout')}
         </Button>
-        <Button
-          className="bg-accent-bright text-primary-foreground hover:bg-accent-press flex-1"
-          disabled={loading}
-          onClick={onAllow}
-        >
-          {t('allow')}
-        </Button>
+        {!denied && (
+          <Button
+            className="bg-accent-bright text-primary-foreground hover:bg-accent-press flex-1"
+            disabled={loading}
+            onClick={onAllow}
+          >
+            {t('allow')}
+          </Button>
+        )}
       </CardFooter>
     </>
   );
@@ -83,6 +98,7 @@ export function ReportLocationStep({ children }: { children: ReactNode }) {
       <LocationPermissionPrompt
         source="report"
         inline
+        denied={sharing.phase === 'denied'}
         loading={sharing.loading}
         onAllow={() => void sharing.allow()}
         onDismiss={sharing.dismiss}

--- a/packages/frontend-next/src/components/map/location-permission-prompt.i18n.ts
+++ b/packages/frontend-next/src/components/map/location-permission-prompt.i18n.ts
@@ -9,6 +9,9 @@ i18n.addResourceBundle('en', NAMESPACE, {
   reportTitle: 'Use your location for this report?',
   reportDescription:
     'Confirming that you are near the selected station helps us filter false reports. Your precise location is not shown to others.',
+  deniedTitle: 'Location access is disabled',
+  deniedDescription:
+    'To share your location, enable access for FreiFahren in your device or browser settings. You can still continue without it.',
   allow: 'Use location',
   notNow: 'Not now',
   continueWithout: 'Continue without',
@@ -22,6 +25,9 @@ i18n.addResourceBundle('de', NAMESPACE, {
   reportTitle: 'Standort für diese Meldung verwenden?',
   reportDescription:
     'Wenn du bestätigst, dass du in der Nähe der ausgewählten Station bist, können wir Falschmeldungen besser filtern. Dein genauer Standort wird anderen nicht angezeigt.',
+  deniedTitle: 'Standortzugriff ist deaktiviert',
+  deniedDescription:
+    'Aktiviere den Standortzugriff für FreiFahren in den Geräte- oder Browsereinstellungen, um deinen Standort zu teilen. Du kannst auch ohne fortfahren.',
   allow: 'Standort verwenden',
   notNow: 'Jetzt nicht',
   continueWithout: 'Ohne fortfahren',

--- a/packages/frontend-next/src/hooks/use-location-sharing.ts
+++ b/packages/frontend-next/src/hooks/use-location-sharing.ts
@@ -69,6 +69,8 @@ export function useMapLocationSharing({
       return;
     }
 
+    if (permission === 'denied') return;
+
     const timer = window.setTimeout(() => {
       if (!isMapLocationPromptDismissed()) setShowPrompt(true);
     }, LOCATION_PROMPT_DELAY_MS);
@@ -109,7 +111,7 @@ export function useMapLocationSharing({
 
 export function useReportLocationSharing() {
   const { position, requestLocation, status } = useGeolocation();
-  const [phase, setPhase] = useState<'checking' | 'prompt' | 'complete'>(
+  const [phase, setPhase] = useState<'checking' | 'prompt' | 'denied' | 'complete'>(
     position ? 'complete' : 'checking',
   );
   const mountedRef = useMountedRef();
@@ -125,6 +127,7 @@ export function useReportLocationSharing() {
 
       const permission = await queryGeolocationPermission();
       if (cancelled) return;
+      track('location_permission_evaluated', { state: permission });
       if (permission === 'granted') {
         const coords = await requestLocationRef.current('report');
         if (cancelled) return;
@@ -132,6 +135,13 @@ export function useReportLocationSharing() {
           setPhase('complete');
           return;
         }
+      }
+
+      if (permission === 'denied') {
+        setPhase('denied');
+        openLocationPrompt('report');
+        track('location_permission_blocked_shown', { source: 'report' });
+        return;
       }
 
       setPhase('prompt');

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -34,6 +34,7 @@ type AnalyticsEvents = {
   contribute_stripe_clicked: { source: ContributeSource };
   contribute_dismissed: { source: ContributeSource };
   location_permission_evaluated: { state: GeolocationPermissionState };
+  location_permission_blocked_shown: { source: 'report' };
   location_prompt_shown: { source: 'map' | 'report' };
   location_prompt_allowed: { source: 'map' | 'report' };
   location_prompt_dismissed: { source: 'map' | 'report' };


### PR DESCRIPTION
## Why

When a user has set location access to **Never**, the native and browser permission checks correctly return `denied`. The location-sharing hooks treated every non-granted state as requestable, so the map still displayed the soft ask even though its primary action could not surface an OS prompt. That made the app appear broken and repeatedly asked for a choice the user had already made in system settings.

## What changed

- Suppress the delayed map soft ask when location access is already denied.
- Give the report flow a distinct denied state instead of rendering the normal permission request.
- Explain that access must be re-enabled in device or browser settings, while preserving the ability to continue reporting without location.
- Track the blocked report state separately so it is not counted as an actionable soft prompt.

The change only touches the shared web bundle. It adds no Capacitor plugin, entitlement, or native configuration change, so it can ship through the existing OTA path without an App Store review.

## Validation

- `bun run lint` (passes with the two existing React Compiler warnings)
- `bun run format:check`
- `bun run build`
- `bun run build:ios`
- Xcode Simulator build
- iOS Simulator with location permission revoked: no map soft ask after 10 seconds; reports show the disabled-access recovery state; **Continue without** reaches step 2
- Web with location permission denied: same recovery state and successful continuation to step 2