### PR TITLE
fix: stop the line filter cutting off on small phones

### DIFF
--- a/packages/frontend-next/src/components/report/ReportForm.tsx
+++ b/packages/frontend-next/src/components/report/ReportForm.tsx
@@ -111,7 +111,9 @@ function LinePicker() {
 
   return (
     <section className="px-4">
-      <div className="mb-3 flex items-center justify-between">
+      {/* Stacked on phones: with enough route types (Berlin adds bus) the filters need ~420px
+          beside the heading, so sharing a row cuts off the last one. */}
+      <div className="mb-3 flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
         <SectionHeading hint={t('optional')}>{t('line')}</SectionHeading>
         <ToggleGroup
           type="single"
@@ -120,7 +122,7 @@ function LinePicker() {
           onValueChange={(value) => {
             if (value) setLineFilter(value as LineFilter);
           }}
-          className="bg-surface-solid border-border border"
+          className="bg-surface-solid border-border max-w-full overflow-x-auto border"
         >
           {FILTERS.map((option) => (
             <ToggleGroupItem


### PR DESCRIPTION
## What

On the report form, the `LINE` heading and the route-type filters shared a row. They now stack on phones.

## Screenshots

375px (iPhone SE), dark mode.

**Before** — `BUS` is off-screen; `TRAM` is the last thing visible, and there is no way to scroll to the missing option:

<!-- drag before-375.png here -->

**After** — the filters sit under the `LINE OPTIONAL` heading, all five visible:

<!-- drag after-375.png here -->

Measured, not eyeballed: the `BUS` toggle's right edge sits at **412px** before the change and **324px** after, in a 375px viewport.

## Why

Berlin gained a bus filter in #947, which pushed the row past the width of a small phone — on a 375px iPhone SE the `BUS` option was off-screen and unreachable, so bus sightings could not be filtered for at all.

The toggles need roughly 420px next to the heading, so this is not specific to the SE: any phone narrower than ~440px lost the last filter, and every city that adds a fourth route type will hit it again.

## How

Stack heading and filters below `sm`, unchanged from `sm` up. The group also scrolls now, because below ~340px five filters do not fit in any layout — that matches the line-chip row directly beneath it, which already scrolls.

## Verified

| viewport | layout | last filter |
| --- | --- | --- |
| 320 | stacked | reachable by scroll |
| 375 | stacked | fully visible |
| 400 | stacked | fully visible |
| 430 | stacked | fully visible |
| 1280 | inline, as before | fully visible |

An earlier attempt used a 400px breakpoint; at exactly 400px the row went inline again and the group's right edge landed at 421px, so it just moved the cutoff. Hence `sm`.
