### PR TITLE
fix: keep Berlin-only reporter counts off other city UIs

### DIFF
--- a/packages/cities/src/berlin.ts
+++ b/packages/cities/src/berlin.ts
@@ -108,5 +108,6 @@ export const BERLIN: CityConfig = {
     },
     community: {
         telegramHandle: '@FreiFahren_BE',
+        reporterCount: { min: 50_000, max: 60_000 },
     },
 }

--- a/packages/cities/src/leipzig.ts
+++ b/packages/cities/src/leipzig.ts
@@ -107,6 +107,6 @@ export const LEIPZIG: CityConfig = {
     },
     community: {
         telegramHandle: '@freifahren_leipzig',
-        reporterCount: { min: 7_532, max: 7_532 },
+        reporterCount: { min: 7_000, max: 8_000 },
     },
 }

--- a/packages/cities/src/leipzig.ts
+++ b/packages/cities/src/leipzig.ts
@@ -107,5 +107,6 @@ export const LEIPZIG: CityConfig = {
     },
     community: {
         telegramHandle: '@freifahren_leipzig',
+        reporterCount: { min: 7_532, max: 7_532 },
     },
 }

--- a/packages/cities/src/types.ts
+++ b/packages/cities/src/types.ts
@@ -105,6 +105,7 @@ export interface CityTelegramProfile {
 export interface CityCommunity {
     /** Telegram group handle reports are synced with (e.g. `@FreiFahren_BE`). */
     telegramHandle: string
+    reporterCount?: { min: number; max: number }
 }
 
 /**

--- a/packages/frontend-next/src/components/map/StatsPopUp.i18n.ts
+++ b/packages/frontend-next/src/components/map/StatsPopUp.i18n.ts
@@ -4,16 +4,16 @@ export const NAMESPACE = 'statsPopUp';
 
 i18n.addResourceBundle('en', NAMESPACE, {
   reports: 'reports',
-  todayInBerlin: 'today in Berlin',
+  todayInCity: 'today in {{city}}',
   over: 'Over',
   reporters: 'reporters',
-  inBerlin: 'in Berlin',
+  inCity: 'in {{city}}',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
   reports: 'Meldungen',
-  todayInBerlin: 'heute in Berlin',
+  todayInCity: 'heute in {{city}}',
   over: 'Über',
   reporters: 'Meldende',
-  inBerlin: 'in Berlin',
+  inCity: 'in {{city}}',
 });

--- a/packages/frontend-next/src/components/map/StatsPopUp.tsx
+++ b/packages/frontend-next/src/components/map/StatsPopUp.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { DAY_MS, useReports } from '@/api/reports';
 import { ToastPill } from '@/components/ui/toast-pill';
+import { currentCity } from '@/lib/city';
 import { pickReporterCount } from '@/lib/reporters';
 import { toast } from '@/lib/toast';
 import { Route as ReportsSummaryRoute } from '@/routes/reports/index';
@@ -35,13 +36,15 @@ export function StatsPopUp() {
 
 function StatsCard({ toastId, reportCount }: { toastId: string | number; reportCount: number }) {
   const { t } = useTranslation(NAMESPACE);
-  const [reporters] = useState(pickReporterCount);
+  const [reporters] = useState(() => pickReporterCount(currentCity));
   const [phase, setPhase] = useState<'reports' | 'reporters'>('reports');
+  const city = currentCity.displayName;
 
   useEffect(() => {
+    if (reporters === null) return;
     const timer = setTimeout(() => setPhase('reporters'), REPORTERS_AT);
     return () => clearTimeout(timer);
-  }, []);
+  }, [reporters]);
 
   return (
     <ToastPill asChild>
@@ -55,12 +58,12 @@ function StatsCard({ toastId, reportCount }: { toastId: string | number; reportC
           key={phase}
           className="text-muted-foreground animate-in fade-in text-xs leading-snug duration-500"
         >
-          {phase === 'reports' ? (
+          {phase === 'reports' || reporters === null ? (
             <>
               <span className="text-foreground block text-sm font-semibold">
                 {reportCount} {t('reports')}
               </span>
-              {t('todayInBerlin')}
+              {t('todayInCity', { city })}
             </>
           ) : (
             <>
@@ -69,7 +72,7 @@ function StatsCard({ toastId, reportCount }: { toastId: string | number; reportC
                 {reporters.toLocaleString()} {t('reporters')}
               </span>
               <br />
-              {t('inBerlin')}
+              {t('inCity', { city })}
             </>
           )}
         </p>

--- a/packages/frontend-next/src/components/report/ReportSuccess.i18n.ts
+++ b/packages/frontend-next/src/components/report/ReportSuccess.i18n.ts
@@ -8,7 +8,7 @@ i18n.addResourceBundle('en', NAMESPACE, {
   sentimentPrompt: 'Do you like FreiFahren?',
   sentimentYes: 'Yes, I like it',
   sentimentNo: 'No, not really',
-  syncText: 'Your report was synced with @FreiFahren_BE',
+  syncText: 'Your report was synced with {{handle}}',
   continue: 'Continue',
 });
 
@@ -18,6 +18,6 @@ i18n.addResourceBundle('de', NAMESPACE, {
   sentimentPrompt: 'Gefällt dir FreiFahren?',
   sentimentYes: 'Ja, gefällt mir',
   sentimentNo: 'Nein, eher nicht',
-  syncText: 'Deine Meldung wurde mit @FreiFahren_BE synchronisiert.',
+  syncText: 'Deine Meldung wurde mit {{handle}} synchronisiert.',
   continue: 'Weiter',
 });

--- a/packages/frontend-next/src/components/report/ReportSuccess.tsx
+++ b/packages/frontend-next/src/components/report/ReportSuccess.tsx
@@ -8,6 +8,7 @@ import { SocialLinks } from '@/components/map/SocialLinks';
 import { LineBadge } from '@/components/transit/LineBadge';
 import { Button } from '@/components/ui/button';
 import { useCountAnimation } from '@/hooks/useCountAnimation';
+import { currentCity } from '@/lib/city';
 import { pickReporterCount } from '@/lib/reporters';
 
 import { ReportFeedback } from './ReportFeedback';
@@ -23,8 +24,8 @@ export function ReportSuccess({
   const { t } = useTranslation(NAMESPACE);
   const { data: stations } = useStations();
   const { data: lines } = useLines();
-  const [reporters] = useState(pickReporterCount);
-  const count = useCountAnimation(reporters, 1500);
+  const [reporters] = useState(() => pickReporterCount(currentCity));
+  const count = useCountAnimation(reporters ?? 0, 1500);
 
   const stationName = stations?.[result.stationId]?.name;
   const lineName = result.lineId ? lines?.find((l) => l.id === result.lineId)?.name : null;
@@ -46,15 +47,17 @@ export function ReportSuccess({
           </div>
         )}
 
-        <div className="mt-5 flex flex-col items-center gap-1">
-          <div className="text-foreground flex items-center gap-2">
-            <Users className="text-muted-foreground size-6" />
-            <span className="font-heading text-4xl font-bold tabular-nums">
-              {count.toLocaleString()}
-            </span>
+        {reporters !== null && (
+          <div className="mt-5 flex flex-col items-center gap-1">
+            <div className="text-foreground flex items-center gap-2">
+              <Users className="text-muted-foreground size-6" />
+              <span className="font-heading text-4xl font-bold tabular-nums">
+                {count.toLocaleString()}
+              </span>
+            </div>
+            <p className="text-muted-foreground text-sm">{t('description')}</p>
           </div>
-          <p className="text-muted-foreground text-sm">{t('description')}</p>
-        </div>
+        )}
 
         <div className="mt-6 w-full">
           <ReportFeedback onDone={onClose} />
@@ -62,7 +65,9 @@ export function ReportSuccess({
       </div>
 
       <div className="border-border/60 bg-card flex shrink-0 flex-col items-center border-t px-6 pt-3 pb-6">
-        <p className="text-muted-foreground text-[0.6875rem]">{t('syncText')}</p>
+        <p className="text-muted-foreground text-[0.6875rem]">
+          {t('syncText', { handle: currentCity.community.telegramHandle })}
+        </p>
         <Button
           type="button"
           size="lg"

--- a/packages/frontend-next/src/lib/reporters.ts
+++ b/packages/frontend-next/src/lib/reporters.ts
@@ -1,10 +1,10 @@
-import type { CityConfig } from '@freifahren/cities'
+import type { CityConfig } from '@freifahren/cities';
 
 // Fabricated social-proof count — the app has no real user metric.
 export const pickReporterCount = (city: CityConfig): number | null => {
-  const range = city.community.reporterCount
+  const range = city.community.reporterCount;
   if (range === undefined) {
-    return null
+    return null;
   }
-  return Math.floor(Math.random() * (range.max - range.min + 1)) + range.min
-}
+  return Math.floor(Math.random() * (range.max - range.min + 1)) + range.min;
+};

--- a/packages/frontend-next/src/lib/reporters.ts
+++ b/packages/frontend-next/src/lib/reporters.ts
@@ -1,6 +1,10 @@
-// Fabricated social-proof count — the app has no real user metric.
-export const MIN_REPORTERS = 50_000;
-export const MAX_REPORTERS = 60_000;
+import type { CityConfig } from '@freifahren/cities'
 
-export const pickReporterCount = () =>
-  Math.floor(Math.random() * (MAX_REPORTERS - MIN_REPORTERS + 1)) + MIN_REPORTERS;
+// Fabricated social-proof count — the app has no real user metric.
+export const pickReporterCount = (city: CityConfig): number | null => {
+  const range = city.community.reporterCount
+  if (range === undefined) {
+    return null
+  }
+  return Math.floor(Math.random() * (range.max - range.min + 1)) + range.min
+}


### PR DESCRIPTION
## Summary
- Leipzig (and any city without `community.reporterCount`) no longer shows the 50–60k “reporters” figure on the map toast or after submitting a report.
- Stats copy uses the active city’s display name; the post-report sync line uses that city’s Telegram handle instead of `@FreiFahren_BE`.
- Berlin keeps the existing social-proof range via city config.

## Test plan
- [ ] Open `http://leipzig.localhost:1871`: map toast (if there are reports today) says “heute in Leipzig” and does not swap to 50k reporters; after a report, no 50k counter and sync text mentions `@freifahren_leipzig`, but rather the circa 7k reporters
- [ ] Open `http://localhost:1871`: Berlin still shows ~50k reporters and `@FreiFahren_BE`.