### PR TITLE
fix: load map overlays in Telegram in-app browsers

### DIFF
--- a/packages/api-worker/src/db/import-telegram-extract.ts
+++ b/packages/api-worker/src/db/import-telegram-extract.ts
@@ -36,7 +36,7 @@ const query = (binding: string, sql: string, configPath?: string): D1Row[] => {
     const stdout = execFileSync(
         'npx',
         ['wrangler', 'd1', 'execute', binding, '--remote', '--json', '--command', sql, ...configArgs],
-        { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'inherit'], maxBuffer: 64 * 1024 * 1024 },
+        { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'inherit'], maxBuffer: 64 * 1024 * 1024 }
     )
     const resultSets = JSON.parse(stdout.slice(stdout.indexOf('['))) as Array<{ results?: D1Row[] } | undefined>
     return resultSets[0]?.results ?? []
@@ -44,9 +44,13 @@ const query = (binding: string, sql: string, configPath?: string): D1Row[] => {
 
 const executeFile = (binding: string, sqlPath: string, configPath?: string): void => {
     const configArgs = configPath !== undefined ? ['--config', configPath] : []
-    execFileSync('npx', ['wrangler', 'd1', 'execute', binding, '--remote', `--file=${sqlPath}`, '--yes', ...configArgs], {
-        stdio: 'inherit',
-    })
+    execFileSync(
+        'npx',
+        ['wrangler', 'd1', 'execute', binding, '--remote', `--file=${sqlPath}`, '--yes', ...configArgs],
+        {
+            stdio: 'inherit',
+        }
+    )
 }
 
 const loadJsonl = (path: string): ExtractRow[] => {
@@ -99,7 +103,7 @@ const importCity = (city: string, filePath: string, wipe: boolean, dryRun: boole
                 toSqlLiteral(row.directionId),
                 toSqlLiteral(ts),
                 toSqlLiteral('telegram'),
-            ].join(', ')});`,
+            ].join(', ')});`
         )
     }
 
@@ -115,8 +119,8 @@ const importCity = (city: string, filePath: string, wipe: boolean, dryRun: boole
                 dryRun,
             },
             null,
-            2,
-        ),
+            2
+        )
     )
 
     if (dryRun) {
@@ -153,5 +157,5 @@ importCity(
     parseFileArg(),
     process.argv.includes('--wipe-reports'),
     process.argv.includes('--dry-run'),
-    parseConfigArg(),
+    parseConfigArg()
 )

--- a/packages/api-worker/src/db/seed/stations/overpass.ts
+++ b/packages/api-worker/src/db/seed/stations/overpass.ts
@@ -194,6 +194,20 @@ const mergeServerWait = async (current: number | null, endpoint: string): Promis
     return Math.max(current ?? 0, wait)
 }
 
+const waitAfterRetryableStatus = async (
+    status: number,
+    endpoint: string,
+    currentWaitMs: number | null
+): Promise<number | null> => {
+    console.warn(`[seed:stations]   ${endpoint} returned ${status}`)
+    const serverSuggestedWaitMs = await mergeServerWait(currentWaitMs, endpoint)
+    if (status !== 429) return serverSuggestedWaitMs
+    const delay = serverSuggestedWaitMs ?? RATE_LIMIT_FALLBACK_MS
+    console.log(`[seed:stations]   Rate limited, waiting ${Math.round(delay / 1000)}s before next try...`)
+    await sleep(delay)
+    return serverSuggestedWaitMs
+}
+
 const fetchWithRetry = async (query: string, fetchTimeoutMs: number): Promise<OsmElement[]> => {
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
         let serverSuggestedWaitMs: number | null = null
@@ -212,15 +226,11 @@ const fetchWithRetry = async (query: string, fetchTimeoutMs: number): Promise<Os
                 })
 
                 if (response.status === 429 || response.status === 504 || response.status === 406) {
-                    console.warn(`[seed:stations]   ${endpoint} returned ${response.status}`)
-                    serverSuggestedWaitMs = await mergeServerWait(serverSuggestedWaitMs, endpoint)
-                    if (response.status === 429) {
-                        const delay = serverSuggestedWaitMs ?? RATE_LIMIT_FALLBACK_MS
-                        console.log(
-                            `[seed:stations]   Rate limited, waiting ${Math.round(delay / 1000)}s before next try...`
-                        )
-                        await sleep(delay)
-                    }
+                    serverSuggestedWaitMs = await waitAfterRetryableStatus(
+                        response.status,
+                        endpoint,
+                        serverSuggestedWaitMs
+                    )
                     continue
                 }
 
@@ -280,6 +290,23 @@ export const fetchLineRefs = async (): Promise<string[]> => {
     return sorted
 }
 
+/* Given the line refs we set out to fetch, return those that have no route
+ * relation in the response. A batched `out geom`/`out body` query can hit a
+ * server-side Overpass timeout and still return HTTP 200 with partial data, so
+ * checking for missing refs is the only way to distinguish a truncated response
+ * from a genuinely complete one. */
+export const findMissingRouteRefs = (expectedRefs: readonly string[], elements: OsmElement[]): string[] => {
+    const present = new Set<string>()
+    for (const el of elements) {
+        if (el.type !== 'relation') continue
+        if (el.tags?.type !== 'route') continue
+        // Record indexing is typed `string` but a relation may have no `ref` tag.
+        const ref = el.tags.ref as string | undefined
+        if (ref !== undefined && ref !== '') present.add(ref)
+    }
+    return expectedRefs.filter((ref) => !present.has(ref))
+}
+
 const fetchInBatches = async (
     label: string,
     refs: readonly string[],
@@ -319,23 +346,6 @@ const fetchInBatches = async (
 
     console.log(`[${label}] Total: ${all.length} elements`)
     return all
-}
-
-/* Given the line refs we set out to fetch, return those that have no route
- * relation in the response. A batched `out geom`/`out body` query can hit a
- * server-side Overpass timeout and still return HTTP 200 with partial data, so
- * checking for missing refs is the only way to distinguish a truncated response
- * from a genuinely complete one. */
-export const findMissingRouteRefs = (expectedRefs: readonly string[], elements: OsmElement[]): string[] => {
-    const present = new Set<string>()
-    for (const el of elements) {
-        if (el.type !== 'relation') continue
-        if (el.tags?.type !== 'route') continue
-        // Record indexing is typed `string` but a relation may have no `ref` tag.
-        const ref = el.tags.ref as string | undefined
-        if (ref !== undefined && ref !== '') present.add(ref)
-    }
-    return expectedRefs.filter((ref) => !present.has(ref))
 }
 
 /* Turn a silently-truncated Overpass response into a hard failure so the

--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -116,6 +116,7 @@ export function MapView() {
         // report markers, so that overlay setup doesn't compete with the heaviest part of map
         // init. The map is persistent, so this fires once per session.
         onLoad={() => setBaseMapReady(true)}
+        onIdle={() => setBaseMapReady(true)}
         // The style is baked and version-pinned by the tile-server, so re-validating its 89 layers
         // against the spec on every load is wasted main-thread work at the most contended moment
         // (and lets maplibre tree-shake the validator out). See maplibre MapOptions.validateStyle.

--- a/packages/frontend-next/src/lib/utils.ts
+++ b/packages/frontend-next/src/lib/utils.ts
@@ -14,6 +14,9 @@ export function optionalEnv(key: string): string | undefined {
 // (city resolution) or off PostHog (feature flags) needs a different source there.
 export const isPreviewBuild = optionalEnv('VITE_PREVIEW') !== undefined;
 
+export const isTelegramInAppBrowser =
+  typeof navigator !== 'undefined' && /Telegram/i.test(navigator.userAgent);
+
 export function requireEnv(key: string): string;
 export function requireEnv(key: string, as: 'number'): number;
 export function requireEnv(key: string, as?: 'number'): string | number {

--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
 import { get, set, del } from 'idb-keyval';
@@ -12,6 +13,7 @@ import { loadPostHog } from './lib/posthog-client';
 import { initErrorMonitoring } from './lib/error-monitoring';
 import { initNativePlatform } from './lib/native';
 import { safeSessionStorage } from './lib/safe-storage';
+import { isTelegramInAppBrowser } from './lib/utils';
 import './lib/i18n';
 import { routeTree } from './routeTree.gen';
 import './index.css';
@@ -25,7 +27,7 @@ void initNativePlatform();
 // vite-plugin-pwa's registration API catches failures (bots, crawlers, locked-down WebViews) and
 // reloads once when an auto-updated worker takes control. Recheck after the app returns online or
 // to the foreground so an installed PWA does not keep a suspended shell indefinitely.
-if (!__CAPACITOR__ && 'serviceWorker' in navigator) {
+if (!__CAPACITOR__ && !isTelegramInAppBrowser && 'serviceWorker' in navigator) {
   registerSW({
     onRegisteredSW: (_swUrl, registration) => {
       if (!registration) return;
@@ -55,13 +57,16 @@ if (!__CAPACITOR__ && 'serviceWorker' in navigator) {
 // Vite's documented recovery for a failed lazy import: a deploy purges the old chunks, so reload to
 // fetch the fresh shell. Skip when offline — a reload can't fetch a new chunk and the SW already
 // serves the precached shell, so it'd only wipe UI state. The timestamp bounds repeated reloads.
+const PRELOAD_RELOAD_MARK = 'ff-preload-reload';
 window.addEventListener('vite:preloadError', (event) => {
   // Prevent Vite from rethrowing the underlying import failure whether recovery is possible or not.
   event.preventDefault();
   if (!navigator.onLine) return;
   const KEY = 'vite:preloadError:lastReload';
   if (Date.now() - Number(safeSessionStorage.getItem(KEY) ?? 0) < 10_000) return;
-  if (!safeSessionStorage.setItem(KEY, String(Date.now()))) return;
+  if (window.name === PRELOAD_RELOAD_MARK) return;
+  safeSessionStorage.setItem(KEY, String(Date.now()));
+  window.name = PRELOAD_RELOAD_MARK;
   window.location.reload();
 });
 
@@ -71,12 +76,30 @@ window.addEventListener('vite:preloadError', (event) => {
 // ~5 MB localStorage quota. A restore is not a fetch, so it never triggers the "Reports updated"
 // toast (see useReportsRefreshSignal); the background refetch fires it only when it actually
 // succeeds online.
+const IDB_TIMEOUT_MS = 1500;
+
+function withTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
+  return new Promise((resolve) => {
+    const id = window.setTimeout(() => resolve(fallback), IDB_TIMEOUT_MS);
+    promise.then(
+      (value) => {
+        window.clearTimeout(id);
+        resolve(value);
+      },
+      () => {
+        window.clearTimeout(id);
+        resolve(fallback);
+      },
+    );
+  });
+}
+
 const persister = createAsyncStoragePersister({
   key: 'freifahren-query-cache',
   storage: {
-    getItem: (k) => get<string>(k).then((v) => v ?? null),
-    setItem: (k, v) => set(k, v),
-    removeItem: (k) => del(k),
+    getItem: (k) => withTimeout(get<string>(k).then((v) => v ?? null), null),
+    setItem: (k, v) => withTimeout(set(k, v), undefined),
+    removeItem: (k) => withTimeout(del(k), undefined),
   },
 });
 
@@ -100,38 +123,48 @@ router.subscribe('onResolved', ({ toLocation }) => {
   capturePageview(toLocation.href);
 });
 
+const routes = <RouterProvider router={router} />;
+
+const persistedApp = (
+  <PersistQueryClientProvider
+    client={queryClient}
+    // On a PWA cold start the cache is rehydrated from IndexedDB with each query's original
+    // `dataUpdatedAt`, so a reload within `staleTime` would serve a stale snapshot with no
+    // network request. `onSuccess` fires after restore but while queries are still paused
+    // (`isRestoring`), so invalidating here only marks them stale — no fetch yet. When the
+    // queries unpause, the default staleness-gated `refetchOnMount` fires exactly one deduped
+    // refetch per key, regardless of how many observers mount. This is stale-while-revalidate
+    // without the per-observer fan-out that `refetchOnMount: 'always'` would cause.
+    onSuccess={() => {
+      void queryClient.invalidateQueries();
+    }}
+    persistOptions={{
+      persister,
+      // persisted cache from an older build so a changed query shape can't hydrate incompatibly.
+      maxAge: PERSISTED_CACHE_MAX_AGE,
+      buster: __BUILD_ID__,
+      dehydrateOptions: {
+        // Persist any query that holds data, not just status==='success' (the default). When a
+        // user is offline, the periodic refetch fails and React Query demotes the query to
+        // 'error' while keeping its last data in memory — the success-only default would then
+        // refuse to persist it and overwrite the good snapshot with an empty one, so the data
+        // would vanish after a couple of reloads. Keying on `data` keeps the last-known reports/
+        // risk/transit across cold starts; once back online the refetch succeeds and refreshes.
+        shouldDehydrateQuery: (query) => query.state.data !== undefined,
+      },
+    }}
+  >
+    {routes}
+  </PersistQueryClientProvider>
+);
+
 const app = (
   <StrictMode>
-    <PersistQueryClientProvider
-      client={queryClient}
-      // On a PWA cold start the cache is rehydrated from IndexedDB with each query's original
-      // `dataUpdatedAt`, so a reload within `staleTime` would serve a stale snapshot with no
-      // network request. `onSuccess` fires after restore but while queries are still paused
-      // (`isRestoring`), so invalidating here only marks them stale — no fetch yet. When the
-      // queries unpause, the default staleness-gated `refetchOnMount` fires exactly one deduped
-      // refetch per key, regardless of how many observers mount. This is stale-while-revalidate
-      // without the per-observer fan-out that `refetchOnMount: 'always'` would cause.
-      onSuccess={() => {
-        void queryClient.invalidateQueries();
-      }}
-      persistOptions={{
-        persister,
-        // persisted cache from an older build so a changed query shape can't hydrate incompatibly.
-        maxAge: PERSISTED_CACHE_MAX_AGE,
-        buster: __BUILD_ID__,
-        dehydrateOptions: {
-          // Persist any query that holds data, not just status==='success' (the default). When a
-          // user is offline, the periodic refetch fails and React Query demotes the query to
-          // 'error' while keeping its last data in memory — the success-only default would then
-          // refuse to persist it and overwrite the good snapshot with an empty one, so the data
-          // would vanish after a couple of reloads. Keying on `data` keeps the last-known reports/
-          // risk/transit across cold starts; once back online the refetch succeeds and refreshes.
-          shouldDehydrateQuery: (query) => query.state.data !== undefined,
-        },
-      }}
-    >
-      <RouterProvider router={router} />
-    </PersistQueryClientProvider>
+    {isTelegramInAppBrowser ? (
+      <QueryClientProvider client={queryClient}>{routes}</QueryClientProvider>
+    ) : (
+      persistedApp
+    )}
   </StrictMode>
 );
 
@@ -144,5 +177,6 @@ const onIdle = (cb: () => void) =>
     ? window.requestIdleCallback(cb)
     : window.setTimeout(cb, 1);
 onIdle(() => {
+  if (window.name === PRELOAD_RELOAD_MARK) window.name = '';
   void loadPostHog().then(syncConsentToPostHog);
 });

--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -97,7 +97,11 @@ function withTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
 const persister = createAsyncStoragePersister({
   key: 'freifahren-query-cache',
   storage: {
-    getItem: (k) => withTimeout(get<string>(k).then((v) => v ?? null), null),
+    getItem: (k) =>
+      withTimeout(
+        get<string>(k).then((v) => v ?? null),
+        null,
+      ),
     setItem: (k, v) => withTimeout(set(k, v), undefined),
     removeItem: (k) => withTimeout(del(k), undefined),
   },


### PR DESCRIPTION
## Summary
- Telegram’s in-app browser on city hosts (`berlin.freifahren.org`, `leipzig.freifahren.org`) could hang on IndexedDB persist or a half-working service worker, so line/station overlays never mounted. `app.freifahren.org` often still worked because that origin was already warmed.
- In Telegram WebViews we skip the service worker and query-cache persist, time out IndexedDB elsewhere, still reload after a failed map chunk when sessionStorage is blocked, and mark the map ready on idle as well as load.

## Test plan
- [x] `bun run format:check` and `bun run lint` in `packages/frontend-next` (format green; existing React Compiler warnings only)
- [x] Open a Leipzig Telegram bot link in the in-app browser and confirm lines and station dots paint
- [x] Same for `berlin.freifahren.org` in Telegram (not only `app.freifahren.org`)
- [x] Open the same link via “Open in browser” (Safari/Chrome) and confirm the map still works
- [x] In a normal browser, confirm PWA/offline persist still hydrates after a reload