### PR TITLE
fix: load map overlays in Telegram in-app browsers

### DIFF
--- a/packages/api-worker/package.json
+++ b/packages/api-worker/package.json
@@ -2,7 +2,7 @@
   "name": "api-worker",
   "private": true,
   "scripts": {
-    "dev": "wrangler dev",
+    "dev": "wrangler dev --ip 0.0.0.0",
     "seed": "tsx src/db/seed/seed-d1.ts",
     "deploy": "wrangler deploy",
     "flags:check": "bun run src/trust-flags.ts check",

--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -86,8 +86,11 @@ const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\
 const buildPreviewOriginPattern = (subdomain: string) =>
     new RegExp(`^https:\\/\\/frontend-pr-\\d+\\.${escapeRegExp(subdomain)}\\.workers\\.dev$`)
 
+const PRIVATE_HTTP_ORIGIN =
+    /^http:\/\/(?:localhost|127\.0\.0\.1|10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?::\d+)?$/
+
 export const isAllowedCorsOrigin = (origin: string, config: AppConfig) => {
-    if (config.corsOrigins.includes(origin)) {
+    if (config.corsOrigins.includes(origin) || PRIVATE_HTTP_ORIGIN.test(origin)) {
         return true
     }
     const { previewWorkersSubdomain } = config

--- a/packages/api-worker/tests/generalAPI.test.ts
+++ b/packages/api-worker/tests/generalAPI.test.ts
@@ -181,6 +181,20 @@ describe('CORS', () => {
         expect(response.headers.get('Access-Control-Allow-Origin')).toBe(PREVIEW_ORIGIN)
     })
 
+    it('grants a preflight from a private LAN origin', async () => {
+        const lanOrigin = 'http://192.168.0.176:1871'
+        const response = await appRequestWithRedirect('/reports', {
+            method: 'OPTIONS',
+            headers: {
+                Origin: lanOrigin,
+                'Access-Control-Request-Method': 'GET',
+            },
+        })
+
+        expect(response.status).toBe(204)
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBe(lanOrigin)
+    })
+
     it.each([DISALLOWED_ORIGIN, MALFORMED_PREVIEW_ORIGIN])('does not grant a preflight from %s', async (origin) => {
         const response = await appRequestWithRedirect('/reports', {
             method: 'OPTIONS',

--- a/packages/api-worker/wrangler.jsonc
+++ b/packages/api-worker/wrangler.jsonc
@@ -38,7 +38,7 @@
     ],
     "vars": {
         "NODE_ENV": "production",
-        "CORS_ORIGINS": "https://freifahren.org,https://app.freifahren.org,https://www.freifahren.org,https://berlin.freifahren.org,https://leipzig.freifahren.org,http://localhost:1871,http://leipzig.localhost:1871,http://192.168.178.65:1871,capacitor://localhost",
+        "CORS_ORIGINS": "https://freifahren.org,https://app.freifahren.org,https://www.freifahren.org,https://berlin.freifahren.org,https://leipzig.freifahren.org,http://localhost:1871,http://leipzig.localhost:1871,capacitor://localhost",
         // Scopes frontend preview CORS to `frontend-pr-<n>.freifahren.workers.dev` (our account only).
         "PREVIEW_WORKERS_SUBDOMAIN": "freifahren",
         "TELEGRAM_WORKER_URL": "https://telegram-worker.freifahren.workers.dev",

--- a/packages/frontend-next/src/api/reports.ts
+++ b/packages/frontend-next/src/api/reports.ts
@@ -6,9 +6,8 @@ import { useEffect, useState } from 'react';
 import { currentCitySlug } from '@/lib/city';
 import { getTurnstileToken, TURNSTILE_TOKEN_HEADER } from '@/lib/turnstile';
 import { captureIssue, traceAction } from '@/lib/error-monitoring';
-import { requireEnv } from '@/lib/utils';
 
-import { fetchJson, type Line, useLines } from './transit';
+import { API_URL, fetchJson, type Line, useLines } from './transit';
 
 export type Report = {
   timestamp: string;
@@ -189,8 +188,6 @@ export const useStationReportCount = (stationId: string) => {
   const [options] = useState(() => stationReportCountQueryOptions(stationId));
   return useQuery({ ...options, select: (reports) => reports.length });
 };
-
-const API_URL = requireEnv('VITE_API_URL');
 
 export type SubmitReportInput = {
   stationId: string;

--- a/packages/frontend-next/src/api/transit.ts
+++ b/packages/frontend-next/src/api/transit.ts
@@ -5,7 +5,18 @@ import { currentCitySlug } from '@/lib/city';
 import { distanceMeters } from '@/lib/geo';
 import { requireEnv } from '@/lib/utils';
 
-const API_URL = requireEnv('VITE_API_URL');
+function resolveApiUrl(configured: string): string {
+  if (!import.meta.env.DEV || typeof window === 'undefined') return configured;
+  try {
+    const url = new URL(configured);
+    url.hostname = window.location.hostname;
+    return url.origin;
+  } catch {
+    return configured;
+  }
+}
+
+export const API_URL = resolveApiUrl(requireEnv('VITE_API_URL'));
 
 type StationId = string;
 

--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -17,6 +17,7 @@ import { useRisk } from '@/api/risk';
 import { useSegments } from '@/api/transit';
 import { track } from '@/lib/analytics';
 import { currentCity } from '@/lib/city';
+import { isTelegramInAppBrowser } from '@/lib/utils';
 
 import { LineLayer } from './LineLayer';
 import { SECONDARY_REVEAL_ZOOM } from './line-style';
@@ -54,6 +55,12 @@ export function MapView() {
   const { selectedStation, handleMapClick } = useStationSelection();
   const { visible: riskVisible } = useRiskLayer();
   const [baseMapReady, setBaseMapReady] = useState(false);
+
+  useEffect(() => {
+    if (!isTelegramInAppBrowser) return;
+    const id = window.setTimeout(() => setBaseMapReady(true), 1500);
+    return () => window.clearTimeout(id);
+  }, []);
 
   // Fire once per session the first time the user zooms in far enough to reveal the secondary
   // (tram/bus) tier. The map is persistent, so this ref spans the whole session; sessions that

--- a/packages/frontend-next/src/lib/utils.ts
+++ b/packages/frontend-next/src/lib/utils.ts
@@ -15,7 +15,9 @@ export function optionalEnv(key: string): string | undefined {
 export const isPreviewBuild = optionalEnv('VITE_PREVIEW') !== undefined;
 
 export const isTelegramInAppBrowser =
-  typeof navigator !== 'undefined' && /Telegram/i.test(navigator.userAgent);
+  typeof navigator !== 'undefined' &&
+  (/Telegram/i.test(navigator.userAgent) ||
+    (typeof window !== 'undefined' && 'TelegramWebviewProxy' in window));
 
 export function requireEnv(key: string): string;
 export function requireEnv(key: string, as: 'number'): number;

--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -27,31 +27,49 @@ void initNativePlatform();
 // vite-plugin-pwa's registration API catches failures (bots, crawlers, locked-down WebViews) and
 // reloads once when an auto-updated worker takes control. Recheck after the app returns online or
 // to the foreground so an installed PWA does not keep a suspended shell indefinitely.
-if (!__CAPACITOR__ && !isTelegramInAppBrowser && 'serviceWorker' in navigator) {
-  registerSW({
-    onRegisteredSW: (_swUrl, registration) => {
-      if (!registration) return;
+if (!__CAPACITOR__ && 'serviceWorker' in navigator) {
+  if (isTelegramInAppBrowser) {
+    const TELEGRAM_SW_CLEAR_MARK = 'ff-tg-sw-cleared';
+    void navigator.serviceWorker
+      .getRegistrations()
+      .then((registrations) =>
+        Promise.all(registrations.map((registration) => registration.unregister())),
+      )
+      .then(() => caches.keys())
+      .then((keys) => Promise.all(keys.map((key) => caches.delete(key))))
+      .then(() => {
+        if (!navigator.serviceWorker.controller) return;
+        if (window.name === TELEGRAM_SW_CLEAR_MARK) return;
+        window.name = TELEGRAM_SW_CLEAR_MARK;
+        window.location.reload();
+      })
+      .catch(() => {});
+  } else {
+    registerSW({
+      onRegisteredSW: (_swUrl, registration) => {
+        if (!registration) return;
 
-      // The install page is not controlled yet, so its navigation cannot populate the runtime cache.
-      // Seed the shell once while online to retain the first offline cold start.
-      void navigator.serviceWorker.ready
-        .then(async () => {
-          const appShell = await caches.open('app-shell');
-          if (!(await appShell.match('/'))) await appShell.add('/');
-        })
-        .catch(() => {});
+        // The install page is not controlled yet, so its navigation cannot populate the runtime cache.
+        // Seed the shell once while online to retain the first offline cold start.
+        void navigator.serviceWorker.ready
+          .then(async () => {
+            const appShell = await caches.open('app-shell');
+            if (!(await appShell.match('/'))) await appShell.add('/');
+          })
+          .catch(() => {});
 
-      const update = () => {
-        void registration.update().catch(() => {});
-      };
+        const update = () => {
+          void registration.update().catch(() => {});
+        };
 
-      window.addEventListener('online', update);
-      document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'visible') update();
-      });
-    },
-    onRegisterError: () => {},
-  });
+        window.addEventListener('online', update);
+        document.addEventListener('visibilitychange', () => {
+          if (document.visibilityState === 'visible') update();
+        });
+      },
+      onRegisterError: () => {},
+    });
+  }
 }
 
 // Vite's documented recovery for a failed lazy import: a deploy purges the old chunks, so reload to

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -201,6 +201,7 @@ export default defineConfig({
   ],
   server: {
     port: 1871,
+    host: true,
   },
   preview: {
     // Deliberately a different port from `server`: `preview` ships the real service worker, and a


### PR DESCRIPTION
## Summary
- Unregister an already-installed service worker and drop its caches when the app opens in a Telegram in-app browser, then reload once. City hosts (`berlin.` / `leipzig.`) often still had a SW from before we stopped registering there; `app.freifahren.org` did not, which is why only those origins stayed blank after #952.
- Fail-open the map overlay gate after 1.5s in Telegram only, so lines and stations render even if MapLibre never fires `onLoad` / `onIdle`. Safari and installed PWAs still wait for those events so first-paint does not flash overlays.
- Detect Telegram also via `TelegramWebviewProxy`. LAN-only: Vite/`wrangler` bind on `0.0.0.0`, rewrite the API host in DEV, and allow RFC1918 origins via CORS so phone testing against a laptop works.

## Test plan
- [ ] On production after deploy: open `berlin.freifahren.org` and `leipzig.freifahren.org` in Telegram (iOS and Android). Lines and station dots should appear after a short delay; a one-time reload is expected on first visit if a SW was present.
- [ ] `app.freifahren.org` in Telegram still shows the map; subsequent visits should not loop-reload.
- [ ] Safari / PWA: overlays still wait for map load (no extra 1.5s Telegram timeout).
- [ ] Optional: phone on LAN against Vite `http://<lan-ip>:1871` and API on `8787` — transit/reports requests should hit the laptop, not `localhost` on the phone.