### PR TITLE
fix: show map overlays when Telegram iOS hides its user agent

### DIFF
--- a/packages/frontend-next/src/components/map/Map.tsx
+++ b/packages/frontend-next/src/components/map/Map.tsx
@@ -17,7 +17,6 @@ import { useRisk } from '@/api/risk';
 import { useSegments } from '@/api/transit';
 import { track } from '@/lib/analytics';
 import { currentCity } from '@/lib/city';
-import { isTelegramInAppBrowser } from '@/lib/utils';
 
 import { LineLayer } from './LineLayer';
 import { SECONDARY_REVEAL_ZOOM } from './line-style';
@@ -57,7 +56,6 @@ export function MapView() {
   const [baseMapReady, setBaseMapReady] = useState(false);
 
   useEffect(() => {
-    if (!isTelegramInAppBrowser) return;
     const id = window.setTimeout(() => setBaseMapReady(true), 1500);
     return () => window.clearTimeout(id);
   }, []);

--- a/packages/frontend-next/src/lib/utils.ts
+++ b/packages/frontend-next/src/lib/utils.ts
@@ -14,10 +14,18 @@ export function optionalEnv(key: string): string | undefined {
 // (city resolution) or off PostHog (feature flags) needs a different source there.
 export const isPreviewBuild = optionalEnv('VITE_PREVIEW') !== undefined;
 
+function isIosInAppBrowser(ua: string): boolean {
+  if (!/iPhone|iPod|iPad/i.test(ua)) return false;
+  if (/CriOS|FxiOS|EdgiOS|OPiOS/i.test(ua)) return false;
+  return !/Safari\//i.test(ua);
+}
+
 export const isTelegramInAppBrowser =
   typeof navigator !== 'undefined' &&
   (/Telegram/i.test(navigator.userAgent) ||
-    (typeof window !== 'undefined' && 'TelegramWebviewProxy' in window));
+    isIosInAppBrowser(navigator.userAgent) ||
+    (typeof window !== 'undefined' &&
+      ('TelegramWebviewProxy' in window || 'Telegram' in window)));
 
 export function requireEnv(key: string): string;
 export function requireEnv(key: string, as: 'number'): number;

--- a/packages/frontend-next/src/lib/utils.ts
+++ b/packages/frontend-next/src/lib/utils.ts
@@ -24,8 +24,7 @@ export const isTelegramInAppBrowser =
   typeof navigator !== 'undefined' &&
   (/Telegram/i.test(navigator.userAgent) ||
     isIosInAppBrowser(navigator.userAgent) ||
-    (typeof window !== 'undefined' &&
-      ('TelegramWebviewProxy' in window || 'Telegram' in window)));
+    (typeof window !== 'undefined' && ('TelegramWebviewProxy' in window || 'Telegram' in window)));
 
 export function requireEnv(key: string): string;
 export function requireEnv(key: string, as: 'number'): number;


### PR DESCRIPTION
Fail-open the overlay gate after 1.5s for every client, and treat iOS WebViews without Safari/ as in-app so the leftover service worker is cleared.

## Describe the issue:

## Explain how you solved the issue:

## Additional notes or considerations:
