### PR TITLE
fix: load stations and lines in Telegram city-host WebViews

### DIFF
--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -97,6 +97,19 @@ export const isAllowedCorsOrigin = (origin: string, config: AppConfig) => {
     return previewWorkersSubdomain !== undefined && buildPreviewOriginPattern(previewWorkersSubdomain).test(origin)
 }
 
+export const corsAllowOrigin = (
+    origin: string,
+    method: string,
+    accessControlRequestMethod: string | undefined,
+    config: AppConfig
+): string | null => {
+    const effectiveMethod = method === 'OPTIONS' ? (accessControlRequestMethod ?? 'GET') : method
+    if (effectiveMethod === 'GET' || effectiveMethod === 'HEAD') {
+        return '*'
+    }
+    return isAllowedCorsOrigin(origin, config) ? origin : null
+}
+
 export type Services = {
     reportsService: ReportsService
     insightsService: InsightsService

--- a/packages/api-worker/src/index.ts
+++ b/packages/api-worker/src/index.ts
@@ -3,7 +3,7 @@ import { cors } from 'hono/cors'
 import { etag, RETAINED_304_HEADERS } from 'hono/etag'
 import { requestId } from 'hono/request-id'
 
-import { Env, isAllowedCorsOrigin, registerContext } from './app-env'
+import { corsAllowOrigin, Env, registerContext } from './app-env'
 import { handleError } from './common/error-handler'
 import { registerVersionedRoutes } from './common/router'
 import { getConfig } from './modules/config'
@@ -50,7 +50,7 @@ export const createApp = () => {
         cors({
             origin: (origin, c) => {
                 const config = (c as Context<Env>).get('config')
-                return isAllowedCorsOrigin(origin, config) ? origin : null
+                return corsAllowOrigin(origin, c.req.method, c.req.header('Access-Control-Request-Method'), config)
             },
             /*
              * Every header the client attaches to a report has to be listed here, or the browser

--- a/packages/api-worker/tests/generalAPI.test.ts
+++ b/packages/api-worker/tests/generalAPI.test.ts
@@ -89,7 +89,7 @@ describe('ETag 304 + CORS', () => {
             testEnv()
         )
         expect(initial.status).toBe(200)
-        expect(initial.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED_ORIGIN)
+        expect(initial.headers.get('Access-Control-Allow-Origin')).toBe('*')
 
         const etag = initial.headers.get('ETag')
         expect(etag).not.toBeNull()
@@ -109,7 +109,7 @@ describe('ETag 304 + CORS', () => {
         // Without this header the browser blocks the cross-origin 304 and the
         // frontend's localStorage cache path fails — that is the regression we
         // are guarding against.
-        expect(revalidated.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED_ORIGIN)
+        expect(revalidated.headers.get('Access-Control-Allow-Origin')).toBe('*')
         expect(revalidated.headers.get('ETag')).toBe(etag)
     })
 })
@@ -120,15 +120,18 @@ describe('CORS', () => {
     const DISALLOWED_ORIGIN = 'https://not-on-the-list.example'
     const MALFORMED_PREVIEW_ORIGIN = 'https://frontend-pr-not-a-number.freifahren.workers.dev'
 
-    it('does not echo a disallowed origin', async () => {
-        const response = await app.request(
+    it('allows GET from any origin including a missing Origin header', async () => {
+        const withOrigin = await app.request(
             '/v0/transit/stations',
             { headers: { Origin: DISALLOWED_ORIGIN } },
             testEnv()
         )
+        expect(withOrigin.status).toBe(200)
+        expect(withOrigin.headers.get('Access-Control-Allow-Origin')).toBe('*')
 
-        expect(response.status).toBe(200)
-        expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull()
+        const withoutOrigin = await app.request('/v0/transit/stations', undefined, testEnv())
+        expect(withoutOrigin.status).toBe(200)
+        expect(withoutOrigin.headers.get('Access-Control-Allow-Origin')).toBe('*')
     })
 
     it('grants a preflight from an allowed origin', async () => {
@@ -192,7 +195,7 @@ describe('CORS', () => {
         })
 
         expect(response.status).toBe(204)
-        expect(response.headers.get('Access-Control-Allow-Origin')).toBe(lanOrigin)
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
     })
 
     it.each([DISALLOWED_ORIGIN, MALFORMED_PREVIEW_ORIGIN])('does not grant a preflight from %s', async (origin) => {


### PR DESCRIPTION
## Summary
- Public GET endpoints (`/v0/transit/*`, reports reads, and GET preflights) now send `Access-Control-Allow-Origin: *`. The CDN cache can no longer replay a `capacitor://localhost` CORS header to `berlin.freifahren.org` / `leipzig.freifahren.org`.
- POST report preflights stay on the origin allowlist, so other sites still cannot submit reports from a visitor’s browser.
- This is why the report form had no stations to tap: that list is API JSON, not MapLibre overlays.

## Test plan
- [ ] Merge and **deploy `api-worker`**. Then purge the transit CDN cache (`transit-network-berlin` and `transit-network-leipzig`) — otherwise the old 30-day HIT with the wrong CORS header stays live.
- [ ] `curl -sI https://api.freifahren.org/v0/transit/stations?city=berlin` (no Origin) should show `access-control-allow-origin: *`, not `capacitor://localhost`.
- [ ] In Telegram, open `berlin.freifahren.org` and `leipzig.freifahren.org`: lines, station dots, stats toast, and the report station list should populate.
- [ ] `app.freifahren.org` in Telegram still works; Safari/PWA unchanged.