### PR TITLE
fix: show Leipzig basemap after switching cities in the native app

### DIFF
--- a/packages/frontend-next/src/lib/offline-basemap.ts
+++ b/packages/frontend-next/src/lib/offline-basemap.ts
@@ -33,8 +33,16 @@ class BlobSource implements Source {
 
 // The immutable `/v<sha>/` segment makes each deploy's archive a stable cache key.
 function archiveKeyFor(archiveUrl: string): string {
-  const version = /\/v([^/]+)\//.exec(archiveUrl)?.[1];
-  return `${ARCHIVE_PREFIX}${version ?? archiveUrl}`;
+  return `${ARCHIVE_PREFIX}${archiveUrl}`;
+}
+
+function styleKeyFor(styleUrl: string): string {
+  return `${STYLE_KEY}:${styleUrl}`;
+}
+
+function archiveBasename(archiveUrl: string): string {
+  const parts = archiveUrl.split('/');
+  return parts[parts.length - 1] ?? archiveUrl;
 }
 
 function archiveUrlFromStyle(style: StyleSpecification): string | null {
@@ -59,13 +67,18 @@ async function fetchStyle(styleUrl: string): Promise<StyleSpecification | null> 
 }
 
 // Drop archives from older deploys so storage tracks only the current version.
-async function pruneOldArchives(keepKey: string): Promise<void> {
+async function pruneOldArchives(keepUrl: string): Promise<void> {
+  const keepKey = archiveKeyFor(keepUrl);
+  const keepName = archiveBasename(keepUrl);
   const all = await keys(store);
   await Promise.all(
     all
-      .filter(
-        (k): k is string => typeof k === 'string' && k.startsWith(ARCHIVE_PREFIX) && k !== keepKey,
-      )
+      .filter((k): k is string => {
+        if (typeof k !== 'string' || !k.startsWith(ARCHIVE_PREFIX) || k === keepKey) return false;
+        const rest = k.slice(ARCHIVE_PREFIX.length);
+        if (!rest.includes('/')) return true;
+        return archiveBasename(rest) === keepName;
+      })
       .map((k) => del(k, store)),
   );
 }
@@ -89,27 +102,32 @@ export async function prepareOfflineBasemap(
 ): Promise<string | StyleSpecification> {
   // Prefer the fresh style; fall back to the last persisted one (which always has its archive) offline.
   const fresh = await fetchStyle(styleUrl);
-  const style = fresh ?? (await get<StyleSpecification>(STYLE_KEY, store)) ?? null;
+  const style = fresh ?? (await get<StyleSpecification>(styleKeyFor(styleUrl), store)) ?? null;
   if (!style) return styleUrl;
+
+  const persistStyle = async (value: StyleSpecification) => {
+    await set(styleKeyFor(styleUrl), value, store);
+    await del(STYLE_KEY, store);
+  };
 
   const archiveUrl = archiveUrlFromStyle(style);
   if (!archiveUrl) {
-    if (fresh) await set(STYLE_KEY, fresh, store);
+    if (fresh) await persistStyle(fresh);
     return style;
   }
 
   const key = archiveKeyFor(archiveUrl);
   const cached = await get<Blob>(key, store);
   if (cached) {
-    if (fresh) await set(STYLE_KEY, fresh, store);
+    if (fresh) await persistStyle(fresh);
     protocol.add(new PMTiles(new BlobSource(cached, archiveUrl)));
   } else if (fresh && navigator.onLine) {
     // New deploy: its archive isn't downloaded yet. Persist the style only *after* its archive lands,
     // and prune older archives only then — so the persisted style always has a matching archive and an
     // interrupted download can never strand the next offline launch (the prior complete pair stays).
     void downloadArchive(archiveUrl, key)
-      .then(() => set(STYLE_KEY, fresh, store))
-      .then(() => pruneOldArchives(key))
+      .then(() => persistStyle(fresh))
+      .then(() => pruneOldArchives(archiveUrl))
       .catch(() => {});
   }
 


### PR DESCRIPTION
## Summary
- Capacitor caches the PMTiles archive in IndexedDB keyed only on the tile-server deploy SHA. Berlin and Leipzig both live under `/vc5fe61e3/…`, so switching to Leipzig reused Berlin’s archive.
- Berlin tiles do not cover Leipzig, so the camera sat on Leipzig lines with an empty basemap. Style fallback used a single global `style` key for the same reason.
- Archives and styles are now keyed by the full URL (city file + version). Pruning still drops old deploys of the same city, not the other city’s map.

## Test plan
- [ ] Native app: start in Berlin, confirm basemap + lines.
- [ ] Switch to Leipzig: Leipzig basemap tiles and Leipzig lines. First switch may download `leipzig.pmtiles` in the background.
- [ ] Switch back to Berlin: Berlin basemap still there (other city archive is no longer deleted).
- [ ] Optional: airplane mode after both cities have been opened once — each city still shows its own basemap.