### PR TITLE
feat: enable read-only Hamburg Telegram ingest and pin D1 to the EU

### DIFF
--- a/packages/api-worker/wrangler.jsonc
+++ b/packages/api-worker/wrangler.jsonc
@@ -37,8 +37,8 @@
         },
         {
             "binding": "DB_HAMBURG",
-            "database_name": "api-worker-db-hamburg",
-            "database_id": "caa8cec3-3ac2-4288-a695-018cfbd22519",
+            "database_name": "api-worker-db-hamburg-eu",
+            "database_id": "78b57951-828b-4673-a63f-4f5de233b184",
             "migrations_dir": "drizzle",
         },
     ],

--- a/packages/cities/src/databases.ts
+++ b/packages/cities/src/databases.ts
@@ -8,7 +8,7 @@ export const CITY_DATABASES = {
         dbBinding: 'DB',
     },
     hamburg: {
-        dbName: 'api-worker-db-hamburg',
+        dbName: 'api-worker-db-hamburg-eu',
         dbBinding: 'DB_HAMBURG',
     },
     leipzig: {

--- a/packages/cities/src/hamburg.ts
+++ b/packages/cities/src/hamburg.ts
@@ -1,17 +1,23 @@
 import type { CityConfig } from './types'
 import { CITY_DATABASES } from './databases'
 
-const promptExamples = `Message: "u3 hbf 2 kontrolleure richtung billstedt"
-{"stationName": "Hauptbahnhof", "directionName": "Billstedt"}
+const promptExamples = `Message: "2 gelbwesten jungfernstieg am gleis richtung altona"
+{"stationName": "Jungfernstieg", "directionName": "Altona"}
 
-Message: "s1 altona richtung pops 3k"
-{"stationName": "Altona", "directionName": "Poppenbüttel"}
+Message: "s3 hbf gerade losgefahren, 3 gelbwesten im ersten wagen richtung neugraben"
+{"stationName": "Hauptbahnhof", "directionName": "Neugraben"}
 
-Message: "jungfernstieg u1 2 mann in zivil"
+Message: "zivis am kontrollieren in der s1 richtung wedel, jetzt jungfernstieg"
+{"stationName": "Jungfernstieg", "directionName": "Wedel"}
+
+Message: "2 kontrolleure in zivil an der bus-halte jungfernstieg ausgestiegen"
 {"stationName": "Jungfernstieg", "directionName": null}
 
 Message: "landungsbrücken clean"
 {"stationName": "Landungsbrücken", "directionName": null}
+
+Message: "hochbahn wache gerade hallerstraße aus der u1 richtung hbf ausgestiegen"
+{"stationName": "Hallerstraße", "directionName": null}
 
 Message: "bus 5 hbf richtung palmaille kontrolle"
 {"stationName": "Hauptbahnhof", "directionName": "Palmaille"}
@@ -19,16 +25,16 @@ Message: "bus 5 hbf richtung palmaille kontrolle"
 Message: "u2 berliner tor richtung niendorf markt"
 {"stationName": "Berliner Tor", "directionName": "Niendorf Markt"}
 
-Message: "s3 hbf nach pinneberg, jetzt dammtor"
+Message: "s3 nach pinneberg, jetzt dammtor"
 {"stationName": "Dammtor", "directionName": "Pinneberg"}
 
-Message: "schlump 2k u2"
+Message: "schlump 2 gelbwesten u2"
 {"stationName": "Schlump", "directionName": null}
 
 Message: "hbf clean auf der s1"
 {"stationName": "Hauptbahnhof", "directionName": null}
 
-Message: "3k barmbek richtung ohlsdorf"
+Message: "gelbwesten barmbek richtung ohlsdorf"
 {"stationName": "Barmbek", "directionName": "Ohlsdorf"}
 
 Message: "weiß jemand ob die s4 fährt?"
@@ -74,8 +80,13 @@ export const HAMBURG: CityConfig = {
         defaultLineColor: '#000000',
     },
     telegram: {
+        // Chosen from ~12k Hamburg group messages: "Gelbweste(n)" (the yellow hi-vis
+        // vests HVV/Hochbahn inspectors wear) dominates by far, well ahead of "Zivil"/
+        // "Zivi" (plainclothes) and formal "Kontrolleur". "Hochbahn Wache" also shows up
+        // regularly; formal "Prüfer" is nearly unused. Unlike Berlin/Leipzig, the "Nk"
+        // count shorthand ("3k") is rare here — people spell out "X gelbwesten"/"X mann".
         inspectorKeywords:
-            'K (for example "3k" means three ticket inspectors), Kontrolleur, Kontrolleure, Kontrolle, Konti, Kontis, HVV-Kontrolle, Hochbahn-Kontrolle, Zivil, in Zivil, Prüfer, Fahrkartenkontrolle',
+            'Gelbweste, Gelbwesten, gelbe Weste (the most common term — Hamburg\'s uniformed inspectors wear yellow hi-vis vests), Zivil, in Zivil, Zivi, Zivis, Zivikontrolle, Kontrolleur, Kontrolleure, Kontrolle, Hochbahn Wache, Hochbahn-Kontrolle, HVV-Kontrolle, Konti, Kontis, Prüfer, Fahrkartenkontrolle',
         untrackedLinesNote:
             'Sightings on OTHER lines (three-digit bus lines, night buses, express X-lines, ' +
             'regional trains, replacement services) are still reports if a station name is mentioned — ' +

--- a/packages/telegram-worker/wrangler.jsonc
+++ b/packages/telegram-worker/wrangler.jsonc
@@ -14,11 +14,12 @@
         // One bot and webhook route messages by their incoming chat ID.
         "TELEGRAM_CHAT_CITIES": {
             "-1001370021231": "berlin",
-            "-1001138115617": "leipzig"
+            "-1001138115617": "leipzig",
+            "-1202572205": "hamburg"
         },
         // Comma-separated city slugs for which app-to-Telegram notifications are paused.
         // Webhook reading and report creation remain enabled. Leave empty to enable all cities.
-        "TELEGRAM_WRITING_DISABLED_CITIES": "",
+        "TELEGRAM_WRITING_DISABLED_CITIES": "hamburg",
         "SENTRY_DSN": "https://9d9ac700f1213d4db367b557167a0594@o4508609338867712.ingest.de.sentry.io/4511633367564368",
     },
     // Messages are processed in the background (ctx.waitUntil) with no queue/retry; failed


### PR DESCRIPTION
## Summary
- Map the Hamburg Telegram group (`-1202572205`) so the bot can extract reports, with `TELEGRAM_WRITING_DISABLED_CITIES=hamburg` so app reports are not posted back into the group yet.
- Point Hamburg at a new D1 (`api-worker-db-hamburg-eu`, `78b57951-828b-4673-a63f-4f5de233b184`) created with EU jurisdiction. Jurisdiction can only be set at creation, so this replaces `api-worker-db-hamburg`.
- Tune Hamburg extraction keywords and few-shot examples toward how that group actually talks (Gelbwesten, Zivis, Hochbahn Wache).

The old non-EU database (`api-worker-db-hamburg` / `caa8cec3-3ac2-4288-a695-018cfbd22519`) is still in the account and still bound in production until this deploys. After merge, CI migrate+seed will populate the EU database, then the api-worker deploy switches the binding. Delete the old database once that has shipped.

## Test plan
- [ ] After merge, confirm telegram-worker deploy picked up `TELEGRAM_CHAT_CITIES` + `TELEGRAM_WRITING_DISABLED_CITIES`
- [ ] Bot in the Hamburg group: a real inspector message creates a report in the EU D1, and nothing is posted back to the group
- [ ] An app-originated Hamburg report is skipped (`status: skipped`) rather than `sendMessage`
- [ ] api-worker deploy migrated and seeded `api-worker-db-hamburg-eu`; `hamburg.freifahren.org` still reads/writes that database
- [ ] Delete `api-worker-db-hamburg` only after the new binding is live