### PR TITLE
fix: prompt before applying PWA updates

### DIFF
--- a/packages/frontend-next/e2e/pwa-offline.spec.ts
+++ b/packages/frontend-next/e2e/pwa-offline.spec.ts
@@ -45,3 +45,32 @@ test('serves the cached shell offline and fetches a fresh shell when online', as
 
   await context.close();
 });
+
+test('shows the update prompt without navigating until the user confirms', async ({
+  browser,
+  baseURL,
+}) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto(`${baseURL}/?pwa-e2e=update-prompt`);
+  const onboarding = page.getByRole('dialog');
+  if (await onboarding.count()) await onboarding.getByRole('button').first().click();
+
+  const prompt = page.getByRole('status').filter({ hasText: 'New version available' });
+  await expect(prompt).toHaveCount(0);
+
+  await page.evaluate(() => {
+    window.dispatchEvent(new Event('freifahren:pwa-update-available'));
+  });
+
+  await expect(prompt).toContainText('New version available');
+  await expect(prompt.getByRole('button', { name: 'Refresh' })).toBeVisible();
+  expect(page.url()).toContain('pwa-e2e=update-prompt');
+
+  await prompt.getByRole('button', { name: 'Dismiss update notice' }).click();
+  await expect(prompt).toHaveCount(0);
+  expect(page.url()).toContain('pwa-e2e=update-prompt');
+
+  await context.close();
+});

--- a/packages/frontend-next/e2e/pwa-offline.spec.ts
+++ b/packages/frontend-next/e2e/pwa-offline.spec.ts
@@ -68,7 +68,7 @@ test('shows the update prompt without navigating until the user confirms', async
   await expect(prompt.getByRole('button', { name: 'Refresh' })).toBeVisible();
   expect(page.url()).toContain('pwa-e2e=update-prompt');
 
-  await prompt.getByRole('button', { name: 'Dismiss update notice' }).click();
+  await prompt.getByRole('button', { name: 'Not now' }).click();
   await expect(prompt).toHaveCount(0);
   expect(page.url()).toContain('pwa-e2e=update-prompt');
 

--- a/packages/frontend-next/src/components/pwa-update-prompt.i18n.ts
+++ b/packages/frontend-next/src/components/pwa-update-prompt.i18n.ts
@@ -1,0 +1,17 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'pwaUpdatePrompt';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  title: 'New version available',
+  text: 'Refresh to use the latest version of FreiFahren.',
+  refresh: 'Refresh',
+  dismiss: 'Dismiss update notice',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  title: 'Neue Version verfügbar',
+  text: 'Aktualisieren Sie, um die neueste Version von FreiFahren zu verwenden.',
+  refresh: 'Aktualisieren',
+  dismiss: 'Hinweis schließen',
+});

--- a/packages/frontend-next/src/components/pwa-update-prompt.i18n.ts
+++ b/packages/frontend-next/src/components/pwa-update-prompt.i18n.ts
@@ -6,12 +6,12 @@ i18n.addResourceBundle('en', NAMESPACE, {
   title: 'New version available',
   text: 'Refresh to use the latest version of FreiFahren.',
   refresh: 'Refresh',
-  dismiss: 'Dismiss update notice',
+  dismiss: 'Not now',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
   title: 'Neue Version verfügbar',
   text: 'Aktualisieren Sie, um die neueste Version von FreiFahren zu verwenden.',
   refresh: 'Aktualisieren',
-  dismiss: 'Hinweis schließen',
+  dismiss: 'Jetzt nicht',
 });

--- a/packages/frontend-next/src/components/pwa-update-prompt.tsx
+++ b/packages/frontend-next/src/components/pwa-update-prompt.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw, X } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 import { useState, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -32,9 +32,18 @@ export function PwaUpdatePrompt() {
             <p className="text-muted-foreground text-xs">{t('text')}</p>
           </div>
         </CardContent>
-        <CardFooter className="justify-between gap-2">
+        <CardFooter className="gap-2">
           <Button
-            size="xs"
+            variant="outline"
+            className="flex-1"
+            aria-label={t('dismiss')}
+            disabled={updating}
+            onClick={() => setDismissed(true)}
+          >
+            {t('dismiss')}
+          </Button>
+          <Button
+            className="bg-accent-bright text-primary-foreground hover:bg-accent-press flex-1"
             aria-label={t('refresh')}
             disabled={updating}
             onClick={() => {
@@ -43,16 +52,6 @@ export function PwaUpdatePrompt() {
             }}
           >
             {updating ? <RefreshCw className="animate-spin" /> : t('refresh')}
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label={t('dismiss')}
-            disabled={updating}
-            onClick={() => setDismissed(true)}
-          >
-            <X />
           </Button>
         </CardFooter>
       </PopupCard>

--- a/packages/frontend-next/src/components/pwa-update-prompt.tsx
+++ b/packages/frontend-next/src/components/pwa-update-prompt.tsx
@@ -1,0 +1,61 @@
+import { RefreshCw, X } from 'lucide-react';
+import { useState, useSyncExternalStore } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { PopupCard } from '@/components/map/PopupCard';
+import { Button } from '@/components/ui/button';
+import { CardContent, CardFooter } from '@/components/ui/card';
+import { applyPwaUpdate, hasPwaUpdateAvailable, subscribePwaUpdate } from '@/lib/pwa-update';
+
+import { NAMESPACE } from './pwa-update-prompt.i18n';
+
+export function PwaUpdatePrompt() {
+  const { t } = useTranslation(NAMESPACE);
+  const updateAvailable = useSyncExternalStore(
+    subscribePwaUpdate,
+    hasPwaUpdateAvailable,
+    () => false,
+  );
+  const [dismissed, setDismissed] = useState(false);
+  const [updating, setUpdating] = useState(false);
+  const visible = updateAvailable && !dismissed;
+
+  if (!visible) return null;
+
+  return (
+    <div role="status" aria-live="polite">
+      <PopupCard cardClassName="gap-3 py-3">
+        <CardContent className="flex items-center gap-3">
+          <RefreshCw className="text-accent-bright size-5 shrink-0" />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold">{t('title')}</p>
+            <p className="text-muted-foreground text-xs">{t('text')}</p>
+          </div>
+        </CardContent>
+        <CardFooter className="gap-2">
+          <Button
+            size="xs"
+            aria-label={t('refresh')}
+            disabled={updating}
+            onClick={() => {
+              setUpdating(true);
+              void applyPwaUpdate().catch(() => setUpdating(false));
+            }}
+          >
+            {updating ? <RefreshCw className="animate-spin" /> : t('refresh')}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={t('dismiss')}
+            disabled={updating}
+            onClick={() => setDismissed(true)}
+          >
+            <X />
+          </Button>
+        </CardFooter>
+      </PopupCard>
+    </div>
+  );
+}

--- a/packages/frontend-next/src/components/pwa-update-prompt.tsx
+++ b/packages/frontend-next/src/components/pwa-update-prompt.tsx
@@ -25,14 +25,14 @@ export function PwaUpdatePrompt() {
   return (
     <div role="status" aria-live="polite">
       <PopupCard cardClassName="gap-3 py-3">
-        <CardContent className="flex items-center gap-3">
+        <CardContent className="flex items-start gap-3">
           <RefreshCw className="text-accent-bright size-5 shrink-0" />
           <div className="min-w-0 flex-1">
             <p className="text-sm font-semibold">{t('title')}</p>
             <p className="text-muted-foreground text-xs">{t('text')}</p>
           </div>
         </CardContent>
-        <CardFooter className="gap-2">
+        <CardFooter className="justify-between gap-2">
           <Button
             size="xs"
             aria-label={t('refresh')}

--- a/packages/frontend-next/src/lib/pwa-update.ts
+++ b/packages/frontend-next/src/lib/pwa-update.ts
@@ -1,0 +1,33 @@
+export const PWA_UPDATE_AVAILABLE_EVENT = 'freifahren:pwa-update-available';
+
+type UpdateServiceWorker = (reloadPage?: boolean) => Promise<void>;
+type PwaUpdateListener = () => void;
+
+let updateServiceWorker: UpdateServiceWorker | null = null;
+let updateAvailable = false;
+
+export function setPwaUpdateServiceWorker(updater: UpdateServiceWorker): void {
+  updateServiceWorker = updater;
+}
+
+export function notifyPwaUpdateAvailable(): void {
+  updateAvailable = true;
+  window.dispatchEvent(new Event(PWA_UPDATE_AVAILABLE_EVENT));
+}
+
+export function subscribePwaUpdate(listener: PwaUpdateListener): () => void {
+  const onUpdate = () => {
+    updateAvailable = true;
+    listener();
+  };
+  window.addEventListener(PWA_UPDATE_AVAILABLE_EVENT, onUpdate);
+  return () => window.removeEventListener(PWA_UPDATE_AVAILABLE_EVENT, onUpdate);
+}
+
+export function hasPwaUpdateAvailable(): boolean {
+  return updateAvailable;
+}
+
+export async function applyPwaUpdate(): Promise<void> {
+  await updateServiceWorker?.(true);
+}

--- a/packages/frontend-next/src/main.tsx
+++ b/packages/frontend-next/src/main.tsx
@@ -12,6 +12,7 @@ import { syncConsentToPostHog } from './lib/consent';
 import { loadPostHog } from './lib/posthog-client';
 import { initErrorMonitoring } from './lib/error-monitoring';
 import { initNativePlatform } from './lib/native';
+import { notifyPwaUpdateAvailable, setPwaUpdateServiceWorker } from './lib/pwa-update';
 import { safeSessionStorage } from './lib/safe-storage';
 import { isTelegramInAppBrowser } from './lib/utils';
 import './lib/i18n';
@@ -24,9 +25,10 @@ initErrorMonitoring();
 
 void initNativePlatform();
 
-// vite-plugin-pwa's registration API catches failures (bots, crawlers, locked-down WebViews) and
-// reloads once when an auto-updated worker takes control. Recheck after the app returns online or
-// to the foreground so an installed PWA does not keep a suspended shell indefinitely.
+// vite-plugin-pwa's registration API catches failures (bots, crawlers, locked-down WebViews). Keep
+// checking after the app returns online or to the foreground so an installed PWA does not keep a
+// suspended shell indefinitely; an available update is surfaced by PwaUpdatePrompt instead of
+// navigating the user away from their current screen.
 if (!__CAPACITOR__ && 'serviceWorker' in navigator) {
   if (isTelegramInAppBrowser) {
     const TELEGRAM_SW_CLEAR_MARK = 'ff-tg-sw-cleared';
@@ -45,7 +47,8 @@ if (!__CAPACITOR__ && 'serviceWorker' in navigator) {
       })
       .catch(() => {});
   } else {
-    registerSW({
+    const updateServiceWorker = registerSW({
+      onNeedRefresh: notifyPwaUpdateAvailable,
       onRegisteredSW: (_swUrl, registration) => {
         if (!registration) return;
 
@@ -69,6 +72,7 @@ if (!__CAPACITOR__ && 'serviceWorker' in navigator) {
       },
       onRegisterError: () => {},
     });
+    setPwaUpdateServiceWorker(updateServiceWorker);
   }
 }
 

--- a/packages/frontend-next/src/routes/__root.tsx
+++ b/packages/frontend-next/src/routes/__root.tsx
@@ -9,6 +9,7 @@ import { FeedbackCard } from '@/components/feedback/FeedbackCard';
 import { LegalDisclaimer } from '@/components/LegalDisclaimer';
 import { Onboarding } from '@/components/onboarding/Onboarding';
 import { PersistentMapView } from '@/components/map/PersistentMapView';
+import { PwaUpdatePrompt } from '@/components/pwa-update-prompt';
 import { ScreenshotBranding } from '@/components/ScreenshotBranding';
 import { GeolocationProvider } from '@/contexts/GeolocationProvider';
 import { ReportSimulationProvider } from '@/contexts/ReportSimulationProvider';
@@ -40,6 +41,7 @@ export const Route = createRootRoute({
         <Outlet />
         <Onboarding />
         <LegalDisclaimer />
+        <PwaUpdatePrompt />
         <ContributeCard />
         <FeedbackCard />
         <ConsentBanner />

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -78,9 +78,9 @@ export default defineConfig({
       // Keep the virtual registration module resolvable for native builds without emitting a
       // service worker there. The call site itself is compile-time gated by __CAPACITOR__.
       disable: isCapacitor,
-      // Silent update: the new service worker takes over and the fresh shell reloads immediately,
-      // with no prompt UI (AGENTS.md: keep registration/update UI minimal).
-      registerType: 'autoUpdate',
+      // Keep the current screen stable while a new worker waits; PwaUpdatePrompt lets the user
+      // choose when the shell reloads instead of losing an in-progress report or navigation.
+      registerType: 'prompt',
       // Register the SW ourselves in main.tsx instead of letting the plugin inject registerSW.js.
       // That generated snippet calls navigator.serviceWorker.register() with no .catch, so a
       // rejection (common in bots/crawlers and locked-down WebViews) surfaces as an unhandled
@@ -112,9 +112,10 @@ export default defineConfig({
         ],
       },
       workbox: {
-        // injectRegister is disabled, so configure the auto-update lifecycle explicitly rather
-        // than relying on vite-plugin-pwa's injected registration snippet to do it for us.
-        skipWaiting: true,
+        // injectRegister is disabled, so configure the update lifecycle explicitly rather than
+        // relying on vite-plugin-pwa's injected registration snippet to do it for us. Leaving the
+        // worker waiting is what makes the user-controlled prompt possible.
+        skipWaiting: false,
         clientsClaim: true,
         // Precache the immutable, content-hashed assets: JS/CSS, the IBM Plex woff2 files, and the
         // lazy maplibre chunk (~1 MB, under the 2 MB default cap) so the map engine paints offline


### PR DESCRIPTION
## Why this change

The web app was observed refreshing itself a few seconds after startup. The frontend intentionally had two reload paths:

- The service worker used `registerType: autoUpdate`, `skipWaiting: true`, and `clientsClaim: true`. When a deployment produced a new worker, it could take control of an active page and the generated PWA registration code reloaded the page.
- Vite lazy-chunk recovery reloads the page when a hashed dynamic import fails. This recovery is still needed after deployments, but it is a separate failure path.

The first path is disruptive: a user can lose the screen they are reading or an in-progress report without choosing to apply an update. Sentry also contains recurring startup and dynamic-import failures, so making the update boundary explicit gives users control while retaining recovery for genuinely stale assets.

## What we changed

- Changed the web PWA registration from `autoUpdate` to `prompt`.
- Left new service workers waiting instead of activating immediately.
- Added a localized, dismissible update notice at the application root.
- The notice reloads only after the user chooses `Refresh`; dismissing it leaves the current route and UI untouched.
- Preserved the existing online/foreground service-worker checks, offline shell behavior, and guarded `vite:preloadError` reload.
- Added an end-to-end test proving that an available update does not navigate until the user confirms, and that dismissal does not navigate.

## Why this is the right trade-off

A prompt is the smallest change that fixes the user-visible problem without removing the benefits of the PWA:

- It prevents silent data and navigation loss.
- It still lets users apply a deployment immediately.
- It keeps the service worker update mechanism and offline cache intact.
- It avoids weakening stale-chunk recovery, which handles a different class of deployment race.
- It works on every route because the notice is mounted at the root, rather than only on the map layout.

The prompt is intentionally session-only. If a user dismisses it, the worker remains available and the next normal reload can apply it; no persistent preference or cache-clearing workaround is introduced.

## Verification

- `bunx prettier --check ...` passed.
- `bun run build` passed.
- `bun run lint` passed with two pre-existing React Compiler warnings in unrelated report components.
- `bun run test -- e2e/pwa-offline.spec.ts` passed: 2 tests.