### PR TITLE
feat: prompt to switch city when GPS is in another network

### DIFF
--- a/packages/frontend-next/src/components/map/CitySwitcher.tsx
+++ b/packages/frontend-next/src/components/map/CitySwitcher.tsx
@@ -1,9 +1,9 @@
-import { Capacitor } from '@capacitor/core';
 import { ChevronDown, MapPin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-import { currentCity, setCityPreference, urlForCity } from '@/lib/city';
+import { currentCity, navigateToCity } from '@/lib/city';
 import { selectableCities, useCitySwitchingEnabled } from '@/lib/city-switching';
+
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -40,11 +40,7 @@ export function CitySwitcher() {
             if (slug === currentCity.slug) return;
             const city = selectableCities.find((c) => c.slug === slug);
             if (!city) return;
-            if (Capacitor.isNativePlatform()) {
-              setCityPreference(city.slug);
-            } else {
-              window.location.assign(urlForCity(city));
-            }
+            navigateToCity(city, { resetAutoSwitch: true });
           }}
         >
           {selectableCities.map((city) => (

--- a/packages/frontend-next/src/components/map/city-location-prompt.i18n.ts
+++ b/packages/frontend-next/src/components/map/city-location-prompt.i18n.ts
@@ -1,0 +1,21 @@
+import { i18n } from '@/lib/i18n';
+
+export const NAMESPACE = 'cityLocationPrompt';
+
+i18n.addResourceBundle('en', NAMESPACE, {
+  title: 'Switch to {{city}}?',
+  description:
+    'Your location looks like you are in {{city}}. FreiFahren shows reports for one city at a time.',
+  switch: 'Switch',
+  stay: 'Stay here',
+  remember: 'Remember this choice',
+});
+
+i18n.addResourceBundle('de', NAMESPACE, {
+  title: 'Zu {{city}} wechseln?',
+  description:
+    'Du bist laut deinem Standort in {{city}}. FreiFahren zeigt Meldungen jeweils für eine Stadt.',
+  switch: 'Wechseln',
+  stay: 'Hier bleiben',
+  remember: 'Diese Auswahl merken',
+});

--- a/packages/frontend-next/src/components/map/city-location-prompt.tsx
+++ b/packages/frontend-next/src/components/map/city-location-prompt.tsx
@@ -1,0 +1,56 @@
+import { MapPin } from 'lucide-react';
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { CardContent, CardFooter } from '@/components/ui/card';
+import { useCityLocationPrompt } from '@/hooks/use-city-location-prompt';
+
+import { NAMESPACE } from './city-location-prompt.i18n';
+import { PopupCard } from './PopupCard';
+
+export function CityLocationPrompt() {
+  const { t } = useTranslation(NAMESPACE);
+  const { promptCity, accept, decline } = useCityLocationPrompt();
+  const [remember, setRemember] = useState(false);
+
+  if (promptCity === null) return null;
+
+  return createPortal(
+    <PopupCard>
+      <CardContent className="flex flex-col gap-1">
+        <h2 className="font-heading flex items-center gap-2 text-lg font-semibold">
+          <MapPin className="text-accent-bright size-5" />
+          {t('title', { city: promptCity.displayName })}
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          {t('description', { city: promptCity.displayName })}
+        </p>
+      </CardContent>
+      <CardFooter className="flex-col items-stretch gap-3">
+        <label className="text-muted-foreground flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={remember}
+            onChange={(e) => setRemember(e.target.checked)}
+            className="accent-accent-bright size-4 shrink-0 rounded border"
+          />
+          {t('remember')}
+        </label>
+        <div className="flex gap-2">
+          <Button variant="outline" className="flex-1" onClick={() => decline(remember)}>
+            {t('stay')}
+          </Button>
+          <Button
+            className="bg-accent-bright text-primary-foreground hover:bg-accent-press flex-1"
+            onClick={() => accept(remember)}
+          >
+            {t('switch')}
+          </Button>
+        </div>
+      </CardFooter>
+    </PopupCard>,
+    document.body,
+  );
+}

--- a/packages/frontend-next/src/hooks/use-city-location-prompt.ts
+++ b/packages/frontend-next/src/hooks/use-city-location-prompt.ts
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { useGeolocation } from '@/contexts/Geolocation.context';
+import { track } from '@/lib/analytics';
+import {
+  getAutoSwitchCityPreference,
+  setAutoSwitchCityPreference,
+  type AutoSwitchCityPreference,
+} from '@/lib/auto-switch-city';
+import { currentCitySlug, navigateToCity } from '@/lib/city';
+import { cityForPosition } from '@/lib/city-for-position';
+import { selectableCities, useCitySwitchingEnabled } from '@/lib/city-switching';
+import { useConsentPrompt, useConsentReview } from '@/lib/consent';
+import { useContributeModalOpen } from '@/lib/contribute-modal';
+import { useActiveLocationPrompt } from '@/lib/location-prompt';
+import { useOnboardingComplete } from '@/lib/onboarding';
+import { optionalEnv } from '@/lib/utils';
+
+const MAX_ACCURACY_METERS = 25_000;
+const analyticsEnabled = optionalEnv('VITE_POSTHOG_KEY') != null;
+
+export function useCityLocationPrompt() {
+  const enabled = useCitySwitchingEnabled();
+  const onboarded = useOnboardingComplete();
+  const { position, accuracy } = useGeolocation();
+  const locationPrompt = useActiveLocationPrompt();
+  const contributeOpen = useContributeModalOpen();
+  const consentPrompt = useConsentPrompt();
+  const consentReview = useConsentReview();
+  const consentVisible = analyticsEnabled && (consentPrompt || consentReview);
+  const storedPreference = getAutoSwitchCityPreference();
+  const [preferenceOverride, setPreferenceOverride] = useState<
+    AutoSwitchCityPreference | null | undefined
+  >(undefined);
+  const preference = preferenceOverride !== undefined ? preferenceOverride : storedPreference;
+  const [sessionDismissed, setSessionDismissed] = useState(false);
+  const switchedRef = useRef(false);
+  const shownForRef = useRef<string | null>(null);
+
+  const blocked =
+    !enabled ||
+    !onboarded ||
+    sessionDismissed ||
+    locationPrompt !== null ||
+    contributeOpen ||
+    consentVisible;
+
+  const locatedCity =
+    position === null || (accuracy !== null && accuracy > MAX_ACCURACY_METERS)
+      ? null
+      : cityForPosition(position.lng, position.lat, selectableCities);
+
+  const mismatch =
+    locatedCity !== null && locatedCity.slug !== currentCitySlug ? locatedCity : null;
+
+  const promptCity = blocked || mismatch === null || preference !== null ? null : mismatch;
+
+  useEffect(() => {
+    if (blocked || mismatch === null || preference !== 'always' || switchedRef.current) return;
+    switchedRef.current = true;
+    track('city_location_auto_switched', { from: currentCitySlug, to: mismatch.slug });
+    navigateToCity(mismatch);
+  }, [blocked, mismatch, preference]);
+
+  useEffect(() => {
+    if (promptCity === null || shownForRef.current === promptCity.slug) return;
+    shownForRef.current = promptCity.slug;
+    track('city_location_prompt_shown', { from: currentCitySlug, to: promptCity.slug });
+  }, [promptCity]);
+
+  const accept = (remember: boolean) => {
+    if (promptCity === null) return;
+    track('city_location_prompt_accepted', {
+      from: currentCitySlug,
+      to: promptCity.slug,
+      remembered: remember,
+    });
+    if (remember) {
+      setAutoSwitchCityPreference('always');
+      setPreferenceOverride('always');
+    }
+    switchedRef.current = true;
+    navigateToCity(promptCity);
+  };
+
+  const decline = (remember: boolean) => {
+    if (promptCity === null) return;
+    track('city_location_prompt_declined', {
+      from: currentCitySlug,
+      to: promptCity.slug,
+      remembered: remember,
+    });
+    if (remember) {
+      setAutoSwitchCityPreference('never');
+      setPreferenceOverride('never');
+      return;
+    }
+    setSessionDismissed(true);
+  };
+
+  return { promptCity, accept, decline };
+}

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -65,6 +65,10 @@ type AnalyticsEvents = {
   app_removal_banner_clicked: Record<string, never>;
   app_removal_banner_dismissed: Record<string, never>;
   feedback_sentiment_selected: { sentiment: FeedbackSentiment };
+  city_location_prompt_shown: { from: string; to: string };
+  city_location_prompt_accepted: { from: string; to: string; remembered: boolean };
+  city_location_prompt_declined: { from: string; to: string; remembered: boolean };
+  city_location_auto_switched: { from: string; to: string };
 };
 
 export function track<E extends keyof AnalyticsEvents>(

--- a/packages/frontend-next/src/lib/auto-switch-city.ts
+++ b/packages/frontend-next/src/lib/auto-switch-city.ts
@@ -1,12 +1,9 @@
-import { Capacitor } from '@capacitor/core';
-
 import { removeNativePreference, saveNativePreference } from '@/lib/native-preference';
 import { safeLocalStorage } from '@/lib/safe-storage';
 
 export type AutoSwitchCityPreference = 'always' | 'never';
 
 const KEY = 'freifahren.autoSwitchCity';
-const YEAR_SECONDS = 60 * 60 * 24 * 365;
 export const RESET_AUTO_SWITCH_PARAM = 'resetAutoSwitch';
 const RESET_WINDOW_NAME = 'ff-reset-auto-switch-city';
 
@@ -14,53 +11,27 @@ function parse(value: string | null): AutoSwitchCityPreference | null {
   return value === 'always' || value === 'never' ? value : null;
 }
 
-function usesCrossSubdomainCookie(): boolean {
-  return typeof window !== 'undefined' && window.location.hostname.endsWith('.freifahren.org');
-}
-
-function readCookie(): string | null {
-  if (typeof document === 'undefined') return null;
-  const prefix = `${KEY}=`;
-  const found = document.cookie.split('; ').find((row) => row.startsWith(prefix));
-  return found === undefined ? null : found.slice(prefix.length);
-}
-
-function writeCookie(value: AutoSwitchCityPreference): void {
-  if (typeof document === 'undefined' || !usesCrossSubdomainCookie()) return;
-  const parts = [
-    `${KEY}=${value}`,
-    'Path=/',
-    `Max-Age=${YEAR_SECONDS}`,
-    'SameSite=Lax',
-    'Secure',
-    'Domain=.freifahren.org',
-  ];
-  document.cookie = parts.join('; ');
-}
-
-function expireCookie(): void {
+function expireLegacyCookie(): void {
   if (typeof document === 'undefined') return;
+  if (!document.cookie.split('; ').some((row) => row.startsWith(`${KEY}=`))) return;
   document.cookie = `${KEY}=; Path=/; Max-Age=0`;
-  if (usesCrossSubdomainCookie()) {
+  if (typeof window !== 'undefined' && window.location.hostname.endsWith('.freifahren.org')) {
     document.cookie = `${KEY}=; Path=/; Max-Age=0; Domain=.freifahren.org`;
   }
 }
 
 export function getAutoSwitchCityPreference(): AutoSwitchCityPreference | null {
-  if (!usesCrossSubdomainCookie()) {
-    if (readCookie() !== null) expireCookie();
-    return parse(safeLocalStorage.getItem(KEY));
-  }
-  return parse(readCookie()) ?? parse(safeLocalStorage.getItem(KEY));
+  expireLegacyCookie();
+  return parse(safeLocalStorage.getItem(KEY));
 }
 
 export function setAutoSwitchCityPreference(value: AutoSwitchCityPreference): void {
-  if (!Capacitor.isNativePlatform()) writeCookie(value);
+  expireLegacyCookie();
   void saveNativePreference(KEY, value);
 }
 
 export function clearAutoSwitchCityPreference(): void {
-  expireCookie();
+  expireLegacyCookie();
   void removeNativePreference(KEY);
 }
 

--- a/packages/frontend-next/src/lib/auto-switch-city.ts
+++ b/packages/frontend-next/src/lib/auto-switch-city.ts
@@ -11,27 +11,15 @@ function parse(value: string | null): AutoSwitchCityPreference | null {
   return value === 'always' || value === 'never' ? value : null;
 }
 
-function expireLegacyCookie(): void {
-  if (typeof document === 'undefined') return;
-  if (!document.cookie.split('; ').some((row) => row.startsWith(`${KEY}=`))) return;
-  document.cookie = `${KEY}=; Path=/; Max-Age=0`;
-  if (typeof window !== 'undefined' && window.location.hostname.endsWith('.freifahren.org')) {
-    document.cookie = `${KEY}=; Path=/; Max-Age=0; Domain=.freifahren.org`;
-  }
-}
-
 export function getAutoSwitchCityPreference(): AutoSwitchCityPreference | null {
-  expireLegacyCookie();
   return parse(safeLocalStorage.getItem(KEY));
 }
 
 export function setAutoSwitchCityPreference(value: AutoSwitchCityPreference): void {
-  expireLegacyCookie();
   void saveNativePreference(KEY, value);
 }
 
 export function clearAutoSwitchCityPreference(): void {
-  expireLegacyCookie();
   void removeNativePreference(KEY);
 }
 

--- a/packages/frontend-next/src/lib/auto-switch-city.ts
+++ b/packages/frontend-next/src/lib/auto-switch-city.ts
@@ -79,7 +79,11 @@ function consumeResetAutoSwitchCity(): void {
   if (fromName) window.name = '';
   if (fromQuery) {
     url.searchParams.delete(RESET_AUTO_SWITCH_PARAM);
-    window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+    window.history.replaceState(
+      window.history.state,
+      '',
+      `${url.pathname}${url.search}${url.hash}`,
+    );
   }
   clearAutoSwitchCityPreference();
 }

--- a/packages/frontend-next/src/lib/auto-switch-city.ts
+++ b/packages/frontend-next/src/lib/auto-switch-city.ts
@@ -1,0 +1,87 @@
+import { Capacitor } from '@capacitor/core';
+
+import { removeNativePreference, saveNativePreference } from '@/lib/native-preference';
+import { safeLocalStorage } from '@/lib/safe-storage';
+
+export type AutoSwitchCityPreference = 'always' | 'never';
+
+const KEY = 'freifahren.autoSwitchCity';
+const YEAR_SECONDS = 60 * 60 * 24 * 365;
+export const RESET_AUTO_SWITCH_PARAM = 'resetAutoSwitch';
+const RESET_WINDOW_NAME = 'ff-reset-auto-switch-city';
+
+function parse(value: string | null): AutoSwitchCityPreference | null {
+  return value === 'always' || value === 'never' ? value : null;
+}
+
+function usesCrossSubdomainCookie(): boolean {
+  return typeof window !== 'undefined' && window.location.hostname.endsWith('.freifahren.org');
+}
+
+function readCookie(): string | null {
+  if (typeof document === 'undefined') return null;
+  const prefix = `${KEY}=`;
+  const found = document.cookie.split('; ').find((row) => row.startsWith(prefix));
+  return found === undefined ? null : found.slice(prefix.length);
+}
+
+function writeCookie(value: AutoSwitchCityPreference): void {
+  if (typeof document === 'undefined' || !usesCrossSubdomainCookie()) return;
+  const parts = [
+    `${KEY}=${value}`,
+    'Path=/',
+    `Max-Age=${YEAR_SECONDS}`,
+    'SameSite=Lax',
+    'Secure',
+    'Domain=.freifahren.org',
+  ];
+  document.cookie = parts.join('; ');
+}
+
+function expireCookie(): void {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${KEY}=; Path=/; Max-Age=0`;
+  if (usesCrossSubdomainCookie()) {
+    document.cookie = `${KEY}=; Path=/; Max-Age=0; Domain=.freifahren.org`;
+  }
+}
+
+export function getAutoSwitchCityPreference(): AutoSwitchCityPreference | null {
+  if (!usesCrossSubdomainCookie()) {
+    if (readCookie() !== null) expireCookie();
+    return parse(safeLocalStorage.getItem(KEY));
+  }
+  return parse(readCookie()) ?? parse(safeLocalStorage.getItem(KEY));
+}
+
+export function setAutoSwitchCityPreference(value: AutoSwitchCityPreference): void {
+  if (!Capacitor.isNativePlatform()) writeCookie(value);
+  void saveNativePreference(KEY, value);
+}
+
+export function clearAutoSwitchCityPreference(): void {
+  expireCookie();
+  void removeNativePreference(KEY);
+}
+
+export function markResetAutoSwitchCity(): void {
+  if (typeof window === 'undefined') return;
+  window.name = RESET_WINDOW_NAME;
+}
+
+function consumeResetAutoSwitchCity(): void {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  const fromQuery = url.searchParams.has(RESET_AUTO_SWITCH_PARAM);
+  const fromName = window.name === RESET_WINDOW_NAME;
+  if (!fromQuery && !fromName) return;
+
+  if (fromName) window.name = '';
+  if (fromQuery) {
+    url.searchParams.delete(RESET_AUTO_SWITCH_PARAM);
+    window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+  }
+  clearAutoSwitchCityPreference();
+}
+
+consumeResetAutoSwitchCity();

--- a/packages/frontend-next/src/lib/city-for-position.ts
+++ b/packages/frontend-next/src/lib/city-for-position.ts
@@ -1,0 +1,25 @@
+import type { CityConfig } from '@freifahren/cities';
+
+function pointInBounds(lng: number, lat: number, city: CityConfig): boolean {
+  const [west, south, east, north] = city.map.bounds;
+  return lng >= west && lng <= east && lat >= south && lat <= north;
+}
+
+function distanceToCenter(lng: number, lat: number, city: CityConfig): number {
+  const [centerLng, centerLat] = city.map.center;
+  const dLng = lng - centerLng;
+  const dLat = lat - centerLat;
+  return dLng * dLng + dLat * dLat;
+}
+
+export function cityForPosition(
+  lng: number,
+  lat: number,
+  cities: readonly CityConfig[],
+): CityConfig | null {
+  const matches = cities.filter((city) => pointInBounds(lng, lat, city));
+  if (matches.length === 0) return null;
+  return matches.reduce((closest, city) =>
+    distanceToCenter(lng, lat, city) < distanceToCenter(lng, lat, closest) ? city : closest,
+  );
+}

--- a/packages/frontend-next/src/lib/city.ts
+++ b/packages/frontend-next/src/lib/city.ts
@@ -1,6 +1,11 @@
 import { Capacitor } from '@capacitor/core';
 import { CITIES, DEFAULT_CITY_SLUG, getCity, type CityConfig } from '@freifahren/cities';
 
+import {
+  RESET_AUTO_SWITCH_PARAM,
+  clearAutoSwitchCityPreference,
+  markResetAutoSwitchCity,
+} from '@/lib/auto-switch-city';
 import { restoreNativePreference, saveNativePreference } from '@/lib/native-preference';
 import { safeLocalStorage } from '@/lib/safe-storage';
 import { isPreviewBuild } from '@/lib/utils';
@@ -62,18 +67,27 @@ export function hostForCity(hostname: string, city: CityConfig): string {
   return [city.subdomain, ...labels.slice(1)].join('.');
 }
 
-export function urlForCity(city: CityConfig): string {
+export function urlForCity(city: CityConfig, options?: { resetAutoSwitch?: boolean }): string {
   const { protocol, hostname, port, pathname, search } = window.location;
-  const origin = `${protocol}//${hostname}${port ? `:${port}` : ''}`;
+  const params = new URLSearchParams(search);
+  if (isPreviewBuild) params.set('city', city.slug);
+  if (options?.resetAutoSwitch) params.set(RESET_AUTO_SWITCH_PARAM, '1');
+  else params.delete(RESET_AUTO_SWITCH_PARAM);
+  const query = params.toString();
+  const host = isPreviewBuild ? hostname : hostForCity(hostname, city);
+  return `${protocol}//${host}${port ? `:${port}` : ''}${pathname}${query ? `?${query}` : ''}`;
+}
 
-  if (isPreviewBuild) {
-    const params = new URLSearchParams(search);
-    params.set('city', city.slug);
-    return `${origin}${pathname}?${params.toString()}`;
+export function navigateToCity(city: CityConfig, options?: { resetAutoSwitch?: boolean }): void {
+  if (options?.resetAutoSwitch) {
+    clearAutoSwitchCityPreference();
+    markResetAutoSwitchCity();
   }
-
-  const host = hostForCity(hostname, city);
-  return `${protocol}//${host}${port ? `:${port}` : ''}${pathname}${search}`;
+  if (Capacitor.isNativePlatform()) {
+    setCityPreference(city.slug);
+    return;
+  }
+  window.location.assign(urlForCity(city, options));
 }
 
 // The active city for this session. The resolution source is pluggable (stored preference on

--- a/packages/frontend-next/src/routes/__root.tsx
+++ b/packages/frontend-next/src/routes/__root.tsx
@@ -7,8 +7,9 @@ import { ConsentBanner } from '@/components/ConsentBanner';
 import { ContributeCard } from '@/components/contribute/ContributeCard';
 import { FeedbackCard } from '@/components/feedback/FeedbackCard';
 import { LegalDisclaimer } from '@/components/LegalDisclaimer';
-import { Onboarding } from '@/components/onboarding/Onboarding';
+import { CityLocationPrompt } from '@/components/map/city-location-prompt';
 import { PersistentMapView } from '@/components/map/PersistentMapView';
+import { Onboarding } from '@/components/onboarding/Onboarding';
 import { ScreenshotBranding } from '@/components/ScreenshotBranding';
 import { GeolocationProvider } from '@/contexts/GeolocationProvider';
 import { ReportSimulationProvider } from '@/contexts/ReportSimulationProvider';
@@ -40,6 +41,7 @@ export const Route = createRootRoute({
         <Outlet />
         <Onboarding />
         <LegalDisclaimer />
+        <CityLocationPrompt />
         <ContributeCard />
         <FeedbackCard />
         <ConsentBanner />


### PR DESCRIPTION
## Summary
- If the existing geolocation is accurate and falls inside another selectable city, show a popup to switch (or stay), with an opt-in “remember this choice”.
- Remembered `always` auto-switches on later visits; `never` stops asking. Changing city in Settings clears that preference on both the current host and the destination (needed because `localhost` / `*.localhost` do not share storage).
- Does not request a new GPS permission, skips while onboarding/consent/other modals are open, and ignores coarse positions (>25 km). Unlisted cities (e.g. Hamburg in production) are not switch targets.

## Test plan
- [ ] On localhost with city switching enabled, spoof GPS inside Leipzig while on Berlin: popup appears; decline without remember → no further prompt this session.
- [ ] Accept without remember → lands on Leipzig; switching back in Settings shows the popup again instead of a silent bounce.
- [ ] Accept with remember → later visits auto-switch; Settings city change forgets the preference and asks again.
- [ ] Decline with remember → no prompt until Settings city change.
- [ ] Coarse accuracy or GPS outside all city bounds → no prompt.
- [ ] Hamburg listed only in DEV: not offered as a target in production.