### PR TITLE
fix: preserve structured fields in Sentry logs

### DIFF
--- a/packages/api-worker/src/common/logger.ts
+++ b/packages/api-worker/src/common/logger.ts
@@ -1,4 +1,4 @@
-// On Workers, Sentry's consoleLoggingIntegration forwards console.{info,warn,error} to Sentry Logs.
+// The Worker entry point injects Sentry's native logger at runtime; the optional sink keeps this module usable by tests and the seed CLI without pulling the Sentry SDK into those bundles.
 // Privacy: log structured fields and lengths, never raw report/message text.
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
@@ -8,6 +8,12 @@ export type Logger = {
     info: (objOrMsg: unknown, msg?: string) => void
     warn: (objOrMsg: unknown, msg?: string) => void
     error: (objOrMsg: unknown, msg?: string) => void
+}
+
+export type LogAttributes = Record<string, unknown>
+
+export type SentryLogSink = {
+    [level in LogLevel]: (message: string, attributes?: LogAttributes) => void
 }
 
 const LEVEL_ORDER: Record<LogLevel, number> = { debug: 10, info: 20, warn: 30, error: 40 }
@@ -20,15 +26,41 @@ const CONSOLE_METHOD: Record<LogLevel, 'log' | 'info' | 'warn' | 'error'> = {
     error: 'error',
 }
 
+let sentryLogSink: SentryLogSink | undefined
+
+// Injected by worker.ts so @sentry/cloudflare stays out of the test and CLI bundles.
+export const setSentryLogSink = (sink: SentryLogSink | undefined): void => {
+    sentryLogSink = sink
+}
+
+const serializeError = (error: Error): LogAttributes => ({
+    name: error.name,
+    message: error.message,
+    ...(error.stack === undefined ? {} : { stack: error.stack }),
+})
+
+const normalize = (objOrMsg: unknown, msg?: string): { message: string; attributes?: LogAttributes } => {
+    if (typeof objOrMsg === 'string') return { message: objOrMsg }
+    if (objOrMsg instanceof Error) {
+        return { message: msg ?? objOrMsg.message, attributes: { err: serializeError(objOrMsg) } }
+    }
+    if (typeof objOrMsg === 'object' && objOrMsg !== null && !Array.isArray(objOrMsg)) {
+        return { message: msg ?? '', attributes: objOrMsg as LogAttributes }
+    }
+    return { message: msg ?? '', attributes: { value: objOrMsg } }
+}
+
 const emit = (level: LogLevel, minLevel: LogLevel, objOrMsg: unknown, msg?: string): void => {
     if (LEVEL_ORDER[level] < LEVEL_ORDER[minLevel]) return
 
     const method = CONSOLE_METHOD[level]
-    if (typeof objOrMsg === 'string') {
-        console[method](objOrMsg)
-        return
+    const { message, attributes } = normalize(objOrMsg, msg)
+    if (attributes === undefined) {
+        console[method](message)
+    } else {
+        console[method](message, attributes)
     }
-    console[method](msg ?? '', objOrMsg)
+    sentryLogSink?.[level](message, attributes)
 }
 
 export const createLogger = (level: LogLevel = 'info'): Logger => ({

--- a/packages/api-worker/src/worker.ts
+++ b/packages/api-worker/src/worker.ts
@@ -1,7 +1,8 @@
 /// <reference types="@cloudflare/workers-types" />
-import { captureException, consoleLoggingIntegration, setTag, withSentry } from '@sentry/cloudflare'
+import { captureException, logger as sentryLogger, setTag, withSentry } from '@sentry/cloudflare'
 
 import { Bindings, setErrorReporter, setScopeTagger } from './app-env'
+import { setSentryLogSink } from './common/logger'
 import { normalizeTransactionName } from './common/normalize-transaction-name'
 
 import { app } from './index'
@@ -9,6 +10,9 @@ import { app } from './index'
 // Wired here, not in index.ts, so @sentry/cloudflare stays out of the test bundle.
 // AsyncLocalStorage (set up by withSentry) keeps captures inside a request's waitUntil on its scope.
 setErrorReporter((error, context) => captureException(error, context))
+
+// Native Sentry logs preserve attributes as queryable fields; the console integration is not used because it serializes the second console argument into the message and would duplicate logs.
+setSentryLogSink(sentryLogger)
 
 // Same reason: let app-env tag the request scope (e.g. the resolved city) without importing the SDK.
 setScopeTagger((key, value) => setTag(key, value))
@@ -20,7 +24,6 @@ export default withSentry(
         release: env.SENTRY_RELEASE,
         environment: env.NODE_ENV,
         enableLogs: true,
-        integrations: [consoleLoggingIntegration({ levels: ['info', 'warn', 'error'] })],
         tracesSampleRate: 1.0,
         beforeSendTransaction: (event) => {
             if (event.transaction === undefined) return event

--- a/packages/api-worker/tests/logger.test.ts
+++ b/packages/api-worker/tests/logger.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createLogger, setSentryLogSink, type SentryLogSink } from '../src/common/logger'
+
+describe('structured logger', () => {
+    afterEach(() => {
+        setSentryLogSink(undefined)
+        vi.restoreAllMocks()
+    })
+
+    it('passes structured fields to the Sentry sink separately from the message', () => {
+        const sink: SentryLogSink = {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+        }
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+        setSentryLogSink(sink)
+
+        createLogger().warn({ outcome: 'refused', platform: 'ios', enforce: true }, 'Turnstile verification')
+
+        expect(sink.warn).toHaveBeenCalledWith('Turnstile verification', {
+            outcome: 'refused',
+            platform: 'ios',
+            enforce: true,
+        })
+        expect(consoleWarn).toHaveBeenCalledWith('Turnstile verification', {
+            outcome: 'refused',
+            platform: 'ios',
+            enforce: true,
+        })
+    })
+
+    it('normalizes Error values into safe structured attributes', () => {
+        const sink: SentryLogSink = {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+        }
+        vi.spyOn(console, 'error').mockImplementation(() => undefined)
+        setSentryLogSink(sink)
+        const error = new Error('upstream failed')
+
+        createLogger().error(error, 'Report copy failed')
+
+        expect(sink.error).toHaveBeenCalledWith(
+            'Report copy failed',
+            expect.objectContaining({ err: expect.objectContaining({ name: 'Error', message: 'upstream failed' }) })
+        )
+    })
+
+    it('applies the configured minimum level to the Sentry sink', () => {
+        const sink: SentryLogSink = {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+        }
+        vi.spyOn(console, 'info').mockImplementation(() => undefined)
+        setSentryLogSink(sink)
+
+        createLogger('warn').info({ ignored: true }, 'Below threshold')
+
+        expect(sink.info).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Why this change was needed

Resolves FRE-775. The API worker was using `consoleLoggingIntegration` and calling `console.*(message, fields)`. Sentry flattened the second argument into the log message, so fields such as `outcome`, `platform`, and `enforce` appeared as JSON text and could not be filtered or grouped in Sentry Logs.

## What changed

- Keep the existing application `Logger` call sites and argument order.
- Add an optional structured Sentry log sink to the logger module.
- Inject `@sentry/cloudflare`'s native `logger` from the Worker entry point.
- Keep console output available for Cloudflare runtime logs.
- Remove `consoleLoggingIntegration` to avoid flattened duplicate Sentry events.
- Normalize `Error` values into bounded structured `err` attributes.
- Add tests covering structured fields, error normalization, and minimum log levels.

`enableLogs: true` remains enabled so native Sentry logs are emitted with queryable attributes. Tests and seed tooling do not import the Sentry SDK.

## Verification

- `bunx vitest run tests/logger.test.ts` — 3 passed.
- `bunx prettier --check src/common/logger.ts src/worker.ts tests/logger.test.ts` — passed.
- Targeted ESLint — no errors.
- `wrangler deploy --dry-run --config wrangler.jsonc` — passed.
- Full API suite — 321 passed; 2 existing unrelated predicted-report threshold tests failed (`getReports.test.ts`).
- Targeted TypeScript compile reports no errors in the changed files; the repository-wide check is currently blocked by existing Cloudflare/Bun type conflicts and missing `cloudflare:test` declarations in this fresh worktree.

After deployment, verify in Sentry Explore that filtering/grouping by `outcome` returns rows instead of requiring message substring matching.