### PR TITLE
fix: stop shipping Telegram extraction prompts in the client bundle

### DIFF
--- a/packages/api-worker/src/db/import-telegram-extract.ts
+++ b/packages/api-worker/src/db/import-telegram-extract.ts
@@ -148,8 +148,9 @@ if (cities.length !== 1) {
     throw new Error('--city <slug> is required (one city)')
 }
 const city = cities[0]
-if (city !== 'leipzig') {
-    throw new Error('telegram extract import is Leipzig-only')
+const SUPPORTED_CITIES = new Set(['leipzig', 'hamburg'])
+if (!SUPPORTED_CITIES.has(city)) {
+    throw new Error(`telegram extract import is only supported for: ${[...SUPPORTED_CITIES].join(', ')}`)
 }
 
 importCity(

--- a/packages/cities/package.json
+++ b/packages/cities/package.json
@@ -5,7 +5,8 @@
   "description": "Shared, dependency-free city registry consumed by every FreiFahren toolchain.",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./public": "./src/public.ts"
   },
   "types": "./src/index.ts"
 }

--- a/packages/cities/src/berlin.telegram.ts
+++ b/packages/cities/src/berlin.telegram.ts
@@ -1,0 +1,74 @@
+import type { CityTelegramProfile } from './types'
+
+// Few-shot examples appended to the Telegram extraction prompt. Tuned to teach
+// disambiguation the model gets wrong: slang names, direction-vs-station,
+// all-clear messages, the implicit-direction case. Kept in German since the chat
+// is mixed German/English.
+const promptExamples = `Message: "U2 alex hab in dem bahnstation gesehen"
+{"stationName": "Alex", "directionName": null}
+
+Message: "3x kotti u3 am Gleis"
+{"stationName": "Kottbusser Tor", "directionName": null}
+
+Message: "gorli u1/u3 3 Männer"
+{"stationName": "Görlitzer Bahnhof", "directionName": null}
+
+Message: "U7 Rathaus Spandau Richt Rudow Höhe sbhf Neukölln 4 Mann BOS"
+{"stationName": "Neukölln", "directionName": "Rudow"}
+
+Message: "u 8 wittenau in blauen westen höhe osloer"
+{"stationName": "osloer", "directionName": "wittenau"}
+
+Message: "Gesundbrunnen clean on u8"
+{"stationName": "Gesundbrunnen", "directionName": null}
+
+Message: "M29 bus moritzplatz"
+{"stationName": "Moritzplatz", "directionName": null}
+
+Message: "3 Bos Jacken M29 Anhalter Bahnhof Richtung Hermannplatz"
+{"stationName": "Anhalter Bahnhof", "directionName": "Hermannplatz"}
+
+Message: "S3 nach ostbahnof"
+{"stationName": null, "directionName": "Ostbahnhof"}
+
+Message: "To Rathaus SPANDAU"
+{"stationName": null, "directionName": "Rathaus Spandau"}
+
+Message: "U7 Rathaus Neukölln 3x BOS just got off the train"
+{"stationName": "Rathaus Neukölln", "directionName": null}
+
+Message: "U6 Kaiserin Augusta 2x bos"
+{"stationName": "Kaiserin-Augusta-Straße", "directionName": null}
+
+Message: "Zoo Richtung Steglitz"
+{"stationName": "Zoo", "directionName": "Steglitz"}
+
+Message: "Hi, kann mir wer ein Ticket verkaufen?"
+{"stationName": null, "directionName": null}
+`
+
+/**
+ * Berlin's Telegram extraction profile. NEVER import this from frontend code — it carries
+ * report-extraction prompt engineering that must not ship in the client bundle. See the
+ * warning on `PublicCityConfig` in ./types.ts.
+ */
+export const BERLIN_TELEGRAM: CityTelegramProfile = {
+    inspectorKeywords: 'Kontrolleur, BVG-Kontrolle, BOS, BW, Blauwesten, Zivilkontrolle, blaue Westen',
+    // MetroBus (M11-M85) IS tracked, so it must not be listed here; what stays
+    // outside the network is the rest of the BVG bus system.
+    untrackedLinesNote:
+        'Sightings on OTHER lines (X-lines, three-digit bus lines, night buses, ' +
+        'replacement services) are still reports if a station name is mentioned — ' +
+        'extract the station (bus stops are named after the nearby U/S station).',
+    circularLineAlias: 'Ringbahn',
+    circularLinePattern: String.raw`(?<![A-Za-z])(?:s[-\s]?)?ring(?:bahn)?`,
+    abbreviations: [
+        [String.raw`straße`, 'strasse'],
+        [String.raw`str\.?(?=\s|$|\/|,|\)|-)`, 'strasse'],
+        [String.raw`str$`, 'strasse'],
+        [String.raw`\bbhf\.?\b`, 'bahnhof'],
+        [String.raw`\bhbf\.?\b`, 'hauptbahnhof'],
+        [String.raw`\bpl\.?\b`, 'platz'],
+    ],
+    promptExamples,
+}

--- a/packages/cities/src/berlin.ts
+++ b/packages/cities/src/berlin.ts
@@ -1,54 +1,7 @@
-import type { CityConfig } from './types'
+import type { PublicCityConfig } from './types'
 import { CITY_DATABASES } from './databases'
 
-// Few-shot examples appended to the Telegram extraction prompt. Tuned to teach
-// disambiguation the model gets wrong: slang names, direction-vs-station,
-// all-clear messages, the implicit-direction case. Kept in German since the chat
-// is mixed German/English.
-const promptExamples = `Message: "U2 alex hab in dem bahnstation gesehen"
-{"stationName": "Alex", "directionName": null}
-
-Message: "3x kotti u3 am Gleis"
-{"stationName": "Kottbusser Tor", "directionName": null}
-
-Message: "gorli u1/u3 3 Männer"
-{"stationName": "Görlitzer Bahnhof", "directionName": null}
-
-Message: "U7 Rathaus Spandau Richt Rudow Höhe sbhf Neukölln 4 Mann BOS"
-{"stationName": "Neukölln", "directionName": "Rudow"}
-
-Message: "u 8 wittenau in blauen westen höhe osloer"
-{"stationName": "osloer", "directionName": "wittenau"}
-
-Message: "Gesundbrunnen clean on u8"
-{"stationName": "Gesundbrunnen", "directionName": null}
-
-Message: "M29 bus moritzplatz"
-{"stationName": "Moritzplatz", "directionName": null}
-
-Message: "3 Bos Jacken M29 Anhalter Bahnhof Richtung Hermannplatz"
-{"stationName": "Anhalter Bahnhof", "directionName": "Hermannplatz"}
-
-Message: "S3 nach ostbahnof"
-{"stationName": null, "directionName": "Ostbahnhof"}
-
-Message: "To Rathaus SPANDAU"
-{"stationName": null, "directionName": "Rathaus Spandau"}
-
-Message: "U7 Rathaus Neukölln 3x BOS just got off the train"
-{"stationName": "Rathaus Neukölln", "directionName": null}
-
-Message: "U6 Kaiserin Augusta 2x bos"
-{"stationName": "Kaiserin-Augusta-Straße", "directionName": null}
-
-Message: "Zoo Richtung Steglitz"
-{"stationName": "Zoo", "directionName": "Steglitz"}
-
-Message: "Hi, kann mir wer ein Ticket verkaufen?"
-{"stationName": null, "directionName": null}
-`
-
-export const BERLIN: CityConfig = {
+export const BERLIN_PUBLIC: PublicCityConfig = {
     slug: 'berlin',
     subdomain: 'berlin',
     displayName: 'Berlin',
@@ -90,26 +43,6 @@ export const BERLIN: CityConfig = {
             bus: '#95276E', // VBB MetroBus purple, one shared color for all bus lines.
         },
         defaultLineColor: '#000000',
-    },
-    telegram: {
-        inspectorKeywords: 'Kontrolleur, BVG-Kontrolle, BOS, BW, Blauwesten, Zivilkontrolle, blaue Westen',
-        // MetroBus (M11-M85) IS tracked, so it must not be listed here; what stays
-        // outside the network is the rest of the BVG bus system.
-        untrackedLinesNote:
-            'Sightings on OTHER lines (X-lines, three-digit bus lines, night buses, ' +
-            'replacement services) are still reports if a station name is mentioned — ' +
-            'extract the station (bus stops are named after the nearby U/S station).',
-        circularLineAlias: 'Ringbahn',
-        circularLinePattern: String.raw`(?<![A-Za-z])(?:s[-\s]?)?ring(?:bahn)?`,
-        abbreviations: [
-            [String.raw`straße`, 'strasse'],
-            [String.raw`str\.?(?=\s|$|\/|,|\)|-)`, 'strasse'],
-            [String.raw`str$`, 'strasse'],
-            [String.raw`\bbhf\.?\b`, 'bahnhof'],
-            [String.raw`\bhbf\.?\b`, 'hauptbahnhof'],
-            [String.raw`\bpl\.?\b`, 'platz'],
-        ],
-        promptExamples,
     },
     community: {
         telegramHandle: '@FreiFahren_BE',

--- a/packages/cities/src/hamburg.telegram.ts
+++ b/packages/cities/src/hamburg.telegram.ts
@@ -1,0 +1,74 @@
+import type { CityTelegramProfile } from './types'
+
+const promptExamples = `Message: "2 gelbwesten jungfernstieg am gleis richtung altona"
+{"stationName": "Jungfernstieg", "directionName": "Altona"}
+
+Message: "s3 hbf gerade losgefahren, 3 gelbwesten im ersten wagen richtung neugraben"
+{"stationName": "Hauptbahnhof", "directionName": "Neugraben"}
+
+Message: "zivis am kontrollieren in der s1 richtung wedel, jetzt jungfernstieg"
+{"stationName": "Jungfernstieg", "directionName": "Wedel"}
+
+Message: "2 kontrolleure in zivil an der bus-halte jungfernstieg ausgestiegen"
+{"stationName": "Jungfernstieg", "directionName": null}
+
+Message: "landungsbrücken clean"
+{"stationName": "Landungsbrücken", "directionName": null}
+
+Message: "hochbahn wache gerade hallerstraße aus der u1 richtung hbf ausgestiegen"
+{"stationName": "Hallerstraße", "directionName": null}
+
+Message: "bus 5 hbf richtung palmaille kontrolle"
+{"stationName": "Hauptbahnhof", "directionName": "Palmaille"}
+
+Message: "u2 berliner tor richtung niendorf markt"
+{"stationName": "Berliner Tor", "directionName": "Niendorf Markt"}
+
+Message: "s3 nach pinneberg, jetzt dammtor"
+{"stationName": "Dammtor", "directionName": "Pinneberg"}
+
+Message: "schlump 2 gelbwesten u2"
+{"stationName": "Schlump", "directionName": null}
+
+Message: "hbf clean auf der s1"
+{"stationName": "Hauptbahnhof", "directionName": null}
+
+Message: "gelbwesten barmbek richtung ohlsdorf"
+{"stationName": "Barmbek", "directionName": "Ohlsdorf"}
+
+Message: "weiß jemand ob die s4 fährt?"
+{"stationName": null, "directionName": null}
+
+Message: "Hi, kann mir wer ein Ticket verkaufen?"
+{"stationName": null, "directionName": null}
+`
+
+/**
+ * Hamburg's Telegram extraction profile. NEVER import this from frontend code — it carries
+ * report-extraction prompt engineering that must not ship in the client bundle. See the
+ * warning on `PublicCityConfig` in ./types.ts.
+ */
+export const HAMBURG_TELEGRAM: CityTelegramProfile = {
+    // Chosen from ~12k Hamburg group messages: "Gelbweste(n)" (the yellow hi-vis
+    // vests HVV/Hochbahn inspectors wear) dominates by far, well ahead of "Zivil"/
+    // "Zivi" (plainclothes) and formal "Kontrolleur". "Hochbahn Wache" also shows up
+    // regularly; formal "Prüfer" is nearly unused. Unlike Berlin/Leipzig, the "Nk"
+    // count shorthand ("3k") is rare here — people spell out "X gelbwesten"/"X mann".
+    inspectorKeywords:
+        'Gelbweste, Gelbwesten, gelbe Weste (the most common term — Hamburg\'s uniformed inspectors wear yellow hi-vis vests), Zivil, in Zivil, Zivi, Zivis, Zivikontrolle, Kontrolleur, Kontrolleure, Kontrolle, Hochbahn Wache, Hochbahn-Kontrolle, HVV-Kontrolle, Konti, Kontis, Prüfer, Fahrkartenkontrolle',
+    untrackedLinesNote:
+        'Sightings on OTHER lines (three-digit bus lines, night buses, express X-lines, ' +
+        'regional trains, replacement services) are still reports if a station name is mentioned — ' +
+        'extract the station (bus stops are named after the nearby U/S station).',
+    circularLineAlias: '',
+    circularLinePattern: '',
+    abbreviations: [
+        [String.raw`straße`, 'strasse'],
+        [String.raw`str\.?(?=\s|$|\/|,|\)|-)`, 'strasse'],
+        [String.raw`str$`, 'strasse'],
+        [String.raw`\bbhf\.?\b`, 'bahnhof'],
+        [String.raw`\bhbf\.?\b`, 'hauptbahnhof'],
+        [String.raw`\bpl\.?\b`, 'platz'],
+    ],
+    promptExamples,
+}

--- a/packages/cities/src/hamburg.ts
+++ b/packages/cities/src/hamburg.ts
@@ -1,50 +1,7 @@
-import type { CityConfig } from './types'
+import type { PublicCityConfig } from './types'
 import { CITY_DATABASES } from './databases'
 
-const promptExamples = `Message: "2 gelbwesten jungfernstieg am gleis richtung altona"
-{"stationName": "Jungfernstieg", "directionName": "Altona"}
-
-Message: "s3 hbf gerade losgefahren, 3 gelbwesten im ersten wagen richtung neugraben"
-{"stationName": "Hauptbahnhof", "directionName": "Neugraben"}
-
-Message: "zivis am kontrollieren in der s1 richtung wedel, jetzt jungfernstieg"
-{"stationName": "Jungfernstieg", "directionName": "Wedel"}
-
-Message: "2 kontrolleure in zivil an der bus-halte jungfernstieg ausgestiegen"
-{"stationName": "Jungfernstieg", "directionName": null}
-
-Message: "landungsbrücken clean"
-{"stationName": "Landungsbrücken", "directionName": null}
-
-Message: "hochbahn wache gerade hallerstraße aus der u1 richtung hbf ausgestiegen"
-{"stationName": "Hallerstraße", "directionName": null}
-
-Message: "bus 5 hbf richtung palmaille kontrolle"
-{"stationName": "Hauptbahnhof", "directionName": "Palmaille"}
-
-Message: "u2 berliner tor richtung niendorf markt"
-{"stationName": "Berliner Tor", "directionName": "Niendorf Markt"}
-
-Message: "s3 nach pinneberg, jetzt dammtor"
-{"stationName": "Dammtor", "directionName": "Pinneberg"}
-
-Message: "schlump 2 gelbwesten u2"
-{"stationName": "Schlump", "directionName": null}
-
-Message: "hbf clean auf der s1"
-{"stationName": "Hauptbahnhof", "directionName": null}
-
-Message: "gelbwesten barmbek richtung ohlsdorf"
-{"stationName": "Barmbek", "directionName": "Ohlsdorf"}
-
-Message: "weiß jemand ob die s4 fährt?"
-{"stationName": null, "directionName": null}
-
-Message: "Hi, kann mir wer ein Ticket verkaufen?"
-{"stationName": null, "directionName": null}
-`
-
-export const HAMBURG: CityConfig = {
+export const HAMBURG_PUBLIC: PublicCityConfig = {
     slug: 'hamburg',
     subdomain: 'hamburg',
     displayName: 'Hamburg',
@@ -83,30 +40,6 @@ export const HAMBURG: CityConfig = {
             bus: '#FA1E41',
         },
         defaultLineColor: '#000000',
-    },
-    telegram: {
-        // Chosen from ~12k Hamburg group messages: "Gelbweste(n)" (the yellow hi-vis
-        // vests HVV/Hochbahn inspectors wear) dominates by far, well ahead of "Zivil"/
-        // "Zivi" (plainclothes) and formal "Kontrolleur". "Hochbahn Wache" also shows up
-        // regularly; formal "Prüfer" is nearly unused. Unlike Berlin/Leipzig, the "Nk"
-        // count shorthand ("3k") is rare here — people spell out "X gelbwesten"/"X mann".
-        inspectorKeywords:
-            'Gelbweste, Gelbwesten, gelbe Weste (the most common term — Hamburg\'s uniformed inspectors wear yellow hi-vis vests), Zivil, in Zivil, Zivi, Zivis, Zivikontrolle, Kontrolleur, Kontrolleure, Kontrolle, Hochbahn Wache, Hochbahn-Kontrolle, HVV-Kontrolle, Konti, Kontis, Prüfer, Fahrkartenkontrolle',
-        untrackedLinesNote:
-            'Sightings on OTHER lines (three-digit bus lines, night buses, express X-lines, ' +
-            'regional trains, replacement services) are still reports if a station name is mentioned — ' +
-            'extract the station (bus stops are named after the nearby U/S station).',
-        circularLineAlias: '',
-        circularLinePattern: '',
-        abbreviations: [
-            [String.raw`straße`, 'strasse'],
-            [String.raw`str\.?(?=\s|$|\/|,|\)|-)`, 'strasse'],
-            [String.raw`str$`, 'strasse'],
-            [String.raw`\bbhf\.?\b`, 'bahnhof'],
-            [String.raw`\bhbf\.?\b`, 'hauptbahnhof'],
-            [String.raw`\bpl\.?\b`, 'platz'],
-        ],
-        promptExamples,
     },
     community: {
         telegramChatId: '-1202572205',

--- a/packages/cities/src/index.ts
+++ b/packages/cities/src/index.ts
@@ -1,19 +1,30 @@
-import { BERLIN } from './berlin'
-import { HAMBURG } from './hamburg'
-import { LEIPZIG } from './leipzig'
+import { BERLIN_PUBLIC } from './berlin'
+import { BERLIN_TELEGRAM } from './berlin.telegram'
+import { HAMBURG_PUBLIC } from './hamburg'
+import { HAMBURG_TELEGRAM } from './hamburg.telegram'
+import { LEIPZIG_PUBLIC } from './leipzig'
+import { LEIPZIG_TELEGRAM } from './leipzig.telegram'
 import type { CityConfig } from './types'
 
 export * from './types'
-export { BERLIN }
-export { HAMBURG }
-export { LEIPZIG }
+
+// Full configs, telegram profile included. BACKEND ONLY (api-worker, telegram-worker) — never
+// import these from packages/frontend-next. See the warning on `PublicCityConfig` in ./types.ts
+// and the frontend-safe entry point at ./public.ts.
+export const BERLIN: CityConfig = { ...BERLIN_PUBLIC, telegram: BERLIN_TELEGRAM }
+export const HAMBURG: CityConfig = { ...HAMBURG_PUBLIC, telegram: HAMBURG_TELEGRAM }
+export const LEIPZIG: CityConfig = { ...LEIPZIG_PUBLIC, telegram: LEIPZIG_TELEGRAM }
+
 export { CITY_DATABASES, CITY_DATABASE_SLUGS, getCityDatabase } from './databases'
 export type { CityDatabaseSlug } from './databases'
 
 /**
- * The city registry: the single source of truth for everything that differs
- * between cities. Keyed by slug. City is a runtime dimension resolved from the
- * hostname (frontend) or an explicit `?city=` param (API).
+ * The city registry: the single source of truth for everything that differs between cities.
+ * Keyed by slug. City is a runtime dimension resolved from the hostname (frontend) or an
+ * explicit `?city=` param (API).
+ *
+ * BACKEND ONLY — carries `telegram`. Frontend code must import `PUBLIC_CITIES` from
+ * `@freifahren/cities/public` instead.
  */
 export const CITIES = {
     berlin: BERLIN,
@@ -33,7 +44,7 @@ export const CITY_SLUGS = Object.keys(CITIES) as CitySlug[]
 
 export const isCitySlug = (value: string): value is CitySlug => Object.prototype.hasOwnProperty.call(CITIES, value)
 
-/** Look up a city by slug, or `undefined` if the slug is unknown. */
+/** Look up a city by slug, or `undefined` if the slug is unknown. BACKEND ONLY (see CITIES). */
 export const getCity = (slug: string): CityConfig | undefined => (isCitySlug(slug) ? CITIES[slug] : undefined)
 
 export const isExcludedLineRef = (ref: string, patterns: readonly string[] | undefined): boolean => {

--- a/packages/cities/src/leipzig.telegram.ts
+++ b/packages/cities/src/leipzig.telegram.ts
@@ -1,0 +1,70 @@
+import type { CityTelegramProfile } from './types'
+
+const promptExamples = `Message: "3k Haltestelle Zoo Richtung gohlis"
+{"stationName": "Zoo", "directionName": "Gohlis"}
+
+Message: "linie 1 hbf richt lausen 3 kontrolleure"
+{"stationName": "Hauptbahnhof", "directionName": "Lausen"}
+
+Message: "lvb kontrolle in der 16 messe richtung lößnig"
+{"stationName": "Messegelände", "directionName": "Lößnig"}
+
+Message: "2k in der 10 nach wahren, jetzt wilhelm-leuschner-platz"
+{"stationName": "Wilhelm-Leuschner-Platz", "directionName": "Wahren"}
+
+Message: "7 richtung böhlitz-ehrenberg, gerade augustusplatz"
+{"stationName": "Augustusplatz", "directionName": "Böhlitz-Ehrenberg"}
+
+Message: "s3 am bayerischen bahnhof prüfer eingestiegen"
+{"stationName": "Bayerischer Bahnhof", "directionName": null}
+
+Message: "11 connewitz 2 fahrkartenkontrolleure"
+{"stationName": "Connewitzer Kreuz", "directionName": null}
+
+Message: "hbf clean"
+{"stationName": "Hauptbahnhof", "directionName": null}
+
+Message: "3k stieglitzstraße richtung innenstadt"
+{"stationName": "Stieglitzstraße", "directionName": null}
+
+Message: "2k südplatz stadteinwärts"
+{"stationName": "Südplatz", "directionName": null}
+
+Message: "automat im ersten wagen kaputt, gerade johannisplatz"
+{"stationName": null, "directionName": null}
+
+Message: "fährt die 70 wieder übers kreuz?"
+{"stationName": null, "directionName": null}
+
+Message: "weiß jemand ob heute noch kontrolliert wird?"
+{"stationName": null, "directionName": null}
+`
+
+/**
+ * Leipzig's Telegram extraction profile. NEVER import this from frontend code — it carries
+ * report-extraction prompt engineering that must not ship in the client bundle. See the
+ * warning on `PublicCityConfig` in ./types.ts.
+ */
+export const LEIPZIG_TELEGRAM: CityTelegramProfile = {
+    // Chosen from ~60k Leipzig group messages: the "3k" shorthand, "uniformiert" and
+    // "zivil" dominate; formal "Prüfer"/"Fahrausweisprüfung" are effectively absent.
+    // Police terms are intentionally excluded (police are not ticket inspectors).
+    inspectorKeywords:
+        'K (for example "3k" means three ticket inspectors), Kontrolleur, Kontrolleure, Kontrolle, Konti, Kontis, Kontrolletti, Kontrollettis, uniformiert, Uniform, Zivil, in Zivil, LVB-Kontrolle, Fahrkartenkontrolle',
+    // LVB's tram and bus network is seeded in full, so only the deliberately
+    // excluded S-Bahn/regional operators fall outside it.
+    untrackedLinesNote:
+        'Sightings on OTHER lines (S-Bahn, regional trains, replacement services) are ' +
+        'still reports if a station name is mentioned — extract the station.',
+    circularLineAlias: '',
+    circularLinePattern: '',
+    abbreviations: [
+        [String.raw`straße`, 'strasse'],
+        [String.raw`str\.?(?=\s|$|\/|,|\)|-)`, 'strasse'],
+        [String.raw`str$`, 'strasse'],
+        [String.raw`\bbhf\.?\b`, 'bahnhof'],
+        [String.raw`\bhbf\.?\b`, 'hauptbahnhof'],
+        [String.raw`\bpl\.?\b`, 'platz'],
+    ],
+    promptExamples,
+}

--- a/packages/cities/src/leipzig.ts
+++ b/packages/cities/src/leipzig.ts
@@ -1,47 +1,7 @@
 import { CITY_DATABASES } from './databases'
-import type { CityConfig } from './types'
+import type { PublicCityConfig } from './types'
 
-const promptExamples = `Message: "3k Haltestelle Zoo Richtung gohlis"
-{"stationName": "Zoo", "directionName": "Gohlis"}
-
-Message: "linie 1 hbf richt lausen 3 kontrolleure"
-{"stationName": "Hauptbahnhof", "directionName": "Lausen"}
-
-Message: "lvb kontrolle in der 16 messe richtung lößnig"
-{"stationName": "Messegelände", "directionName": "Lößnig"}
-
-Message: "2k in der 10 nach wahren, jetzt wilhelm-leuschner-platz"
-{"stationName": "Wilhelm-Leuschner-Platz", "directionName": "Wahren"}
-
-Message: "7 richtung böhlitz-ehrenberg, gerade augustusplatz"
-{"stationName": "Augustusplatz", "directionName": "Böhlitz-Ehrenberg"}
-
-Message: "s3 am bayerischen bahnhof prüfer eingestiegen"
-{"stationName": "Bayerischer Bahnhof", "directionName": null}
-
-Message: "11 connewitz 2 fahrkartenkontrolleure"
-{"stationName": "Connewitzer Kreuz", "directionName": null}
-
-Message: "hbf clean"
-{"stationName": "Hauptbahnhof", "directionName": null}
-
-Message: "3k stieglitzstraße richtung innenstadt"
-{"stationName": "Stieglitzstraße", "directionName": null}
-
-Message: "2k südplatz stadteinwärts"
-{"stationName": "Südplatz", "directionName": null}
-
-Message: "automat im ersten wagen kaputt, gerade johannisplatz"
-{"stationName": null, "directionName": null}
-
-Message: "fährt die 70 wieder übers kreuz?"
-{"stationName": null, "directionName": null}
-
-Message: "weiß jemand ob heute noch kontrolliert wird?"
-{"stationName": null, "directionName": null}
-`
-
-export const LEIPZIG: CityConfig = {
+export const LEIPZIG_PUBLIC: PublicCityConfig = {
     slug: 'leipzig',
     subdomain: 'leipzig',
     displayName: 'Leipzig',
@@ -86,29 +46,6 @@ export const LEIPZIG: CityConfig = {
             String.raw`^Messe Transport$`,
             String.raw`^108$`,
         ],
-    },
-    telegram: {
-        // Chosen from ~60k Leipzig group messages: the "3k" shorthand, "uniformiert" and
-        // "zivil" dominate; formal "Prüfer"/"Fahrausweisprüfung" are effectively absent.
-        // Police terms are intentionally excluded (police are not ticket inspectors).
-        inspectorKeywords:
-            'K (for example "3k" means three ticket inspectors), Kontrolleur, Kontrolleure, Kontrolle, Konti, Kontis, Kontrolletti, Kontrollettis, uniformiert, Uniform, Zivil, in Zivil, LVB-Kontrolle, Fahrkartenkontrolle',
-        // LVB's tram and bus network is seeded in full, so only the deliberately
-        // excluded S-Bahn/regional operators fall outside it.
-        untrackedLinesNote:
-            'Sightings on OTHER lines (S-Bahn, regional trains, replacement services) are ' +
-            'still reports if a station name is mentioned — extract the station.',
-        circularLineAlias: '',
-        circularLinePattern: '',
-        abbreviations: [
-            [String.raw`straße`, 'strasse'],
-            [String.raw`str\.?(?=\s|$|\/|,|\)|-)`, 'strasse'],
-            [String.raw`str$`, 'strasse'],
-            [String.raw`\bbhf\.?\b`, 'bahnhof'],
-            [String.raw`\bhbf\.?\b`, 'hauptbahnhof'],
-            [String.raw`\bpl\.?\b`, 'platz'],
-        ],
-        promptExamples,
     },
     community: {
         telegramHandle: '@freifahren_leipzig',

--- a/packages/cities/src/public.ts
+++ b/packages/cities/src/public.ts
@@ -1,0 +1,35 @@
+// Frontend-safe entry point. Import from here (`@freifahren/cities/public`), never from the
+// package root (`@freifahren/cities`) — the root re-exports the full `CityConfig`, including
+// `telegram` (report-extraction prompt engineering), which a bundler will embed verbatim in
+// the client JS the moment anything in this module graph is imported. This file's import graph
+// touches only the `*_PUBLIC` halves of each city — never `./berlin.telegram`,
+// `./hamburg.telegram`, or `./leipzig.telegram` — so that data can never reach a browser
+// through this path even transitively.
+import { BERLIN_PUBLIC } from './berlin'
+import { HAMBURG_PUBLIC } from './hamburg'
+import { LEIPZIG_PUBLIC } from './leipzig'
+import type { PublicCityConfig } from './types'
+
+export type { PublicCityConfig } from './types'
+
+// Deliberately NOT imported from ./index — importing anything from that module, even a type,
+// risks a future edit turning it into a real runtime import and pulling the telegram profiles
+// back into this graph. Keep this file's imports limited to the `*_PUBLIC` values above.
+export const PUBLIC_CITY_SLUGS = ['berlin', 'hamburg', 'leipzig'] as const
+
+export const PUBLIC_CITIES = {
+    berlin: BERLIN_PUBLIC,
+    hamburg: HAMBURG_PUBLIC,
+    leipzig: LEIPZIG_PUBLIC,
+} as const satisfies Record<(typeof PUBLIC_CITY_SLUGS)[number], PublicCityConfig>
+
+export type PublicCitySlug = keyof typeof PUBLIC_CITIES
+
+export const DEFAULT_CITY_SLUG = 'berlin' as const
+
+const isPublicCitySlug = (value: string): value is keyof typeof PUBLIC_CITIES =>
+    Object.prototype.hasOwnProperty.call(PUBLIC_CITIES, value)
+
+/** Look up the frontend-safe view of a city, or `undefined` if the slug is unknown. */
+export const getPublicCity = (slug: string): PublicCityConfig | undefined =>
+    isPublicCitySlug(slug) ? PUBLIC_CITIES[slug] : undefined

--- a/packages/cities/src/types.ts
+++ b/packages/cities/src/types.ts
@@ -170,6 +170,16 @@ export interface CityConfig extends CityDatabaseConfig {
     community: CityCommunity
 }
 
+/**
+ * Everything about a city EXCEPT `telegram`. `telegram` carries report-extraction prompt
+ * engineering (inspector keywords, few-shot examples) that must never reach a browser — a
+ * bundler can't tree-shake individual properties off an object literal that's otherwise used,
+ * so any frontend import of the full `CityConfig` embeds it verbatim in the shipped JS.
+ * Frontend code must only ever import this type (and the `PUBLIC_CITIES`/`getPublicCity`
+ * values in ./public.ts), never `CityConfig`/`CITIES`/`getCity`/`BERLIN`/`HAMBURG`/`LEIPZIG`.
+ */
+export type PublicCityConfig = Omit<CityConfig, 'telegram'>
+
 /** The D1 resources provisioned for each city. */
 export interface CityDatabaseConfig {
     /** D1 database name. */

--- a/packages/frontend-next/src/lib/city-for-position.ts
+++ b/packages/frontend-next/src/lib/city-for-position.ts
@@ -1,11 +1,11 @@
-import type { CityConfig } from '@freifahren/cities';
+import type { PublicCityConfig } from '@freifahren/cities/public';
 
-function pointInBounds(lng: number, lat: number, city: CityConfig): boolean {
+function pointInBounds(lng: number, lat: number, city: PublicCityConfig): boolean {
   const [west, south, east, north] = city.map.bounds;
   return lng >= west && lng <= east && lat >= south && lat <= north;
 }
 
-function distanceToCenter(lng: number, lat: number, city: CityConfig): number {
+function distanceToCenter(lng: number, lat: number, city: PublicCityConfig): number {
   const [centerLng, centerLat] = city.map.center;
   const dLng = lng - centerLng;
   const dLat = lat - centerLat;
@@ -15,8 +15,8 @@ function distanceToCenter(lng: number, lat: number, city: CityConfig): number {
 export function cityForPosition(
   lng: number,
   lat: number,
-  cities: readonly CityConfig[],
-): CityConfig | null {
+  cities: readonly PublicCityConfig[],
+): PublicCityConfig | null {
   const matches = cities.filter((city) => pointInBounds(lng, lat, city));
   if (matches.length === 0) return null;
   return matches.reduce((closest, city) =>

--- a/packages/frontend-next/src/lib/city-switching.ts
+++ b/packages/frontend-next/src/lib/city-switching.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from 'react';
 
-import { CITIES, type CityConfig } from '@freifahren/cities';
+import { PUBLIC_CITIES, type PublicCityConfig } from '@freifahren/cities/public';
 
 import { FEATURE_FLAGS, getFeatureFlag, subscribeToFeatureFlags } from '@/lib/feature-flags';
 import { isPreviewBuild } from '@/lib/utils';
@@ -11,7 +11,7 @@ import { isPreviewBuild } from '@/lib/utils';
 
 const includeUnlistedCities = import.meta.env.DEV || isPreviewBuild;
 
-export const selectableCities: CityConfig[] = Object.values(CITIES).filter(
+export const selectableCities: PublicCityConfig[] = Object.values(PUBLIC_CITIES).filter(
   (city) => city.listed !== false || includeUnlistedCities,
 );
 

--- a/packages/frontend-next/src/lib/city.ts
+++ b/packages/frontend-next/src/lib/city.ts
@@ -1,5 +1,5 @@
 import { Capacitor } from '@capacitor/core';
-import { CITIES, DEFAULT_CITY_SLUG, getCity, type CityConfig } from '@freifahren/cities';
+import { DEFAULT_CITY_SLUG, PUBLIC_CITIES, getPublicCity, type PublicCityConfig } from '@freifahren/cities/public';
 
 import {
   RESET_AUTO_SWITCH_PARAM,
@@ -18,30 +18,30 @@ import { isPreviewBuild } from '@/lib/utils';
 // and by `?city=` on a preview. Unset (fresh install mid-onboarding) falls back to the default.
 const CITY_PREFERENCE_KEY = 'freifahren.city';
 
-const defaultCity = (): CityConfig => getCity(DEFAULT_CITY_SLUG) as CityConfig;
+const defaultCity = (): PublicCityConfig => getPublicCity(DEFAULT_CITY_SLUG) as PublicCityConfig;
 
 // Native (Capacitor): the WebView origin is capacitor://localhost, so the hostname can't
 // select a city. Resolve from a persisted preference instead (localStorage is synchronous and
 // available in the WebView); the onboarding flow writes it and reloads on change.
-const resolveNativeCity = (): CityConfig => {
+const resolveNativeCity = (): PublicCityConfig => {
   const stored = safeLocalStorage.getItem(CITY_PREFERENCE_KEY);
-  return (stored ? getCity(stored) : undefined) ?? defaultCity();
+  return (stored ? getPublicCity(stored) : undefined) ?? defaultCity();
 };
 
 // Preview: one workers.dev host serves every city, so `?city=` selects one and is persisted, which
 // keeps it across the reload a switch performs and across in-app navigation that drops the query.
-const resolvePreviewCity = (): CityConfig | undefined => {
+const resolvePreviewCity = (): PublicCityConfig | undefined => {
   if (typeof location === 'undefined') return undefined;
 
   const requested = new URLSearchParams(location.search).get('city');
-  const city = requested ? getCity(requested) : undefined;
+  const city = requested ? getPublicCity(requested) : undefined;
   if (city) {
     safeLocalStorage.setItem(CITY_PREFERENCE_KEY, city.slug);
     return city;
   }
 
   const stored = safeLocalStorage.getItem(CITY_PREFERENCE_KEY);
-  return stored ? getCity(stored) : undefined;
+  return stored ? getPublicCity(stored) : undefined;
 };
 
 const isLocalhost = (hostname: string): boolean =>
@@ -49,15 +49,15 @@ const isLocalhost = (hostname: string): boolean =>
 
 // Web: the subdomain selects the city (berlin.freifahren.org -> berlin). Unknown hosts
 // (freifahren.org, app./www., localhost) fall back to the default.
-const resolveWebCity = (hostname: string): CityConfig => {
+const resolveWebCity = (hostname: string): PublicCityConfig => {
   const preview = isPreviewBuild ? resolvePreviewCity() : undefined;
   if (preview) return preview;
 
   const label = hostname.split('.')[0];
-  return Object.values(CITIES).find((city) => city.subdomain === label) ?? defaultCity();
+  return Object.values(PUBLIC_CITIES).find((city) => city.subdomain === label) ?? defaultCity();
 };
 
-export function hostForCity(hostname: string, city: CityConfig): string {
+export function hostForCity(hostname: string, city: PublicCityConfig): string {
   if (isLocalhost(hostname)) {
     return city.slug === DEFAULT_CITY_SLUG ? 'localhost' : `${city.subdomain}.localhost`;
   }
@@ -67,7 +67,7 @@ export function hostForCity(hostname: string, city: CityConfig): string {
   return [city.subdomain, ...labels.slice(1)].join('.');
 }
 
-export function urlForCity(city: CityConfig, options?: { resetAutoSwitch?: boolean }): string {
+export function urlForCity(city: PublicCityConfig, options?: { resetAutoSwitch?: boolean }): string {
   const { protocol, hostname, port, pathname, search } = window.location;
   const params = new URLSearchParams(search);
   if (isPreviewBuild) params.set('city', city.slug);
@@ -78,7 +78,7 @@ export function urlForCity(city: CityConfig, options?: { resetAutoSwitch?: boole
   return `${protocol}//${host}${port ? `:${port}` : ''}${pathname}${query ? `?${query}` : ''}`;
 }
 
-export function navigateToCity(city: CityConfig, options?: { resetAutoSwitch?: boolean }): void {
+export function navigateToCity(city: PublicCityConfig, options?: { resetAutoSwitch?: boolean }): void {
   if (options?.resetAutoSwitch) {
     clearAutoSwitchCityPreference();
     markResetAutoSwitchCity();
@@ -92,7 +92,7 @@ export function navigateToCity(city: CityConfig, options?: { resetAutoSwitch?: b
 
 // The active city for this session. The resolution source is pluggable (stored preference on
 // native, hostname on web); the resolved city is fixed once the app boots.
-export const currentCity: CityConfig = Capacitor.isNativePlatform()
+export const currentCity: PublicCityConfig = Capacitor.isNativePlatform()
   ? resolveNativeCity()
   : resolveWebCity(typeof location !== 'undefined' ? location.hostname : '');
 

--- a/packages/frontend-next/src/lib/city.ts
+++ b/packages/frontend-next/src/lib/city.ts
@@ -1,5 +1,10 @@
 import { Capacitor } from '@capacitor/core';
-import { DEFAULT_CITY_SLUG, PUBLIC_CITIES, getPublicCity, type PublicCityConfig } from '@freifahren/cities/public';
+import {
+  DEFAULT_CITY_SLUG,
+  PUBLIC_CITIES,
+  getPublicCity,
+  type PublicCityConfig,
+} from '@freifahren/cities/public';
 
 import {
   RESET_AUTO_SWITCH_PARAM,
@@ -67,7 +72,10 @@ export function hostForCity(hostname: string, city: PublicCityConfig): string {
   return [city.subdomain, ...labels.slice(1)].join('.');
 }
 
-export function urlForCity(city: PublicCityConfig, options?: { resetAutoSwitch?: boolean }): string {
+export function urlForCity(
+  city: PublicCityConfig,
+  options?: { resetAutoSwitch?: boolean },
+): string {
   const { protocol, hostname, port, pathname, search } = window.location;
   const params = new URLSearchParams(search);
   if (isPreviewBuild) params.set('city', city.slug);
@@ -78,7 +86,10 @@ export function urlForCity(city: PublicCityConfig, options?: { resetAutoSwitch?:
   return `${protocol}//${host}${port ? `:${port}` : ''}${pathname}${query ? `?${query}` : ''}`;
 }
 
-export function navigateToCity(city: PublicCityConfig, options?: { resetAutoSwitch?: boolean }): void {
+export function navigateToCity(
+  city: PublicCityConfig,
+  options?: { resetAutoSwitch?: boolean },
+): void {
   if (options?.resetAutoSwitch) {
     clearAutoSwitchCityPreference();
     markResetAutoSwitchCity();

--- a/packages/frontend-next/src/lib/reporters.ts
+++ b/packages/frontend-next/src/lib/reporters.ts
@@ -1,7 +1,7 @@
-import type { CityConfig } from '@freifahren/cities';
+import type { PublicCityConfig } from '@freifahren/cities/public';
 
 // Fabricated social-proof count — the app has no real user metric.
-export const pickReporterCount = (city: CityConfig): number | null => {
+export const pickReporterCount = (city: PublicCityConfig): number | null => {
   const range = city.community.reporterCount;
   if (range === undefined) {
     return null;

--- a/packages/frontend-next/tsconfig.app.json
+++ b/packages/frontend-next/tsconfig.app.json
@@ -24,7 +24,8 @@
     /* Path aliases */
     "paths": {
       "@/*": ["./src/*"],
-      "@freifahren/cities": ["../cities/src/index.ts"]
+      "@freifahren/cities": ["../cities/src/index.ts"],
+      "@freifahren/cities/public": ["../cities/src/public.ts"]
     }
   },
   "include": ["src"]

--- a/packages/frontend-next/tsconfig.json
+++ b/packages/frontend-next/tsconfig.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"],
-      "@freifahren/cities": ["../cities/src/index.ts"]
+      "@freifahren/cities": ["../cities/src/index.ts"],
+      "@freifahren/cities/public": ["../cities/src/public.ts"]
     }
   }
 }

--- a/packages/frontend-next/vite.config.ts
+++ b/packages/frontend-next/vite.config.ts
@@ -214,8 +214,15 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
-      // Shared city registry (small static data), bundled into the client. Vite does not
-      // read tsconfig `paths`, so the alias is declared here too.
+      // Frontend-safe city registry subset (no `telegram` prompt data — see the warning on
+      // `PublicCityConfig` in packages/cities/src/types.ts). Declared BEFORE the plain
+      // '@freifahren/cities' alias below: alias matching is prefix-based and first-match-wins,
+      // so the more specific path must come first or it would resolve through the full-config
+      // alias instead (`.../index.ts/public`, which doesn't exist). Vite does not read tsconfig
+      // `paths`, so the alias is declared here too.
+      '@freifahren/cities/public': path.resolve(__dirname, '../cities/src/public.ts'),
+      // Full city registry incl. `telegram`. BACKEND ONLY — must never be imported from
+      // frontend-next source; import '@freifahren/cities/public' instead.
       '@freifahren/cities': path.resolve(__dirname, '../cities/src/index.ts'),
     },
   },

--- a/packages/telegram-worker/evals/run.ts
+++ b/packages/telegram-worker/evals/run.ts
@@ -278,7 +278,11 @@ async function extractWithRetry(
         } catch (exc) {
             last = exc
             const msg = exc instanceof Error ? exc.message : String(exc)
-            if (!/\b429\b|\b5\d\d\b|timeout|timed out|fetch failed|network|ECONNRESET/i.test(msg)) {
+            if (
+                !/\b429\b|\b5\d\d\b|timeout|timed out|fetch failed|network|ECONNRESET|ENOTFOUND|getaddrinfo|EAI_AGAIN/i.test(
+                    msg
+                )
+            ) {
                 throw exc
             }
             await sleep(Math.min(20000, 1000 * 2 ** i) + Math.floor(Math.random() * 400))

--- a/packages/telegram-worker/evals/shared.ts
+++ b/packages/telegram-worker/evals/shared.ts
@@ -63,7 +63,11 @@ export async function extractWithRetry(
         } catch (exc) {
             last = exc
             const msg = exc instanceof Error ? exc.message : String(exc)
-            if (!/\b429\b|\b5\d\d\b|timeout|timed out|fetch failed|network|ECONNRESET/i.test(msg)) {
+            if (
+                !/\b429\b|\b5\d\d\b|timeout|timed out|fetch failed|network|ECONNRESET|ENOTFOUND|getaddrinfo|EAI_AGAIN/i.test(
+                    msg
+                )
+            ) {
                 throw exc
             }
             await sleep(Math.min(20000, 1000 * 2 ** i) + Math.floor(Math.random() * 400))

--- a/packages/telegram-worker/src/config.ts
+++ b/packages/telegram-worker/src/config.ts
@@ -49,6 +49,10 @@ const GERMAN_GENERIC_NON_STATION_WORDS: ReadonlySet<string> = new Set([
     'sueden',
     'osten',
     'westen',
+    // English loanword for "downtown" (seen in Hamburg chats as "Richtung City") — without
+    // this it fuzzy-matches into any station whose name happens to contain "City"
+    // (e.g. Hamburg's "Rübenkamp (City Nord)").
+    'city',
 ])
 
 /**

--- a/packages/telegram-worker/src/extractor.ts
+++ b/packages/telegram-worker/src/extractor.ts
@@ -452,6 +452,9 @@ export function buildSystemPrompt(index: TransitIndex, profile: CityProfile): st
         'are reports. Typos, slang, and language mixing are normal.\n' +
         '- For clear non-reports (spam/ads, questions, ticket sales, social chitchat with no ' +
         'location, off-topic banter), set both fields to null.\n' +
+        '- General police presence, traffic stops, protests, demos, or political content are NOT ' +
+        'ticket-inspector sightings even if a station or words like "Bullen"/"Wannen"/"Cops" appear — ' +
+        'set both fields to null unless a fare-inspection cue is also present.\n' +
         '- stationName: the station the user is currently at. Copy it as written, including typos. ' +
         'If the user gives a CURRENT station and a DIRECTION ("U7 Rathaus Spandau Richtung Rudow ' +
         'höhe Neukölln" / "u8 wittenau höhe osloer"), the CURRENT station is the one near a word ' +


### PR DESCRIPTION
## Summary
- The frontend imports the full `CityConfig` object for map bounds/community info/etc. Bundlers can't tree-shake individual properties off an object literal that's otherwise used, so the `telegram` field (Mistral inspector-keyword lists + few-shot prompt examples for Berlin/Hamburg/Leipzig) was shipping verbatim in the public JS bundle — readable by anyone via devtools, independent of repo visibility. Confirmed with a real `vite build` grep before/after.
- Splits `packages/cities` into a frontend-safe half (`*_PUBLIC`, exported from a new `@freifahren/cities/public` entry point) and a telegram-only half (`*.telegram.ts`, backend-only). Root `@freifahren/cities` still exports the full merged `CityConfig` for api-worker/telegram-worker. Updated the 4 frontend-next modules that read city config, plus the tsconfig paths + Vite alias that duplicate the package's exports map for this workspace.
- Small fixes found while finishing the Hamburg Telegram-history eval/import pass:
  - Add `"city"` to the generic-non-station-word list (fixed a fuzzy-match false positive: "Richtung City" resolved to Hamburg's "Rübenkamp (City Nord)").
  - Add an explicit non-report rule for general police/protest/political content in the extraction prompt — the Hamburg source Telegram group is topically broader (police/demos) than a pure fare-control channel.
  - Treat DNS blips (`ENOTFOUND`/`getaddrinfo`/`EAI_AGAIN`) as retryable in the eval harness, not just 429/5xx/timeout.
  - Allow `db:import-telegram` for `hamburg`, not just `leipzig`.

## Test plan
- [x] `bun x tsc --noEmit` clean in `packages/cities`, `packages/telegram-worker`, `packages/api-worker` (no cities/CityConfig-related errors)
- [x] `bun run build` in `packages/frontend-next` succeeds; `grep`ing `dist/` for `Gelbwesten`/`inspectorKeywords`/`promptExamples`/etc. now returns nothing (previously present)
- [x] `packages/telegram-worker`: 61/61 tests pass
- [x] `packages/api-worker`: 257/257 tests pass