### PR TITLE
feat: prompt for city expansion when outside covered networks

### DIFF
--- a/packages/frontend-next/src/components/map/city-location-prompt.i18n.ts
+++ b/packages/frontend-next/src/components/map/city-location-prompt.i18n.ts
@@ -9,6 +9,11 @@ i18n.addResourceBundle('en', NAMESPACE, {
   switch: 'Switch',
   stay: 'Stay here',
   remember: 'Remember this choice',
+  expansionTitle: 'Want FreiFahren in your city?',
+  expansionDescription:
+    'You are outside the cities FreiFahren currently covers. Would you like FreiFahren where you live?',
+  expansionCta: 'Yes, tell me more',
+  expansionStay: 'Not now',
 });
 
 i18n.addResourceBundle('de', NAMESPACE, {
@@ -18,4 +23,9 @@ i18n.addResourceBundle('de', NAMESPACE, {
   switch: 'Wechseln',
   stay: 'Hier bleiben',
   remember: 'Diese Auswahl merken',
+  expansionTitle: 'FreiFahren auch in deiner Stadt?',
+  expansionDescription:
+    'Du bist außerhalb der Städte, die FreiFahren gerade abdeckt. Möchtest du FreiFahren auch bei dir haben?',
+  expansionCta: 'Ja, mehr erfahren',
+  expansionStay: 'Nicht jetzt',
 });

--- a/packages/frontend-next/src/components/map/city-location-prompt.tsx
+++ b/packages/frontend-next/src/components/map/city-location-prompt.tsx
@@ -12,41 +12,48 @@ import { PopupCard } from './PopupCard';
 
 export function CityLocationPrompt() {
   const { t } = useTranslation(NAMESPACE);
-  const { promptCity, accept, decline } = useCityLocationPrompt();
+  const { promptCity, showExpansion, accept, decline } = useCityLocationPrompt();
   const [remember, setRemember] = useState(false);
 
-  if (promptCity === null) return null;
+  if (!showExpansion && promptCity === null) return null;
+
+  const title = showExpansion
+    ? t('expansionTitle')
+    : t('title', { city: promptCity?.displayName });
+  const description = showExpansion
+    ? t('expansionDescription')
+    : t('description', { city: promptCity?.displayName });
 
   return createPortal(
     <PopupCard>
       <CardContent className="flex flex-col gap-1">
         <h2 className="font-heading flex items-center gap-2 text-lg font-semibold">
           <MapPin className="text-accent-bright size-5" />
-          {t('title', { city: promptCity.displayName })}
+          {title}
         </h2>
-        <p className="text-muted-foreground text-sm">
-          {t('description', { city: promptCity.displayName })}
-        </p>
+        <p className="text-muted-foreground text-sm">{description}</p>
       </CardContent>
       <CardFooter className="flex-col items-stretch gap-3">
-        <label className="text-muted-foreground flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={remember}
-            onChange={(e) => setRemember(e.target.checked)}
-            className="accent-accent-bright size-4 shrink-0 rounded border"
-          />
-          {t('remember')}
-        </label>
+        {promptCity !== null && (
+          <label className="text-muted-foreground flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={remember}
+              onChange={(e) => setRemember(e.target.checked)}
+              className="accent-accent-bright size-4 shrink-0 rounded border"
+            />
+            {t('remember')}
+          </label>
+        )}
         <div className="flex gap-2">
           <Button variant="outline" className="flex-1" onClick={() => decline(remember)}>
-            {t('stay')}
+            {showExpansion ? t('expansionStay') : t('stay')}
           </Button>
           <Button
             className="bg-accent-bright text-primary-foreground hover:bg-accent-press flex-1"
             onClick={() => accept(remember)}
           >
-            {t('switch')}
+            {showExpansion ? t('expansionCta') : t('switch')}
           </Button>
         </div>
       </CardFooter>

--- a/packages/frontend-next/src/components/map/city-location-prompt.tsx
+++ b/packages/frontend-next/src/components/map/city-location-prompt.tsx
@@ -17,9 +17,7 @@ export function CityLocationPrompt() {
 
   if (!showExpansion && promptCity === null) return null;
 
-  const title = showExpansion
-    ? t('expansionTitle')
-    : t('title', { city: promptCity?.displayName });
+  const title = showExpansion ? t('expansionTitle') : t('title', { city: promptCity?.displayName });
   const description = showExpansion
     ? t('expansionDescription')
     : t('description', { city: promptCity?.displayName });

--- a/packages/frontend-next/src/hooks/use-city-location-prompt.ts
+++ b/packages/frontend-next/src/hooks/use-city-location-prompt.ts
@@ -53,10 +53,8 @@ export function useCityLocationPrompt() {
   const switchBlocked = !enabled || !onboarded || sessionDismissed || overlaysOpen;
   const promptCity = switchBlocked || mismatch === null || preference !== null ? null : mismatch;
 
-  const expansionBlocked =
-    !onboarded || sessionDismissed || overlaysOpen || promptCity !== null;
-  const showExpansion =
-    !expansionBlocked && hasAccuratePosition && locatedCity === null;
+  const expansionBlocked = !onboarded || sessionDismissed || overlaysOpen || promptCity !== null;
+  const showExpansion = !expansionBlocked && hasAccuratePosition && locatedCity === null;
 
   useEffect(() => {
     if (switchBlocked || mismatch === null || preference !== 'always' || switchedRef.current)

--- a/packages/frontend-next/src/hooks/use-city-location-prompt.ts
+++ b/packages/frontend-next/src/hooks/use-city-location-prompt.ts
@@ -7,6 +7,7 @@ import {
   setAutoSwitchCityPreference,
   type AutoSwitchCityPreference,
 } from '@/lib/auto-switch-city';
+import { CITY_EXPANSION_URL } from '@/lib/city-expansion-prompt';
 import { currentCitySlug, navigateToCity } from '@/lib/city';
 import { cityForPosition } from '@/lib/city-for-position';
 import { selectableCities, useCitySwitchingEnabled } from '@/lib/city-switching';
@@ -37,30 +38,33 @@ export function useCityLocationPrompt() {
   const switchedRef = useRef(false);
   const shownForRef = useRef<string | null>(null);
 
-  const blocked =
-    !enabled ||
-    !onboarded ||
-    sessionDismissed ||
-    locationPrompt !== null ||
-    contributeOpen ||
-    consentVisible;
+  const overlaysOpen = locationPrompt !== null || contributeOpen || consentVisible;
 
-  const locatedCity =
-    position === null || (accuracy !== null && accuracy > MAX_ACCURACY_METERS)
-      ? null
-      : cityForPosition(position.lng, position.lat, selectableCities);
+  const hasAccuratePosition =
+    position !== null && (accuracy === null || accuracy <= MAX_ACCURACY_METERS);
+
+  const locatedCity = hasAccuratePosition
+    ? cityForPosition(position.lng, position.lat, selectableCities)
+    : null;
 
   const mismatch =
     locatedCity !== null && locatedCity.slug !== currentCitySlug ? locatedCity : null;
 
-  const promptCity = blocked || mismatch === null || preference !== null ? null : mismatch;
+  const switchBlocked = !enabled || !onboarded || sessionDismissed || overlaysOpen;
+  const promptCity = switchBlocked || mismatch === null || preference !== null ? null : mismatch;
+
+  const expansionBlocked =
+    !onboarded || sessionDismissed || overlaysOpen || promptCity !== null;
+  const showExpansion =
+    !expansionBlocked && hasAccuratePosition && locatedCity === null;
 
   useEffect(() => {
-    if (blocked || mismatch === null || preference !== 'always' || switchedRef.current) return;
+    if (switchBlocked || mismatch === null || preference !== 'always' || switchedRef.current)
+      return;
     switchedRef.current = true;
     track('city_location_auto_switched', { from: currentCitySlug, to: mismatch.slug });
     navigateToCity(mismatch);
-  }, [blocked, mismatch, preference]);
+  }, [switchBlocked, mismatch, preference]);
 
   useEffect(() => {
     if (promptCity === null || shownForRef.current === promptCity.slug) return;
@@ -68,7 +72,19 @@ export function useCityLocationPrompt() {
     track('city_location_prompt_shown', { from: currentCitySlug, to: promptCity.slug });
   }, [promptCity]);
 
+  useEffect(() => {
+    if (!showExpansion || shownForRef.current === 'expansion') return;
+    shownForRef.current = 'expansion';
+    track('city_expansion_prompt_shown', { from: currentCitySlug });
+  }, [showExpansion]);
+
   const accept = (remember: boolean) => {
+    if (showExpansion) {
+      track('city_expansion_prompt_accepted', { from: currentCitySlug });
+      window.open(CITY_EXPANSION_URL, '_blank', 'noopener,noreferrer');
+      setSessionDismissed(true);
+      return;
+    }
     if (promptCity === null) return;
     track('city_location_prompt_accepted', {
       from: currentCitySlug,
@@ -84,6 +100,11 @@ export function useCityLocationPrompt() {
   };
 
   const decline = (remember: boolean) => {
+    if (showExpansion) {
+      track('city_expansion_prompt_declined', { from: currentCitySlug });
+      setSessionDismissed(true);
+      return;
+    }
     if (promptCity === null) return;
     track('city_location_prompt_declined', {
       from: currentCitySlug,
@@ -98,5 +119,5 @@ export function useCityLocationPrompt() {
     setSessionDismissed(true);
   };
 
-  return { promptCity, accept, decline };
+  return { promptCity, showExpansion, accept, decline };
 }

--- a/packages/frontend-next/src/lib/analytics.ts
+++ b/packages/frontend-next/src/lib/analytics.ts
@@ -66,6 +66,9 @@ type AnalyticsEvents = {
   city_location_prompt_accepted: { from: string; to: string; remembered: boolean };
   city_location_prompt_declined: { from: string; to: string; remembered: boolean };
   city_location_auto_switched: { from: string; to: string };
+  city_expansion_prompt_shown: { from: string };
+  city_expansion_prompt_accepted: { from: string };
+  city_expansion_prompt_declined: { from: string };
 };
 
 export function track<E extends keyof AnalyticsEvents>(

--- a/packages/frontend-next/src/lib/city-expansion-prompt.ts
+++ b/packages/frontend-next/src/lib/city-expansion-prompt.ts
@@ -1,0 +1,1 @@
+export const CITY_EXPANSION_URL = 'https://freifahren.org/expansion';


### PR DESCRIPTION
## Summary
- When GPS is inside another selectable city (Berlin/Leipzig in prod), keep the existing city-switch prompt.
- When GPS is accurately outside every selectable city bounding box, show the same sheet asking whether they want FreiFahren in their city, with a CTA to https://freifahren.org/expansion.
- The expansion prompt has no “remember this choice” checkbox; dismiss is session-only so it does not interfere with city auto-switch preferences.

## Test plan
- [x] In a covered city that is not the current one, confirm the switch prompt still appears (including remember / auto-switch).
- [x] Set location just outside Berlin or Leipzig bounds; confirm the expansion copy and that “Ja, mehr erfahren” opens https://freifahren.org/expansion.
- [x] Confirm “Nicht jetzt” hides the prompt until reload, with no remember checkbox.
- [x] Confirm inaccurate GPS (>25 km) does not show either prompt.