### PR TITLE
ci: deploy feedback notifier on main

### DIFF
--- a/.github/workflows/feedback-notifier-deploy.yml
+++ b/.github/workflows/feedback-notifier-deploy.yml
@@ -1,0 +1,50 @@
+name: Feedback Notifier Deploy
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - 'packages/feedback-notifier/**'
+            - '.github/workflows/feedback-notifier-deploy.yml'
+    workflow_dispatch: {}
+
+# Newest commit wins; never run two deploys at once.
+concurrency:
+    group: deploy-feedback-notifier
+    cancel-in-progress: true
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        environment:
+            name: feedback-notifier
+            url: https://feedback-notifier.freifahren.workers.dev
+        permissions:
+            contents: read
+        defaults:
+            run:
+                working-directory: packages/feedback-notifier
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Set up Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install dependencies
+              run: bun install --frozen-lockfile
+
+            - name: Typecheck
+              run: bun run typecheck
+
+            - name: Test
+              run: bun run test
+
+            - name: Deploy to Cloudflare Workers
+              run: bunx wrangler@latest deploy
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- deploy the feedback notifier Worker when its package changes on `main`
- typecheck and test the Worker before deployment
- record the production Worker URL as the GitHub deployment environment

## Validation
- YAML parsed successfully
- `bun run typecheck`
- `bun run test`