### PR TITLE
feat: normalize trusted Telegram reports through the API

### DIFF
--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -6,8 +6,10 @@ import { AppError } from './common/errors'
 import { createLogger, Logger, LogLevel } from './common/logger'
 import { createD1Db, DbConnection } from './db'
 import { InsightsService } from './modules/insights'
-import type { PublicReportGate } from './modules/report-gate/report-gate-contract'
+import type { PublicReportGate, TrustedReportGate } from './modules/report-gate/report-gate-contract'
 import { ReportsService } from './modules/reports'
+import { ReportSubmissionService } from './modules/reports/report-submission-service'
+import { invalidateStationReportsCache } from './modules/reports/reports-cache-middleware'
 import { RiskService } from './modules/risk'
 import type { CacheCtx } from './modules/transit/reference-cache'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
@@ -17,6 +19,7 @@ export type Bindings = {
     DB?: D1Database
     DB_HAMBURG?: D1Database
     DB_LEIPZIG?: D1Database
+    TRUSTED_REPORT_GATE?: TrustedReportGate
     REPORT_GATE?: PublicReportGate
     REPORT_GATE_MODE?: 'preview-open'
     CORS_ORIGINS?: string
@@ -84,6 +87,7 @@ export type Services = {
 export type Env = {
     Bindings: Bindings
     Variables: Services & {
+        reportSubmissionService: ReportSubmissionService
         logger: Logger
         config: AppConfig
         // This request's city database.
@@ -144,11 +148,7 @@ export const setScopeTagger = (tagger: ScopeTagger) => {
     scopeTagger = tagger
 }
 
-// Resolve the request's city from the explicit `?city=` query parameter. It is a
-// Query param, not a header, because Workers Cache keys requests by URL, preventing one city's cached responses from serving another. A missing param defaults to Berlin (legacy clients: the Capacitor app and old PWA shells); an unknown
-// City is a 400 rather than a silent fallback.
-const resolveCity = (c: Context<Env>): CityConfig => {
-    const requested = c.req.query('city') ?? DEFAULT_CITY_SLUG
+export const resolveCityBySlug = (requested: string): CityConfig => {
     const city = getCity(requested)
     if (city === undefined) {
         throw new AppError({
@@ -166,6 +166,25 @@ const resolveCity = (c: Context<Env>): CityConfig => {
 const cityDbBinding = (env: Bindings, dbBinding: string): D1Database | undefined =>
     (env as unknown as Record<string, D1Database | undefined>)[dbBinding]
 
+export const createCityDatabase = (env: Bindings, city: CityConfig): DbConnection => {
+    const binding = cityDbBinding(env, city.dbBinding)
+    if (binding === undefined) {
+        throw new AppError({ message: 'City database unavailable', statusCode: 503 })
+    }
+    return createD1Db(binding)
+}
+
+export const createCityServices = (db: DbConnection, city: CityConfig, cacheCtx: CacheCtx): Services => {
+    const transitNetworkDataService = new TransitNetworkDataService(db, city.slug, cacheCtx)
+    const reportsService = new ReportsService(db, transitNetworkDataService)
+    return {
+        transitNetworkDataService,
+        reportsService,
+        insightsService: new InsightsService(db, transitNetworkDataService, city.timezone),
+        riskService: new RiskService(reportsService, transitNetworkDataService),
+    }
+}
+
 const applyServices = (c: Context<Env>, db: DbConnection, config: AppConfig) => {
     // The executionCtx powers the cache write in cachedReference (waitUntil). It throws off
     // Workers (tests, seed CLI), where the cache is absent anyway, so fall back to undefined.
@@ -176,14 +195,22 @@ const applyServices = (c: Context<Env>, db: DbConnection, config: AppConfig) => 
         cacheCtx = undefined
     }
 
-    const transitNetworkDataService = new TransitNetworkDataService(db, c.get('city').slug, cacheCtx)
-    const reportsService = new ReportsService(db, transitNetworkDataService)
-
+    const services = createCityServices(db, c.get('city'), cacheCtx)
     c.set('config', config)
-    c.set('reportsService', reportsService)
-    c.set('insightsService', new InsightsService(db, transitNetworkDataService, c.get('city').timezone))
-    c.set('riskService', new RiskService(reportsService, transitNetworkDataService))
-    c.set('transitNetworkDataService', transitNetworkDataService)
+    c.set('reportsService', services.reportsService)
+    c.set(
+        'reportSubmissionService',
+        new ReportSubmissionService({
+            city: c.get('city'),
+            reportsService: services.reportsService,
+            logger: c.get('logger'),
+            invalidate: (stationId) =>
+                invalidateStationReportsCache(c.req.url, c.req.header('Origin') ?? null, c.get('city').slug, stationId),
+        })
+    )
+    c.set('insightsService', services.insightsService)
+    c.set('riskService', services.riskService)
+    c.set('transitNetworkDataService', services.transitNetworkDataService)
 }
 
 export const registerContext = (app: Hono<Env>) => {
@@ -201,7 +228,7 @@ export const registerContext = (app: Hono<Env>) => {
 
         // Resolve the city first: it decides which DB this request talks to, and every
         // Downstream query goes through the services built from that one binding below.
-        const city = resolveCity(c)
+        const city = resolveCityBySlug(c.req.query('city') ?? DEFAULT_CITY_SLUG)
         c.set('city', city)
         // Tag the Sentry request scope so every event/transaction is filterable by city.
         scopeTagger('city', city.slug)
@@ -209,11 +236,7 @@ export const registerContext = (app: Hono<Env>) => {
         // The city's D1 binding is the connection — no per-request lifecycle to manage. It is
         // Present on Workers and provided by the Miniflare pool in tests; the seed CLI reaches the
         // Same D1 through getPlatformProxy rather than this request path.
-        const binding = cityDbBinding(c.env, city.dbBinding)
-        if (binding === undefined) {
-            throw new Error(`No D1 binding "${city.dbBinding}" bound for city "${city.slug}"`)
-        }
-        const db = createD1Db(binding)
+        const db = createCityDatabase(c.env, city)
         c.set('db', db)
         applyServices(c, db, config)
 

--- a/packages/api-worker/src/db/schema/reports.ts
+++ b/packages/api-worker/src/db/schema/reports.ts
@@ -52,12 +52,12 @@ const insertReportDbSchema = createInsertSchema(reports).pick({
 })
 
 // API input schema:
-// - Allows missing stationId (bot sometimes cannot detect it)
-// - Allows missing source (we default to telegram)
+// - Allows missing stationId so normalization can infer it
+// - Defaults public submissions to web_app; Telegram uses private RPC
 // - Requires at least one of stationId, lineId, or directionId
 export const insertReportSchema = insertReportDbSchema
     .extend({
-        source: insertReportDbSchema.shape.source.optional(),
+        source: z.enum(['mini_app', 'web_app', 'mobile_app']).default('web_app'),
         stationId: insertReportDbSchema.shape.stationId.optional(),
     })
     .superRefine((data, ctx) => {

--- a/packages/api-worker/src/modules/report-gate/report-gate-client.ts
+++ b/packages/api-worker/src/modules/report-gate/report-gate-client.ts
@@ -6,7 +6,12 @@ import type { Env } from '../../app-env'
 import { AppError, normalizeInternalCode } from '../../common/errors'
 
 import { isOpenReportPreview, submitOpenPreviewReport } from './preview-report-gate'
-import type { NormalizedReport, PublicReportGate, ReportGateResult } from './report-gate-contract'
+import type {
+    NormalizedReport,
+    ReportGateResult,
+    TrustedReportGate,
+    TrustedReportGateIntakeRequest,
+} from './report-gate-contract'
 
 export type { NormalizedReport } from './report-gate-contract'
 
@@ -76,18 +81,16 @@ const reportGateUnavailable = (error?: unknown) =>
         description: error === undefined ? undefined : error instanceof Error ? error.message : String(error),
     })
 
-const callGate = async <T extends z.ZodType>(
-    c: Context<Env>,
-    call: (gate: PublicReportGate) => Promise<ReportGateResult<unknown>>,
-    dataSchema: T
-): Promise<z.output<T>> => {
-    if (c.env.REPORT_GATE === undefined) {
-        throw reportGateUnavailable()
-    }
+const callGate = async <Gate, Data>(
+    gate: Gate | undefined,
+    call: (gate: Gate) => Promise<ReportGateResult<unknown>>,
+    dataSchema: z.ZodType<Data>
+): Promise<Data> => {
+    if (gate === undefined) throw reportGateUnavailable()
 
-    let result: z.infer<typeof gateResultSchema>
+    let result: ReportGateResult<unknown>
     try {
-        result = gateResultSchema.parse(await call(c.env.REPORT_GATE))
+        result = gateResultSchema.parse(await call(gate))
     } catch (error) {
         throw reportGateUnavailable(error)
     }
@@ -111,7 +114,7 @@ export const submitToReportGate = async (c: Context<Env>, report: NormalizedRepo
     assertPublicReportIntakeEnabled(c)
 
     return callGate(
-        c,
+        c.env.REPORT_GATE,
         (gate) =>
             gate.intake({
                 city: cityDescriptor(c),
@@ -126,5 +129,12 @@ export const submitToReportGate = async (c: Context<Env>, report: NormalizedRepo
 export const resolveReportViewer = async (c: Context<Env>) => {
     if (isOpenReportPreview(c)) return { clientHash: null, minStationTrust: 0 }
 
-    return callGate(c, (gate) => gate.viewer({ city: cityDescriptor(c), request: requestMetadata(c) }), viewerSchema)
+    return callGate(
+        c.env.REPORT_GATE,
+        (gate) => gate.viewer({ city: cityDescriptor(c), request: requestMetadata(c) }),
+        viewerSchema
+    )
 }
+
+export const submitTrustedReportToGate = (gate: TrustedReportGate | undefined, input: TrustedReportGateIntakeRequest) =>
+    callGate(gate, (gate) => gate.intake(input), createdReportSchema)

--- a/packages/api-worker/src/modules/report-gate/report-gate-contract.ts
+++ b/packages/api-worker/src/modules/report-gate/report-gate-contract.ts
@@ -64,3 +64,12 @@ export type PublicReportGate = {
     intake(request: ReportGateIntakeRequest): Promise<ReportGateResult<CreatedReport>>
     viewer(request: ReportGateViewerRequest): Promise<ReportGateResult<ReportViewer>>
 }
+
+export type TrustedReportGateIntakeRequest = {
+    city: CityDescriptor
+    report: NormalizedReport & { source: 'telegram' }
+}
+
+export type TrustedReportGate = {
+    intake(request: TrustedReportGateIntakeRequest): Promise<ReportGateResult<CreatedReport>>
+}

--- a/packages/api-worker/src/modules/reports/report-submission-service.ts
+++ b/packages/api-worker/src/modules/reports/report-submission-service.ts
@@ -1,0 +1,61 @@
+import type { CityConfig } from '@freifahren/cities'
+
+import { reportError } from '../../app-env'
+import type { Logger } from '../../common/logger'
+import { submitTrustedReportToGate } from '../report-gate/report-gate-client'
+import type { CreatedReport, NormalizedReport, TrustedReportGate } from '../report-gate/report-gate-contract'
+
+import type { RawReport } from './post-process-report'
+import type { ReportsService } from './reports-service'
+
+type SubmissionDependencies = {
+    city: CityConfig
+    reportsService: ReportsService
+    logger: Logger
+    invalidate: (stationId: string) => Promise<void>
+}
+
+export class ReportSubmissionService {
+    constructor(private readonly dependencies: SubmissionDependencies) {}
+
+    submitPublicReport(
+        input: Omit<RawReport, 'source'> & { source: Exclude<RawReport['source'], 'telegram'> },
+        submit: (report: NormalizedReport) => Promise<CreatedReport>
+    ) {
+        return this.submit(input, submit)
+    }
+
+    submitTelegramReport(input: Omit<RawReport, 'source'>, gate: TrustedReportGate | undefined) {
+        const city = this.dependencies.city
+        return this.submit({ ...input, source: 'telegram' }, (report) =>
+            submitTrustedReportToGate(gate, {
+                city: {
+                    slug: city.slug,
+                    publicAppUrl: city.publicAppUrl,
+                    dbBinding: city.dbBinding,
+                    telegramChatId: city.community.telegramChatId ?? null,
+                    reporting: city.reporting,
+                },
+                report: { ...report, source: 'telegram' },
+            })
+        )
+    }
+
+    private async submit(input: RawReport, persist: (report: NormalizedReport) => Promise<CreatedReport>) {
+        const { reportsService, logger, invalidate } = this.dependencies
+        const normalized = await reportsService.postProcessReport(input)
+        const created = await persist({
+            ...normalized,
+            lineId: normalized.lineId ?? null,
+            directionId: normalized.directionId ?? null,
+        })
+        // A cache failure must not turn a committed report into a retryable submission failure.
+        try {
+            await invalidate(created.stationId)
+        } catch (error) {
+            logger.warn({ stationId: created.stationId }, 'Failed to invalidate station reports cache')
+            reportError(error, { tags: { task: 'reports-cache-invalidation' } })
+        }
+        return created
+    }
+}

--- a/packages/api-worker/src/modules/reports/reports-routes.ts
+++ b/packages/api-worker/src/modules/reports/reports-routes.ts
@@ -2,13 +2,12 @@ import { isNil } from 'lodash'
 import { DateTime } from 'luxon'
 import { z } from 'zod'
 
-import { Env, reportError } from '../../app-env'
+import { Env } from '../../app-env'
 import { defineRoute } from '../../common/router'
 import { insertReportSchema } from '../../db'
 import { assertPublicReportIntakeEnabled, submitToReportGate } from '../report-gate'
 
 import { getDefaultReportsRange, MAX_REPORTS_TIMEFRAME } from './constants'
-import { invalidateStationReportsCache } from './reports-cache-middleware'
 import { resolveViewer } from './viewer'
 
 const reportsQuerySchema = z
@@ -103,38 +102,10 @@ export const postReport = defineRoute<Env>()({
     },
     handler: async (c) => {
         assertPublicReportIntakeEnabled(c)
-        const reportsService = c.get('reportsService')
-        const logger = c.get('logger')
-
-        const reportData = c.req.valid('json')
-
-        const postProcessedReportData = await reportsService.postProcessReport({
-            ...reportData,
-            source: reportData.source ?? 'telegram',
-        })
-
-        const report = await submitToReportGate(c, {
-            ...postProcessedReportData,
-            lineId: postProcessedReportData.lineId ?? null,
-            directionId: postProcessedReportData.directionId ?? null,
-        })
-
-        /*
-         * Awaited, not deferred: the app invalidates and refetches this station's count as soon as
-         * it sees the 200, so the entry has to be gone before we send it. A colo-local delete is
-         * cheap, and a cache miss must never fail a report that is already committed.
-         */
-        try {
-            await invalidateStationReportsCache(
-                c.req.url,
-                c.req.header('Origin') ?? null,
-                c.get('city').slug,
-                report.stationId
-            )
-        } catch (error) {
-            logger.warn({ stationId: report.stationId }, 'Failed to invalidate station reports cache')
-            reportError(error, { tags: { task: 'reports-cache-invalidation' } })
-        }
+        const input = c.req.valid('json')
+        const report = await c
+            .get('reportSubmissionService')
+            .submitPublicReport(input, (normalized) => submitToReportGate(c, normalized))
 
         return c.json(report)
     },

--- a/packages/api-worker/src/modules/reports/telegram-reports-entrypoint.ts
+++ b/packages/api-worker/src/modules/reports/telegram-reports-entrypoint.ts
@@ -1,0 +1,76 @@
+import { WorkerEntrypoint } from 'cloudflare:workers'
+import { z } from 'zod'
+
+import { type Bindings, createCityDatabase, createCityServices, reportError, resolveCityBySlug } from '../../app-env'
+import { AppError } from '../../common/errors'
+import { createLogger } from '../../common/logger'
+import type { CreatedReport, ReportGateResult } from '../report-gate/report-gate-contract'
+
+import { ReportSubmissionService } from './report-submission-service'
+import { invalidateStationReportsCache } from './reports-cache-middleware'
+
+const telegramReportSchema = z
+    .object({
+        city: z.string().min(1),
+        report: z
+            .object({
+                stationId: z.string().min(1),
+                lineId: z.string().nullable(),
+                directionId: z.string().nullable(),
+            })
+            .strict(),
+    })
+    .strict()
+
+export type TelegramReportIntake = z.infer<typeof telegramReportSchema>
+
+export class TelegramReportsEntrypoint extends WorkerEntrypoint<Bindings> {
+    async intake(input: TelegramReportIntake): Promise<ReportGateResult<CreatedReport>> {
+        const logger = createLogger(this.env.LOG_LEVEL ?? 'info')
+        try {
+            const parsed = telegramReportSchema.safeParse(input)
+            if (!parsed.success) {
+                throw new AppError({
+                    message: 'Invalid Telegram report',
+                    statusCode: 400,
+                    internalCode: 'VALIDATION_FAILED',
+                })
+            }
+            const city = resolveCityBySlug(parsed.data.city)
+            const db = createCityDatabase(this.env, city)
+            const { reportsService } = createCityServices(db, city, this.ctx)
+            const service = new ReportSubmissionService({
+                city,
+                reportsService,
+                logger,
+                // RPC has no browser origin. Other origins/colos retain the existing bounded TTL.
+                invalidate: (stationId) =>
+                    invalidateStationReportsCache(
+                        'https://api.freifahren.org/v0/reports',
+                        city.publicAppUrl,
+                        city.slug,
+                        stationId
+                    ),
+            })
+            const data = await service.submitTelegramReport(parsed.data.report, this.env.TRUSTED_REPORT_GATE)
+            return { ok: true, data }
+        } catch (error) {
+            const failure = error instanceof AppError ? error : new AppError({ message: 'Report submission failed' })
+            logger.error(
+                { internalCode: failure.internalCode, statusCode: failure.statusCode },
+                'Telegram report submission failed'
+            )
+            if (!(error instanceof AppError) || failure.statusCode >= 500) {
+                reportError(error, { tags: { task: 'telegram-report-intake' } })
+            }
+            return {
+                ok: false,
+                error: {
+                    message: failure.message,
+                    statusCode: failure.statusCode,
+                    internalCode: failure.internalCode,
+                },
+            }
+        }
+    }
+}

--- a/packages/api-worker/src/worker.ts
+++ b/packages/api-worker/src/worker.ts
@@ -4,6 +4,7 @@ import { captureException, logger as sentryLogger, setTag, withSentry } from '@s
 import { Bindings, setErrorReporter, setScopeTagger } from './app-env'
 import { setSentryLogSink } from './common/logger'
 import { normalizeTransactionName } from './common/normalize-transaction-name'
+import { TelegramReportsEntrypoint } from './modules/reports/telegram-reports-entrypoint'
 
 import { app } from './index'
 
@@ -43,4 +44,15 @@ export default withSentry(
             return app.fetch(request, env, ctx)
         },
     } satisfies ExportedHandler<Bindings>
+)
+
+export const TrustedTelegramReportsEntrypoint = withSentry(
+    (env: Bindings) => ({
+        dsn: env.SENTRY_DSN,
+        release: env.SENTRY_RELEASE,
+        environment: env.NODE_ENV,
+        enableLogs: true,
+        tracesSampleRate: 1.0,
+    }),
+    TelegramReportsEntrypoint
 )

--- a/packages/api-worker/tests/getInsights.test.ts
+++ b/packages/api-worker/tests/getInsights.test.ts
@@ -16,7 +16,7 @@ let variantStationIds: string[]
 
 const sendReportAt = async (timestamp: Date) => {
     setSystemTime(timestamp)
-    expect((await sendReportRequest({ stationId, source: 'telegram' })).status).toBe(200)
+    expect((await sendReportRequest({ stationId, source: 'web_app' })).status).toBe(200)
 }
 
 beforeAll(async () => {
@@ -122,9 +122,9 @@ describe('GET /insights/lines/:lineName', () => {
         const previousMonday = new Date('2026-07-06T12:15:00.000Z')
         const now = new Date('2026-07-13T12:00:00.000Z')
         setSystemTime(previousMonday)
-        expect((await sendReportRequest({ stationId, lineId, source: 'telegram' })).status).toBe(200)
+        expect((await sendReportRequest({ stationId, lineId, source: 'web_app' })).status).toBe(200)
         setSystemTime(new Date('2026-07-13T09:30:00.000Z'))
-        expect((await sendReportRequest({ stationId, lineId, source: 'telegram' })).status).toBe(200)
+        expect((await sendReportRequest({ stationId, lineId, source: 'web_app' })).status).toBe(200)
         setSystemTime(now)
 
         const response = await appRequestWithRedirect(`/insights/lines/${encodeURIComponent(lineName)}`)
@@ -176,7 +176,7 @@ describe('GET /insights/lines/:lineName', () => {
                     await sendReportRequest({
                         stationId: variantStationIds[index]!,
                         lineId: variantLineId,
-                        source: 'telegram',
+                        source: 'web_app',
                     })
                 ).status
             ).toBe(200)

--- a/packages/api-worker/tests/getReports.test.ts
+++ b/packages/api-worker/tests/getReports.test.ts
@@ -16,7 +16,7 @@ let testLineId: string
 
 const sendReportAt = async (timestamp: Date, stationId: string = testStationId, lineId: string = testLineId) => {
     setSystemTime(timestamp)
-    expect((await sendReportRequest({ stationId, lineId, source: 'telegram' })).status).toBe(200)
+    expect((await sendReportRequest({ stationId, lineId, source: 'web_app' })).status).toBe(200)
 }
 
 const toIsoSeconds = (value: DateTime) => value.toUTC().toISO({ suppressMilliseconds: true })!
@@ -43,7 +43,7 @@ const getValidReportPayload = async () => {
         stationId: stationOnLine.stationId,
         lineId: testLineId,
         directionId: stationOnLine.stationId,
-        source: 'telegram' as const,
+        source: 'web_app' as const,
     }
 }
 
@@ -180,7 +180,7 @@ describe('Predicted reports', () => {
         const realStationIds = [allStationIds[0], allStationIds[1]]
 
         for (const stationId of realStationIds) {
-            await sendReportRequest({ stationId, lineId: testLineId, directionId: stationId, source: 'telegram' })
+            await sendReportRequest({ stationId, lineId: testLineId, directionId: stationId, source: 'web_app' })
         }
 
         // Set 'to' after creating reports to ensure they're captured
@@ -220,7 +220,7 @@ describe('Predicted reports', () => {
         const stationId = allStationIds[0]
 
         for (let i = 0; i < 3; i++) {
-            await sendReportRequest({ stationId, lineId: testLineId, directionId: stationId, source: 'telegram' })
+            await sendReportRequest({ stationId, lineId: testLineId, directionId: stationId, source: 'web_app' })
         }
 
         // Set 'to' after creating reports to ensure they're captured
@@ -258,7 +258,7 @@ describe('Predicted reports', () => {
             stationId: realStationId,
             lineId: testLineId,
             directionId: realStationId,
-            source: 'telegram',
+            source: 'web_app',
         })
 
         // Set 'to' after creating reports to ensure they're captured

--- a/packages/api-worker/tests/getRisk.test.ts
+++ b/packages/api-worker/tests/getRisk.test.ts
@@ -73,7 +73,7 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('returns non-empty segments_risk after a recent real report', async () => {
-        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'web_app' })
 
         const response = await getRisk()
 
@@ -84,7 +84,7 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('each segment entry has a valid color and a risk score between 0 and 1', async () => {
-        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'web_app' })
 
         const response = await getRisk()
         const body = (await response.json()) as RiskResponse
@@ -98,7 +98,7 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('only includes segments with risk — green segments are excluded', async () => {
-        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'web_app' })
 
         const response = await getRisk()
         const body = (await response.json()) as RiskResponse
@@ -110,7 +110,7 @@ describe('GET /v0/risk response shape', () => {
     })
 
     it('segment IDs are numeric strings matching database IDs', async () => {
-        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'web_app' })
 
         const response = await getRisk()
         const body = (await response.json()) as RiskResponse
@@ -150,7 +150,7 @@ describe('GET /v0/risk timeframe filtering', () => {
             lineId: testLineId,
             directionId: null,
             timestamp: twoHoursAgo,
-            source: 'telegram',
+            source: 'web_app',
         })
 
         const response = await getRisk()
@@ -169,7 +169,7 @@ describe('GET /v0/risk timeframe filtering', () => {
             lineId: testLineId,
             directionId: null,
             timestamp: thirtyMinutesAgo,
-            source: 'telegram',
+            source: 'web_app',
         })
 
         const response = await getRisk()
@@ -188,7 +188,7 @@ describe('GET /v0/risk timeframe filtering', () => {
             lineId: testLineId,
             directionId: null,
             timestamp: fiftyFiveMinutesAgo,
-            source: 'telegram',
+            source: 'web_app',
         })
 
         const oldResponse = await getRisk()
@@ -201,7 +201,7 @@ describe('GET /v0/risk timeframe filtering', () => {
         await db.delete(reports)
 
         // Insert a fresh report
-        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'web_app' })
 
         const freshResponse = await getRisk()
         const freshBody = (await freshResponse.json()) as RiskResponse
@@ -258,14 +258,14 @@ describe('GET /v0/risk expiry', () => {
             // 10min before the later report, inside the 15min travel budget, so it is superseded and
             // expires 3min after being overtaken — 7min ago.
             timestamp: new Date(now - 20 * 60 * 1000),
-            source: 'telegram' as const,
+            source: 'web_app' as const,
         }
         const liveReport = {
             stationId: laterStationId,
             lineId: chainLineId,
             directionId: null,
             timestamp: new Date(now - 10 * 60 * 1000),
-            source: 'telegram' as const,
+            source: 'web_app' as const,
         }
 
         await db.insert(reports).values([supersededReport, liveReport])
@@ -316,7 +316,7 @@ describe('GET /v0/risk segment targeting', () => {
     })
 
     it('a report on a line causes segments of that line to appear in the risk output', async () => {
-        await postRiskReport({ stationId: stationOnSegmentLine, lineId: segmentLineId, source: 'telegram' })
+        await postRiskReport({ stationId: stationOnSegmentLine, lineId: segmentLineId, source: 'web_app' })
 
         const response = await getRisk()
         const body = (await response.json()) as RiskResponse
@@ -344,7 +344,7 @@ describe('GET /v0/risk segment targeting', () => {
         const [singleLineStationId, singleLineStationData] = singleLineStation
         const inferredLineId = singleLineStationData.lines[0]!
 
-        await postRiskReport({ stationId: singleLineStationId, source: 'telegram' })
+        await postRiskReport({ stationId: singleLineStationId, source: 'web_app' })
 
         const response = await getRisk()
         const body = (await response.json()) as RiskResponse
@@ -378,7 +378,7 @@ describe('GET /v0/risk segment targeting', () => {
 
         if (!stationA) return
 
-        await postRiskReport({ stationId: stationA.stationId, lineId: lineA, source: 'telegram' })
+        await postRiskReport({ stationId: stationA.stationId, lineId: lineA, source: 'web_app' })
 
         const response = await getRisk()
         const body = (await response.json()) as RiskResponse
@@ -436,7 +436,7 @@ describe('GET /v0/risk report type handling', () => {
 
     it('multiple reports on the same line accumulate higher risk than a single report', async () => {
         // Single report
-        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId: testStationId, lineId: testLineId, source: 'web_app' })
 
         const singleResponse = await getRisk()
         const singleBody = (await singleResponse.json()) as RiskResponse
@@ -453,7 +453,7 @@ describe('GET /v0/risk report type handling', () => {
             .limit(2)
 
         for (const s of stationsOnLine) {
-            await postRiskReport({ stationId: s.stationId, lineId: testLineId, source: 'telegram' })
+            await postRiskReport({ stationId: s.stationId, lineId: testLineId, source: 'web_app' })
         }
 
         const multiResponse = await getRisk()
@@ -478,7 +478,7 @@ describe('GET /v0/risk report type handling', () => {
         const directionId = stationsOnLine[stationsOnLine.length - 1]!.stationId
 
         // Report without direction
-        await postRiskReport({ stationId, lineId: testLineId, source: 'telegram' })
+        await postRiskReport({ stationId, lineId: testLineId, source: 'web_app' })
 
         const undirectedResponse = await getRisk()
         const undirectedBody = (await undirectedResponse.json()) as RiskResponse
@@ -486,7 +486,7 @@ describe('GET /v0/risk report type handling', () => {
         await db.delete(reports)
 
         // Report with direction
-        await postRiskReport({ stationId, lineId: testLineId, directionId, source: 'telegram' })
+        await postRiskReport({ stationId, lineId: testLineId, directionId, source: 'web_app' })
 
         const directedResponse = await getRisk()
         const directedBody = (await directedResponse.json()) as RiskResponse
@@ -517,7 +517,7 @@ describe('GET /v0/risk report type handling', () => {
         const [singleLineStationId] = singleLineStationOnA
 
         // --- Baseline: report at a single-line station on lineA with an explicit lineId ---
-        await postRiskReport({ stationId: singleLineStationId, lineId: lineA, source: 'telegram' })
+        await postRiskReport({ stationId: singleLineStationId, lineId: lineA, source: 'web_app' })
 
         const baselineResponse = await getRisk()
         const baselineBody = (await baselineResponse.json()) as RiskResponse
@@ -533,7 +533,7 @@ describe('GET /v0/risk report type handling', () => {
         await db.delete(reports)
 
         // --- Multi-line: same station but no lineId → lines = [lineA, lineB] ---
-        await postRiskReport({ stationId: multiLineStationId, source: 'telegram' })
+        await postRiskReport({ stationId: multiLineStationId, source: 'web_app' })
 
         const multiResponse = await getRisk()
         const multiBody = (await multiResponse.json()) as RiskResponse
@@ -573,7 +573,7 @@ describe('GET /v0/risk report type handling', () => {
         const [hubStationId, hubData] = hub
         if (hubData.lines.length < 4) return // skip if the seeded data has no high-degree hub
 
-        await postRiskReport({ stationId: hubStationId, source: 'telegram' })
+        await postRiskReport({ stationId: hubStationId, source: 'web_app' })
 
         const response = await getRisk()
         expect(response.status).toBe(200)
@@ -610,7 +610,7 @@ describe('GET /v0/risk circular lines', () => {
 
         // The first segment's fromStation sits at the boundary where the list wraps
         const boundaryStationId = lineSegments[0]!.fromStationId
-        await postRiskReport({ stationId: boundaryStationId, lineId: circularLine.id, source: 'telegram' })
+        await postRiskReport({ stationId: boundaryStationId, lineId: circularLine.id, source: 'web_app' })
 
         const response = await getRisk()
         const body = (await response.json()) as RiskResponse
@@ -671,7 +671,7 @@ describe('GET /v0/risk overlapping segments', () => {
 
         const overlapSegmentIds = overlapIds
 
-        await postRiskReport({ stationId: overlapStationId, lineId: primaryLineId, source: 'telegram' })
+        await postRiskReport({ stationId: overlapStationId, lineId: primaryLineId, source: 'web_app' })
 
         const response = await getRisk()
         const body = (await response.json()) as RiskResponse

--- a/packages/api-worker/tests/postReport.test.ts
+++ b/packages/api-worker/tests/postReport.test.ts
@@ -182,7 +182,7 @@ describe('Report API contract', () => {
         expect(body.stationId).toBe(sorted1)
     })
 
-    it('defaults to telegram source when source is missing in request', async () => {
+    it('defaults to web_app source when source is missing in request', async () => {
         const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
 
         const response = await sendReportRequest({
@@ -198,7 +198,7 @@ describe('Report API contract', () => {
             .orderBy(desc(reports.timestamp))
             .limit(1)
 
-        expect(report.source).toBe('telegram')
+        expect(report.source).toBe('web_app')
     })
 
     it('can submit a report with a direction', async () => {

--- a/packages/api-worker/tests/reportsCache.test.ts
+++ b/packages/api-worker/tests/reportsCache.test.ts
@@ -104,7 +104,7 @@ describe('station reports cache invalidation', () => {
         const key = await seedCacheEntry(stationA)
         expect(await cache.match(key)).toBeDefined()
 
-        expect((await sendReportRequest({ stationId: stationA, source: 'telegram' })).status).toBe(200)
+        expect((await sendReportRequest({ stationId: stationA, source: 'web_app' })).status).toBe(200)
 
         expect(await cache.match(key)).toBeUndefined()
     })
@@ -114,7 +114,7 @@ describe('station reports cache invalidation', () => {
         const keyA = await seedCacheEntry(stationA)
         const keyB = await seedCacheEntry(stationB)
 
-        expect((await sendReportRequest({ stationId: stationA, source: 'telegram' })).status).toBe(200)
+        expect((await sendReportRequest({ stationId: stationA, source: 'web_app' })).status).toBe(200)
 
         expect(await cache.match(keyA)).toBeUndefined()
         expect(await cache.match(keyB)).toBeDefined()

--- a/packages/api-worker/tests/riskSegmentIds.test.ts
+++ b/packages/api-worker/tests/riskSegmentIds.test.ts
@@ -34,7 +34,7 @@ describe('risk keys and segment ids', () => {
             .from(lineStations)
             .where(eq(lineStations.lineId, line.id))
             .limit(1)
-        await sendReportRequest({ stationId: station.stationId, lineId: line.id, source: 'telegram' }, app)
+        await sendReportRequest({ stationId: station.stationId, lineId: line.id, source: 'web_app' }, app)
 
         const [risk, collection] = await Promise.all([
             getJson<RiskResponse>('/risk'),

--- a/packages/api-worker/tests/telegram-report-intake.test.ts
+++ b/packages/api-worker/tests/telegram-report-intake.test.ts
@@ -1,0 +1,146 @@
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { eq } from 'drizzle-orm'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+    TelegramReportsEntrypoint,
+    type TelegramReportIntake,
+} from '../src/modules/reports/telegram-reports-entrypoint'
+import { referenceCacheKey } from '../src/modules/transit/reference-cache'
+import { TransitNetworkDataService } from '../src/modules/transit/transit-network-data-service'
+import { db, reports, stations } from './test-db'
+import { appRequestWithRedirect, fakeReportGate, resetTestEnv, setTestEnv, testEnv } from './test-utils'
+
+const intake = async (input: unknown, bindings = testEnv()) => {
+    const ctx = createExecutionContext()
+    const entrypoint = new TelegramReportsEntrypoint(ctx, bindings)
+    const result = await entrypoint.intake(input as TelegramReportIntake)
+    await waitOnExecutionContext(ctx)
+    return result
+}
+
+const stationReport = async () => {
+    const [station] = await db.select({ id: stations.id }).from(stations).limit(1)
+    return { stationId: station.id, lineId: null as string | null, directionId: null as string | null }
+}
+
+afterEach(async () => {
+    resetTestEnv()
+    vi.restoreAllMocks()
+    // RPC fills the real reference cache; the shared test runtime also runs cache and seed suites.
+    const cache = (caches as CacheStorage & { default: Cache }).default
+    await Promise.all(['stations', 'lines'].map((key) => cache.delete(new Request(referenceCacheKey('berlin', key)))))
+})
+
+describe('Telegram report intake', () => {
+    it('normalizes and persists through the same pipeline as public HTTP intake', async () => {
+        const report = await stationReport()
+        report.directionId = report.stationId
+        const response = await appRequestWithRedirect('/reports', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ...report, source: 'web_app' }),
+        })
+        expect(response.status).toBe(200)
+        const publicReport = (await response.json()) as Record<string, unknown>
+        const result = await intake({ city: 'berlin', report })
+        expect(result.ok).toBe(true)
+        if (!result.ok) throw new Error('Intake failed')
+        expect(result.data).toMatchObject({
+            stationId: publicReport.stationId,
+            lineId: publicReport.lineId,
+            directionId: null,
+        })
+        const [stored] = await db.select().from(reports).where(eq(reports.reportId, result.data.reportId))
+        expect(stored).toMatchObject({ source: 'telegram', directionId: null })
+        expect(fakeReportGate.lastIntake).not.toHaveProperty('request')
+        expect(fakeReportGate.lastIntake).not.toHaveProperty('turnstileToken')
+    })
+
+    it('clears a direction when no line can be inferred between two multi-line stations', async () => {
+        const network = await new TransitNetworkDataService(db, 'berlin').getStations()
+        const candidates = Object.entries(network).filter(([, station]) => station.lines.length > 1)
+        const pair = candidates.flatMap(([stationId, station]) => {
+            const direction = candidates.find(([, other]) => other.lines.every((line) => !station.lines.includes(line)))
+            return direction ? [{ stationId, directionId: direction[0], lineId: null }] : []
+        })[0]
+        expect(pair).toBeDefined()
+        const result = await intake({ city: 'berlin', report: pair })
+        expect(result).toMatchObject({ ok: true, data: { stationId: pair.stationId, lineId: null, directionId: null } })
+    })
+
+    it('rejects Telegram source on public HTTP intake before calling either gate', async () => {
+        const trusted = vi.fn()
+        const publicIntake = vi.fn()
+        setTestEnv({
+            TRUSTED_REPORT_GATE: { intake: trusted },
+            REPORT_GATE: { intake: publicIntake, viewer: vi.fn() },
+        })
+        const response = await appRequestWithRedirect('/reports', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ...(await stationReport()), source: 'telegram' }),
+        })
+        expect(response.status).toBe(400)
+        expect(trusted).not.toHaveBeenCalled()
+        expect(publicIntake).not.toHaveBeenCalled()
+    })
+
+    it.each([{}, { city: 'unknown' }, { city: { slug: 'berlin', dbBinding: 'DB' } }])(
+        'rejects missing, unknown, or caller-controlled city descriptors',
+        async (input) => {
+            const result = await intake({ ...input, report: await stationReport() })
+            expect(result).toMatchObject({ ok: false, error: { statusCode: 400 } })
+            expect(fakeReportGate.lastIntake).toBeUndefined()
+        }
+    )
+
+    it('rejects source and trust metadata supplied over RPC', async () => {
+        const result = await intake({
+            city: 'berlin',
+            report: { ...(await stationReport()), source: 'web_app', trust: 1 },
+        })
+        expect(result).toMatchObject({ ok: false, error: { internalCode: 'VALIDATION_FAILED' } })
+        expect(fakeReportGate.lastIntake).toBeUndefined()
+    })
+
+    it('fails closed when the requested city database is unavailable', async () => {
+        const result = await intake(
+            { city: 'leipzig', report: await stationReport() },
+            { ...testEnv(), DB_LEIPZIG: undefined }
+        )
+        expect(result).toMatchObject({ ok: false, error: { statusCode: 503 } })
+        expect(fakeReportGate.lastIntake).toBeUndefined()
+    })
+
+    it('does not use preview persistence when the trusted gate is unavailable', async () => {
+        const result = await intake(
+            { city: 'berlin', report: await stationReport() },
+            {
+                ...testEnv(),
+                REPORT_GATE_MODE: 'preview-open',
+                TRUSTED_REPORT_GATE: undefined,
+            }
+        )
+        expect(result).toMatchObject({ ok: false, error: { statusCode: 503, internalCode: 'REPORT_GATE_UNAVAILABLE' } })
+    })
+
+    it('rejects unknown transit references before contacting the gate', async () => {
+        const result = await intake({
+            city: 'berlin',
+            report: { ...(await stationReport()), directionId: 'missing-station' },
+        })
+        expect(result.ok).toBe(false)
+        expect(fakeReportGate.lastIntake).toBeUndefined()
+    })
+
+    it('keeps a committed report successful when cache invalidation fails', async () => {
+        vi.spyOn((caches as CacheStorage & { default: Cache }).default, 'delete').mockRejectedValue(
+            new Error('Cache unavailable')
+        )
+        const result = await intake({ city: 'berlin', report: await stationReport() })
+        expect(result.ok).toBe(true)
+        if (!result.ok) throw new Error('Intake failed')
+        expect(await db.select().from(reports).where(eq(reports.reportId, result.data.reportId))).toHaveLength(1)
+    })
+})

--- a/packages/api-worker/tests/test-utils.ts
+++ b/packages/api-worker/tests/test-utils.ts
@@ -3,7 +3,11 @@ import { vi } from 'vitest'
 
 import type { Bindings } from '../src/app-env'
 import { app } from '../src/index'
-import type { PublicReportGate, ReportGateIntakeRequest } from '../src/modules/report-gate/report-gate-contract'
+import type {
+    PublicReportGate,
+    ReportGateIntakeRequest,
+    TrustedReportGate,
+} from '../src/modules/report-gate/report-gate-contract'
 
 const overrides: Partial<Bindings> = {}
 
@@ -50,45 +54,68 @@ const reportGateBinding: PublicReportGate = {
             } as const
         }
 
-        const cityDb = (workerEnv as unknown as Record<string, D1Database | undefined>)[body.city.dbBinding]
-        if (cityDb === undefined) throw new Error('Unknown database binding')
+        return persistFakeReport(body)
+    },
+}
 
-        const now = Date.now()
-        const row = await cityDb
-            .prepare(
-                `INSERT INTO reports
+const persistFakeReport = async (
+    body: ReportGateIntakeRequest,
+    trust = fakeReportGate.intakeTrust,
+    clientHash: string | null = hashFor(body.request)
+) => {
+    const cityDb = (workerEnv as unknown as Record<string, D1Database | undefined>)[body.city.dbBinding]
+    if (cityDb === undefined) throw new Error('Unknown database binding')
+
+    const now = Date.now()
+    const row = await cityDb
+        .prepare(
+            `INSERT INTO reports
              (station_id, line_id, direction_id, timestamp, source, client_hash, trust)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
              RETURNING report_id, station_id, line_id, direction_id, timestamp`
-            )
-            .bind(
-                body.report.stationId,
-                body.report.lineId,
-                body.report.directionId,
-                now,
-                body.report.source,
-                hashFor(body.request),
-                fakeReportGate.intakeTrust
-            )
-            .first<{
-                report_id: number
-                station_id: string
-                line_id: string | null
-                direction_id: string | null
-                timestamp: number
-            }>()
+        )
+        .bind(
+            body.report.stationId,
+            body.report.lineId,
+            body.report.directionId,
+            now,
+            body.report.source,
+            clientHash,
+            trust
+        )
+        .first<{
+            report_id: number
+            station_id: string
+            line_id: string | null
+            direction_id: string | null
+            timestamp: number
+        }>()
 
-        if (row === null) throw new Error('Insert failed')
-        return {
-            ok: true,
-            data: {
-                reportId: row.report_id,
-                stationId: row.station_id,
-                lineId: row.line_id,
-                directionId: row.direction_id,
-                timestamp: new Date(row.timestamp).toISOString(),
+    if (row === null) throw new Error('Insert failed')
+    return {
+        ok: true,
+        data: {
+            reportId: row.report_id,
+            stationId: row.station_id,
+            lineId: row.line_id,
+            directionId: row.direction_id,
+            timestamp: new Date(row.timestamp).toISOString(),
+        },
+    } as const
+}
+
+export const trustedReportGateBinding: TrustedReportGate = {
+    async intake(body) {
+        if (fakeReportGate.unavailable) throw new Error('Fake report gate unavailable')
+        fakeReportGate.lastIntake = body as unknown as Record<string, unknown>
+        return persistFakeReport(
+            {
+                ...body,
+                request: { ip: '', userAgent: '', asn: null, asOrganization: null, platform: 'telegram' },
             },
-        } as const
+            1,
+            null
+        )
     },
 }
 
@@ -114,6 +141,7 @@ export const testEnv = (): Bindings => ({
     POSTHOG_API_KEY: overrides.POSTHOG_API_KEY ?? workerEnv.POSTHOG_API_KEY,
     POSTHOG_HOST: overrides.POSTHOG_HOST ?? workerEnv.POSTHOG_HOST,
     REPORT_GATE: overrides.REPORT_GATE ?? reportGateBinding,
+    TRUSTED_REPORT_GATE: overrides.TRUSTED_REPORT_GATE ?? trustedReportGateBinding,
 })
 
 export const setSystemTime = (date?: Date) => {

--- a/packages/api-worker/wrangler.jsonc
+++ b/packages/api-worker/wrangler.jsonc
@@ -24,6 +24,11 @@
     ],
     "services": [
         {
+            "binding": "TRUSTED_REPORT_GATE",
+            "service": "report-gate",
+            "entrypoint": "TrustedTelegramReportsEntrypoint",
+        },
+        {
             "binding": "REPORT_GATE",
             "service": "report-gate",
             "entrypoint": "PublicReportsEntrypoint",


### PR DESCRIPTION
Telegram reports currently go straight from the Telegram worker to report-gate, bypassing the API's transit post-processing. A report can therefore retain a direction without a usable line (FRE-787). This change makes the API own report normalization for both HTTP and trusted Telegram intake, while keeping report-gate responsible for persistence and the public anti-spam path.

## Design

```text
Public HTTP POST /reports -> ReportSubmissionService -> public report-gate intake
Telegram worker -> API private RPC intake -> ReportSubmissionService -> trusted report-gate intake
```

`ReportSubmissionService` owns the shared normalize → persist → invalidate sequence. The HTTP router gets it from request context. The new `TrustedTelegramReportsEntrypoint` is exported from the API worker with Sentry instrumentation; its RPC adapter builds the equivalent city-specific dependencies because Hono middleware does not run for RPC calls.

The Telegram RPC contract accepts only a city slug and station/line/direction identifiers. It rejects caller-provided source, trust and database descriptors. The API resolves the city/database, assigns `source: telegram`, runs the existing transit rules, and calls `TRUSTED_REPORT_GATE`. Access is through a named Cloudflare service binding, with no public HTTP route or shared password header.

The public schema defaults omitted sources to `web_app` and accepts only `web_app`, `mini_app`, and `mobile_app`. `telegram` is rejected before either gate is called. Missing HTTP city parameters retain the existing default for legacy clients; RPC city is required and unknown cities are rejected.

The gate client validates RPC envelopes and response data, translates unavailable bindings/transport/malformed results into `REPORT_GATE_UNAVAILABLE`, and preserves structured gate rejections. Trusted intake fails closed if its binding is missing, including in preview mode.

Cache invalidation is awaited after persistence and failures do not turn a committed report into an apparent failed submission. RPC targets the canonical API URL and city app origin; other origin/colo variants retain the existing five-minute edge TTL bound.

## Scope and cost

This adds a service-binding hop and reuses the existing API services and D1 tables. It adds no queues, Durable Objects, scheduled jobs, dependencies, or migrations. The companion private-gate PR inserts trusted reports immediately with trust 1 without scoring, identity extraction, Turnstile or Telegram forwarding. Public submissions retain their existing anti-spam behavior.

Bot-token consolidation (FRE-788) and adaptive per-city Telegram summaries are follow-up work. Public-report forwarding remains owned by report-gate in this first change.

## Validation

- API typecheck, full integration suite: 268 tests across 28 files.
- Frontend production build (including TypeScript) passed against the narrowed public input schema; existing large-chunk warnings remain.
- API lint: no errors (warnings remain); full formatting check and Wrangler deployment dry run passed.
- New integration coverage exercises HTTP/RPC normalization parity, direction-without-line regression, public source spoofing, strict RPC validation, missing city database/binding, and cache failure after persistence.
- Ran the actual Telegram, API and private gate bundles together under local Miniflare with real RPC service bindings and D1. Applied API migrations and seeded bundled reference data through `seedBaseData`.
- Sent an authenticated Telegram webhook; mocked only external Mistral/Turnstile responses. Verified normalized null line/direction and immediate trust 1 even with invalid scoring configuration, public read visibility, rejection of public Telegram source, public Turnstile quarantine, unknown-city rejection and no public trusted-intake route.
- Companion suites: Telegram 61 tests and private gate 37 tests, with typechecks and deployment dry runs passing. These are local results; hosted CI and production behavior are separate checks.

## Rollout

Merge/deploy the private gate change first, then this API PR. Confirm the API deployment succeeds before merging the dependent Telegram-worker PR that switches its binding. Separate PRs prevent the independent API and Telegram deployment workflows from racing. No production deployment was performed during this validation.

Rollback order: switch Telegram back before removing the API RPC entrypoint. The existing gate entrypoint and input shape remain compatible with the old Telegram worker.

## Related PRs

1. Private gate: https://github.com/FreiFahren/report-gate/pull/10
2. API ownership: https://github.com/FreiFahren/FreiFahren/pull/975
3. Telegram binding switch (depends on deployed API): https://github.com/FreiFahren/FreiFahren/pull/976
