### PR TITLE
feat: show report direction arrows on the map

### DIFF
--- a/packages/frontend-next/src/components/map/ReportsLayer.tsx
+++ b/packages/frontend-next/src/components/map/ReportsLayer.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/hooks/useReportsLayer';
 
 import { ReportPulseMarker } from './ReportPulseMarker';
+import { ReportDirectionMarker } from './report-direction-marker';
 
 const DOT_RADIUS = 8;
 const DOT_STROKE_WIDTH = 2;
@@ -38,9 +39,24 @@ export function ReportsLayer() {
         <Layer
           id={REPORTS_HIT_LAYER_ID}
           type="circle"
-          paint={{ 'circle-radius': 14, 'circle-color': '#000000', 'circle-opacity': 0 }}
+          paint={{
+            'circle-radius': ['case', ['!=', ['get', 'bearing'], null], 24, 14],
+            'circle-color': '#000000',
+            'circle-opacity': 0,
+          }}
         />
       </Source>
+      {data.features.map((feature, index) =>
+        feature.properties.bearing === null ? null : (
+          <ReportDirectionMarker
+            key={`${feature.properties.stationId}-${feature.properties.timestamp}-${index}`}
+            longitude={feature.geometry.coordinates[0]}
+            latitude={feature.geometry.coordinates[1]}
+            bearing={feature.properties.bearing}
+            opacity={feature.properties.opacity}
+          />
+        ),
+      )}
       {data.features
         .filter((feature) => feature.properties.pulse)
         .map((feature) => (

--- a/packages/frontend-next/src/components/map/report-direction-marker.tsx
+++ b/packages/frontend-next/src/components/map/report-direction-marker.tsx
@@ -1,0 +1,52 @@
+import { Marker } from 'react-map-gl/maplibre';
+
+type ReportDirectionMarkerProps = {
+  longitude: number;
+  latitude: number;
+  bearing: number;
+  opacity: number;
+};
+
+export function ReportDirectionMarker({
+  longitude,
+  latitude,
+  bearing,
+  opacity,
+}: ReportDirectionMarkerProps) {
+  return (
+    <Marker
+      longitude={longitude}
+      latitude={latitude}
+      rotation={bearing}
+      rotationAlignment="map"
+      pitchAlignment="map"
+      opacity={opacity.toString()}
+      style={{ pointerEvents: 'none' }}
+    >
+      <svg
+        aria-hidden="true"
+        width="48"
+        height="48"
+        viewBox="0 0 48 48"
+        className="text-destructive"
+      >
+        <path
+          d="m19 9 5-5 5 5"
+          fill="none"
+          stroke="white"
+          strokeWidth="6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="m19 9 5-5 5 5"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </Marker>
+  );
+}

--- a/packages/frontend-next/src/hooks/useReportsLayer.ts
+++ b/packages/frontend-next/src/hooks/useReportsLayer.ts
@@ -3,10 +3,11 @@ import type { FeatureCollection, Point } from 'geojson';
 import { useEffect } from 'react';
 
 import { HOUR_MS, type Report, useReports } from '@/api/reports';
-import { type Stations, useStations } from '@/api/transit';
+import { type Line, type Stations, useLines, useStations } from '@/api/transit';
 import { useReportSimulation } from '@/contexts/ReportSimulation.context';
 import { useNow } from '@/hooks/useNow';
 import { MIN_OPACITY, reportOpacity } from '@/lib/report-decay';
+import { reportDirectionBearing } from '@/lib/report-direction';
 import { useIsReportViewed } from '@/lib/viewed-reports';
 import { Route as ReportDetailRoute } from '@/routes/_map/reports/$stationId';
 
@@ -23,6 +24,7 @@ export type ReportPointProps = {
   timestamp: string;
   opacity: number;
   pulse: boolean;
+  bearing: number | null;
 };
 
 /*
@@ -36,6 +38,7 @@ function reportsToGeoJSON(
   stations: Stations,
   isViewed: (stationId: string, timestamp: string) => boolean,
   nowMs: number,
+  lines: Line[],
 ): FeatureCollection<Point, ReportPointProps> {
   const features = reports.flatMap((report) => {
     const station = stations[report.stationId];
@@ -59,7 +62,13 @@ function reportsToGeoJSON(
           type: 'Point' as const,
           coordinates: [station.coordinates.longitude, station.coordinates.latitude],
         },
-        properties: { stationId: report.stationId, timestamp: report.timestamp, opacity, pulse },
+        properties: {
+          stationId: report.stationId,
+          timestamp: report.timestamp,
+          opacity,
+          pulse,
+          bearing: reportDirectionBearing(report, lines, stations),
+        },
       },
     ];
   });
@@ -74,6 +83,7 @@ function reportsToGeoJSON(
 export function useReportsLayer(): FeatureCollection<Point, ReportPointProps> | null {
   const { data: liveReports } = useReports(HOUR_MS);
   const { data: stations } = useStations();
+  const { data: lines } = useLines();
   const isViewed = useIsReportViewed();
   const router = useRouter();
   const simulation = useReportSimulation();
@@ -83,7 +93,8 @@ export function useReportsLayer(): FeatureCollection<Point, ReportPointProps> | 
   const reports = simulation.reports ?? liveReports;
   const now = simulation.nowMs ?? wallNow;
 
-  const data = reports && stations ? reportsToGeoJSON(reports, stations, isViewed, now) : null;
+  const data =
+    reports && stations ? reportsToGeoJSON(reports, stations, isViewed, now, lines ?? []) : null;
 
   // Warm the report-detail route for every visible report. Reports navigate imperatively, so the
   // router's viewport preloading never sees them. Keyed on the station-id set so it only re-runs

--- a/packages/frontend-next/src/lib/report-direction.ts
+++ b/packages/frontend-next/src/lib/report-direction.ts
@@ -1,0 +1,27 @@
+import type { Report } from '@/api/reports';
+import type { Line, Stations } from '@/api/transit';
+
+export function reportDirectionBearing(
+  report: Report,
+  lines: Line[],
+  stations: Stations,
+): number | null {
+  if (!report.directionId || !report.lineId) return null;
+  const line = lines.find((line) => line.id === report.lineId);
+  if (!line || line.isCircular) return null;
+  const fromIndex = line.stations.indexOf(report.stationId);
+  const toIndex = line.stations.indexOf(report.directionId);
+  if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) return null;
+
+  // Follow the local route, not the straight line to a potentially distant terminus.
+  const from = stations[report.stationId]?.coordinates;
+  const next = stations[line.stations[fromIndex + Math.sign(toIndex - fromIndex)]]?.coordinates;
+  if (!from || !next) return null;
+  const radians = Math.PI / 180;
+  const x = (next.longitude - from.longitude) * radians;
+  const y =
+    Math.log(Math.tan(Math.PI / 4 + (next.latitude * radians) / 2)) -
+    Math.log(Math.tan(Math.PI / 4 + (from.latitude * radians) / 2));
+  if (x === 0 && y === 0) return null;
+  return (Math.atan2(x, y) / radians + 360) % 360;
+}


### PR DESCRIPTION
## Summary

Add small red-and-white direction chevrons beside report dots on the map. Arrows point toward the next station along the reported line, rotate with the map, and fade with their report. Reports without a resolvable direction keep the existing dot. The report hit target includes the arrow.

## Validation

- Production build and TypeScript check passed.
- ESLint passed with two existing React Compiler warnings in report lists/forms; changed files pass Prettier.
- Checked bearings for a bent route, reverse travel, absent direction/line, unknown destination, same-station destination, and circular lines.
- Browser-verified the production build with four sample reports over the real Berlin map: three direction arrows and one undirected dot. Confirmed report-marker clicks open report details and captured desktop/mobile screenshots. Sample reports were intercepted in the browser; no production reports were created.

No new dependencies.
