### PR TITLE
feat: own Telegram report delivery in the Telegram worker

### DIFF
--- a/packages/telegram-worker/.dev.vars.example
+++ b/packages/telegram-worker/.dev.vars.example
@@ -3,3 +3,6 @@
 MISTRAL_API_KEY=
 # The secret_token you pass to Telegram setWebhook; the worker checks it on every webhook.
 TELEGRAM_WEBHOOK_SECRET=
+
+# Sole runtime owner of outgoing Telegram requests
+TELEGRAM_BOT_TOKEN=

--- a/packages/telegram-worker/README.md
+++ b/packages/telegram-worker/README.md
@@ -39,7 +39,7 @@ CITY_NAME=Leipzig bun run eval --parallel 8
 
 ## Deploy
 
-Set secrets (`MISTRAL_API_KEY`, `TELEGRAM_WEBHOOK_SECRET`) with `wrangler secret put <NAME>`, then
+Set secrets (`MISTRAL_API_KEY`, `TELEGRAM_WEBHOOK_SECRET`, `TELEGRAM_BOT_TOKEN`) with `wrangler secret put <NAME>`, then
 `bun run deploy`. Add the existing bot to each configured city group and register its webhook once:
 
 ```sh

--- a/packages/telegram-worker/src/forwarding.ts
+++ b/packages/telegram-worker/src/forwarding.ts
@@ -1,0 +1,77 @@
+import { getCity } from '@freifahren/cities'
+import type { Env, TransitIndex } from './types'
+import type { AcceptedReportNotification } from './types'
+import { profileFor } from './config'
+import { getTransitIndex, lineNameForId } from './transit'
+import { reportError } from './observability'
+import { sendTelegramMessage } from './telegram-client'
+
+function escapeHtml(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#x27;')
+}
+
+function formatForwardedReport(
+    index: TransitIndex,
+    report: AcceptedReportNotification['report'],
+    publicAppUrl: string
+): string {
+    const station = index.stations[report.stationId]
+    const direction = report.directionId !== null ? index.stations[report.directionId] : null
+    const lineName = report.lineId !== null ? lineNameForId(index, report.lineId) : null
+    // utm_source lets the app attribute arrivals from this link in analytics (PostHog
+    // captures utm_* automatically). The app redirects /station/<id> to the live report
+    // view when one is fresh.
+    const stationUrl = `${publicAppUrl}/station/${encodeURIComponent(report.stationId)}?utm_source=telegram&utm_medium=bot`
+
+    const lines = [`<b>Station:</b> ${escapeHtml(station.name)}`]
+    if (lineName !== null) {
+        lines.push(`<b>Line:</b> ${escapeHtml(lineName)}`)
+    }
+    if (direction !== null) {
+        lines.push(`<b>Direction:</b> ${escapeHtml(direction.name)}`)
+    }
+    lines.push('')
+    lines.push(`Mehr Informationen auf <a href="${escapeHtml(stationUrl)}">${escapeHtml(publicAppUrl)}</a>`)
+    return lines.join('\n')
+}
+
+export async function forwardReport(
+    { city: slug, report }: AcceptedReportNotification,
+    env: Pick<Env, 'NODE_ENV' | 'BACKEND_URL' | 'TELEGRAM_BOT_TOKEN'>,
+    ctx: ExecutionContext
+): Promise<void> {
+    const city = getCity(slug)
+    if (!city) throw new Error('Unknown notification city')
+    if (
+        env.NODE_ENV !== 'production' ||
+        report.source === 'telegram' ||
+        !city.reporting.telegramForwardingEnabled ||
+        !city.community.telegramChatId
+    )
+        return
+
+    try {
+        if (!env.TELEGRAM_BOT_TOKEN) throw new Error('Telegram bot token is not configured')
+        const index = await getTransitIndex(env.BACKEND_URL, profileFor(slug), slug, ctx)
+        if (
+            !index.stations[report.stationId] ||
+            (report.directionId !== null && !index.stations[report.directionId]) ||
+            (report.lineId !== null && lineNameForId(index, report.lineId) === null)
+        ) {
+            throw new Error('Notification references unknown transit data')
+        }
+        await sendTelegramMessage(
+            env.TELEGRAM_BOT_TOKEN,
+            city.community.telegramChatId,
+            formatForwardedReport(index, report, city.publicAppUrl)
+        )
+    } catch (error) {
+        reportError('Failed to forward app report to Telegram', error, { city: slug, reportId: report.reportId })
+        throw error
+    }
+}

--- a/packages/telegram-worker/src/index.ts
+++ b/packages/telegram-worker/src/index.ts
@@ -1,34 +1,25 @@
-import { withSentry, consoleLoggingIntegration } from '@sentry/cloudflare'
+import { withSentry } from '@sentry/cloudflare'
 import type { Env } from './types'
 import { handleWebhook } from './webhook'
-import { redactTelegramBotTokenFromBreadcrumb, redactTelegramBotTokenFromSpan } from './observability'
+import { sentryOptions } from './observability'
+import { TelegramNotifications } from './notifications'
 
 // withSentry wraps the handler: unhandled errors in fetch are captured automatically,
 // console.* is forwarded to Sentry Logs, and Sentry.captureException works inside
 // ctx.waitUntil (the SDK binds the client via AsyncLocalStorage).
-export default withSentry(
-    (env: Env) => ({
-        dsn: env.SENTRY_DSN,
-        release: env.SENTRY_RELEASE,
-        environment: env.NODE_ENV,
-        enableLogs: true,
-        integrations: [consoleLoggingIntegration({ levels: ['info', 'warn', 'error'] })],
-        tracesSampleRate: 1.0,
-        beforeBreadcrumb: redactTelegramBotTokenFromBreadcrumb,
-        beforeSendSpan: redactTelegramBotTokenFromSpan,
-    }),
-    {
-        async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-            const url = new URL(request.url)
+export default withSentry((env: Env) => sentryOptions(env), {
+    async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+        const url = new URL(request.url)
 
-            if (request.method === 'POST' && url.pathname === '/telegram/webhook') {
-                return handleWebhook(request, env, ctx)
-            }
-            if (request.method === 'GET' && url.pathname === '/health') {
-                return new Response('ok', { status: 200 })
-            }
+        if (request.method === 'POST' && url.pathname === '/telegram/webhook') {
+            return handleWebhook(request, env, ctx)
+        }
+        if (request.method === 'GET' && url.pathname === '/health') {
+            return new Response('ok', { status: 200 })
+        }
 
-            return new Response('not found', { status: 404 })
-        },
-    } satisfies ExportedHandler<Env>
-)
+        return new Response('not found', { status: 404 })
+    },
+} satisfies ExportedHandler<Env>)
+
+export const TelegramNotificationsEntrypoint = withSentry(sentryOptions, TelegramNotifications)

--- a/packages/telegram-worker/src/notifications.ts
+++ b/packages/telegram-worker/src/notifications.ts
@@ -1,0 +1,12 @@
+import { WorkerEntrypoint } from 'cloudflare:workers'
+import { AcceptedReportNotification } from './types'
+
+import { forwardReport } from './forwarding'
+
+export class TelegramNotifications extends WorkerEntrypoint<Cloudflare.Env & { TELEGRAM_BOT_TOKEN?: string }> {
+    async reportAccepted(input: AcceptedReportNotification): Promise<void> {
+        const parsed = AcceptedReportNotification.safeParse(input)
+        if (!parsed.success) throw new Error('Invalid accepted report notification')
+        await forwardReport(parsed.data, this.env, this.ctx)
+    }
+}

--- a/packages/telegram-worker/src/observability.ts
+++ b/packages/telegram-worker/src/observability.ts
@@ -1,4 +1,10 @@
-import { captureException, type Breadcrumb, type CloudflareOptions } from '@sentry/cloudflare'
+import type { Env } from './types'
+import {
+    consoleLoggingIntegration,
+    captureException,
+    type Breadcrumb,
+    type CloudflareOptions,
+} from '@sentry/cloudflare'
 
 const TELEGRAM_BOT_API_TOKEN = /(https:\/\/api\.telegram\.org\/bot)[^/\s?#]+/gi
 
@@ -52,3 +58,14 @@ export function reportError(message: string, err: unknown, extra?: Record<string
         ...extra,
     })
 }
+
+export const sentryOptions = (env: Pick<Env, 'SENTRY_DSN' | 'SENTRY_RELEASE' | 'NODE_ENV'>): CloudflareOptions => ({
+    dsn: env.SENTRY_DSN,
+    release: env.SENTRY_RELEASE,
+    environment: env.NODE_ENV,
+    enableLogs: true,
+    integrations: [consoleLoggingIntegration({ levels: ['info', 'warn', 'error'] })],
+    tracesSampleRate: 1.0,
+    beforeBreadcrumb: redactTelegramBotTokenFromBreadcrumb,
+    beforeSendSpan: redactTelegramBotTokenFromSpan,
+})

--- a/packages/telegram-worker/src/telegram-client.ts
+++ b/packages/telegram-worker/src/telegram-client.ts
@@ -1,0 +1,33 @@
+const ERROR_DESCRIPTION_LIMIT = 500
+
+export async function sendTelegramMessage(token: string, chatId: string, text: string): Promise<void> {
+    let response: Response
+    try {
+        response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                chat_id: chatId,
+                text,
+                parse_mode: 'HTML',
+                link_preview_options: { is_disabled: false, prefer_large_media: false, show_above_text: false },
+            }),
+            // A timeout may occur after Telegram posts; retrying could duplicate the message.
+            signal: AbortSignal.timeout(5_000),
+        })
+    } catch {
+        // Fetch errors can contain the URL, which embeds the token.
+        throw new Error('Telegram request failed or timed out')
+    }
+    const result = (await response.json().catch(() => null)) as { ok?: boolean; description?: unknown } | null
+    if (response.ok && result?.ok === true) return
+    const description =
+        typeof result?.description === 'string'
+            ? result.description
+                  .replaceAll(token, '[REDACTED]')
+                  .replace(/\s+/g, ' ')
+                  .trim()
+                  .slice(0, ERROR_DESCRIPTION_LIMIT)
+            : 'No usable error description'
+    throw new Error(`Telegram notification failed with status ${response.status}: ${description}`)
+}

--- a/packages/telegram-worker/src/transit.ts
+++ b/packages/telegram-worker/src/transit.ts
@@ -20,7 +20,7 @@ interface RawLine {
 export function buildIndex(
     rawStations: Record<string, RawStation>,
     rawLines: RawLine[],
-    profile: CityProfile,
+    profile: CityProfile
 ): TransitIndex {
     const variants: IndexVariant[] = rawLines.map((line) => ({
         id: line.id,
@@ -48,24 +48,41 @@ export function buildIndex(
     }
 
     const lineNames = [...new Set(variants.map((v) => v.name))].sort()
-    const circularLineNames = [
-        ...new Set(rawLines.filter((l) => l.isCircular).map((l) => l.name)),
-    ].sort()
+    const circularLineNames = [...new Set(rawLines.filter((l) => l.isCircular).map((l) => l.name))].sort()
 
     return { stations, byNorm, linesByStation, lineNames, circularLineNames, variants }
 }
 
-// No caching here; the api-worker serves these from its edge cache.
+// Notification bursts reuse transit responses locally as well as the API's edge cache.
+async function fetchTransit(url: string, ctx?: ExecutionContext): Promise<Response> {
+    if (!ctx) return fetch(url)
+    const cache = (caches as CacheStorage & { default: Cache }).default
+    const key = new Request(url)
+    const cached = await cache.match(key).catch(() => undefined)
+    if (cached) return cached
+    const response = await fetch(url)
+    if (response.ok) {
+        const stored = new Response(response.clone().body, response)
+        stored.headers.set('Cache-Control', 'public, max-age=3600')
+        ctx.waitUntil(cache.put(key, stored).catch(() => undefined))
+    }
+    return response
+}
 const cityUrl = (backendUrl: string, path: string, city: string): string => {
     const url = new URL(path, `${backendUrl}/`)
     url.searchParams.set('city', city)
     return url.toString()
 }
 
-export async function getTransitIndex(backendUrl: string, profile: CityProfile, city: string): Promise<TransitIndex> {
+export async function getTransitIndex(
+    backendUrl: string,
+    profile: CityProfile,
+    city: string,
+    ctx?: ExecutionContext
+): Promise<TransitIndex> {
     const [stationsResp, linesResp] = await Promise.all([
-        fetch(cityUrl(backendUrl, '/v0/transit/stations', city)),
-        fetch(cityUrl(backendUrl, '/v0/transit/lines', city)),
+        fetchTransit(cityUrl(backendUrl, '/v0/transit/stations', city), ctx),
+        fetchTransit(cityUrl(backendUrl, '/v0/transit/lines', city), ctx),
     ])
     if (!stationsResp.ok) {
         throw new Error(`GET /v0/transit/stations failed: ${stationsResp.status}`)
@@ -93,11 +110,7 @@ export function lineNameForId(index: TransitIndex, lineId: string): string | nul
 
 // Mirrors the frontend's longest-variant fallback: of the variants whose name matches (and
 // which contain the station, if given), return the id of the one with the most stations.
-export function resolveLineVariant(
-    index: TransitIndex,
-    lineName: string,
-    stationId: string | null,
-): string | null {
+export function resolveLineVariant(index: TransitIndex, lineName: string, stationId: string | null): string | null {
     let candidates = index.variants.filter((v) => v.name === lineName)
     if (candidates.length === 0) {
         return null

--- a/packages/telegram-worker/src/types.ts
+++ b/packages/telegram-worker/src/types.ts
@@ -15,6 +15,7 @@ export type Env = Omit<Cloudflare.Env, 'NODE_ENV' | 'BACKEND_URL' | 'MISTRAL_MOD
     // Secrets (wrangler secret put)
     MISTRAL_API_KEY: string
     TELEGRAM_WEBHOOK_SECRET: string
+    TELEGRAM_BOT_TOKEN?: string
 }
 
 // Telegram update — only the fields we read.
@@ -85,3 +86,21 @@ export interface TransitIndex {
     circularLineNames: string[]
     variants: IndexVariant[]
 }
+
+export const AcceptedReportNotification = z
+    .object({
+        city: z.string().min(1).max(64),
+        report: z
+            .object({
+                reportId: z.number().int().positive(),
+                stationId: z.string().min(1).max(16),
+                lineId: z.string().min(1).max(16).nullable(),
+                directionId: z.string().min(1).max(16).nullable(),
+                timestamp: z.string().datetime(),
+                source: z.enum(['web_app', 'mini_app', 'mobile_app', 'telegram']),
+            })
+            .strict(),
+    })
+    .strict()
+
+export type AcceptedReportNotification = z.infer<typeof AcceptedReportNotification>

--- a/packages/telegram-worker/test/notifications.test.ts
+++ b/packages/telegram-worker/test/notifications.test.ts
@@ -1,0 +1,141 @@
+import { createExecutionContext, fetchMock, waitOnExecutionContext } from 'cloudflare:test'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { CITIES } from '@freifahren/cities'
+import { TelegramNotificationsEntrypoint } from '../src/index'
+import type { AcceptedReportNotification } from '../src/types'
+import type { Env } from '../src/types'
+
+const notification: AcceptedReportNotification = {
+    city: 'leipzig',
+    report: {
+        reportId: 1,
+        stationId: 'station-a',
+        lineId: 'line-a',
+        directionId: 'station-b',
+        timestamp: '2026-09-05T12:00:00.000Z',
+        source: 'web_app',
+    },
+}
+const bindings: Env = {
+    NODE_ENV: 'production',
+    BACKEND_URL: 'https://notification-transit.test',
+    SENTRY_DSN: '',
+    MISTRAL_MODEL: 'unused',
+    MISTRAL_API_KEY: 'unused',
+    TELEGRAM_WEBHOOK_SECRET: 'unused',
+    TELEGRAM_BOT_TOKEN: '1:test-secret',
+    REPORT_API: { intake: async () => ({ ok: true, data: {} }) },
+}
+let messages: Record<string, unknown>[] = []
+let transitReads = 0
+let telegramStatus = 200
+let telegramBody: object = { ok: true }
+const deliver = async (input: unknown = notification, overrides: Partial<Env> = {}) => {
+    const ctx = createExecutionContext()
+    const entrypoint = new TelegramNotificationsEntrypoint(ctx, {
+        ...bindings,
+        ...overrides,
+        REPORT_API: {
+            fetch: async () => new Response(),
+            connect: () => {
+                throw new Error('Unused binding')
+            },
+        },
+    } as ConstructorParameters<typeof TelegramNotificationsEntrypoint>[1])
+    try {
+        await entrypoint.reportAccepted(input as AcceptedReportNotification)
+    } finally {
+        await waitOnExecutionContext(ctx)
+    }
+}
+
+beforeAll(() => {
+    fetchMock.activate()
+    fetchMock.disableNetConnect()
+    fetchMock
+        .get(bindings.BACKEND_URL)
+        .intercept({ path: '/v0/transit/stations?city=leipzig' })
+        .reply(() => {
+            transitReads++
+            return { statusCode: 200, data: { 'station-a': { name: 'A & <B>' }, 'station-b': { name: 'C' } } }
+        })
+        .persist()
+    fetchMock
+        .get(bindings.BACKEND_URL)
+        .intercept({ path: '/v0/transit/lines?city=leipzig' })
+        .reply(() => {
+            transitReads++
+            return { statusCode: 200, data: [{ id: 'line-a', name: 'L<1>', stations: ['station-a', 'station-b'] }] }
+        })
+        .persist()
+    fetchMock
+        .get('https://api.telegram.org')
+        .intercept({ path: '/bot1:test-secret/sendMessage', method: 'POST' })
+        .reply((options) => {
+            messages.push(JSON.parse(String(options.body)))
+            return { statusCode: telegramStatus, data: telegramBody }
+        })
+        .persist()
+})
+afterAll(() => {
+    fetchMock.enableNetConnect()
+    fetchMock.deactivate()
+})
+beforeEach(async () => {
+    messages = []
+    transitReads = 0
+    telegramStatus = 200
+    telegramBody = { ok: true }
+    const cache = (caches as CacheStorage & { default: Cache }).default
+    await Promise.all(
+        ['stations', 'lines'].map((name) => cache.delete(`${bindings.BACKEND_URL}/v0/transit/${name}?city=leipzig`))
+    )
+})
+
+describe('accepted report notifications', () => {
+    it('resolves the destination, names and HTML in the Telegram worker and caches transit reads', async () => {
+        await deliver()
+        expect(messages).toHaveLength(1)
+        expect(messages[0]).toMatchObject({ chat_id: CITIES.leipzig.community.telegramChatId, parse_mode: 'HTML' })
+        expect(messages[0].text).toContain('A &amp; &lt;B&gt;')
+        expect(messages[0].text).toContain('L&lt;1&gt;')
+        expect(messages[0].text).toContain(CITIES.leipzig.publicAppUrl)
+        await deliver({ ...notification, report: { ...notification.report, reportId: 2 } })
+        expect(messages).toHaveLength(2)
+        expect(transitReads).toBe(2)
+    })
+    it('skips disabled cities, Telegram echoes and non-production delivery before doing any I/O', async () => {
+        await deliver({ ...notification, city: 'berlin' })
+        await deliver({ ...notification, report: { ...notification.report, source: 'telegram' } })
+        await deliver(notification, { NODE_ENV: 'development' })
+        expect(messages).toHaveLength(0)
+        expect(transitReads).toBe(0)
+    })
+    it.each([
+        { ...notification, city: 'unknown' },
+        { ...notification, chatId: 'arbitrary-chat' },
+        { ...notification, report: { ...notification.report, text: '<b>arbitrary</b>' } },
+    ])('rejects unknown cities and caller-controlled delivery fields', async (input) => {
+        await expect(deliver(input)).rejects.toBeInstanceOf(Error)
+        expect(messages).toHaveLength(0)
+        expect(transitReads).toBe(0)
+    })
+    it('fails without a token rather than silently dropping an enabled notification', async () => {
+        await expect(deliver(notification, { TELEGRAM_BOT_TOKEN: undefined })).rejects.toBeInstanceOf(Error)
+        expect(transitReads).toBe(0)
+    })
+    it.each(['stationId', 'lineId', 'directionId'])('rejects unknown %s without sending', async (field) => {
+        await expect(
+            deliver({ ...notification, report: { ...notification.report, [field]: 'missing' } })
+        ).rejects.toBeInstanceOf(Error)
+        expect(messages).toHaveLength(0)
+    })
+    it.each([200, 400, 429])('surfaces Telegram errors without leaking the token or retrying (%s)', async (status) => {
+        telegramStatus = status
+        telegramBody = { ok: false, description: 'Failure for 1:test-secret' }
+        const error = await deliver().catch((error) => error as Error)
+        expect(error).toBeInstanceOf(Error)
+        expect(String(error)).not.toContain('1:test-secret')
+        expect(messages).toHaveLength(1)
+    })
+})


### PR DESCRIPTION
Move outbound Telegram delivery into `telegram-worker`, so bot credentials, chat selection and message formatting have one runtime owner. This restores the pre-report-gate forwarding design behind a private RPC entrypoint; incoming Telegram webhooks remain unchanged.

## Ownership and flow

```text
API normalizes -> gate persists/scores -> private reportAccepted RPC
  -> Telegram-worker resolves city policy and transit names -> formats -> Telegram sendMessage
```

`TelegramNotificationsEntrypoint.reportAccepted` accepts only a city slug and an accepted report (ID, timestamp, source and station/line/direction IDs). Its strict runtime schema rejects caller-supplied chat IDs and message HTML. It delegates to `forwardReport`, keeping transport validation separate from delivery policy.

Telegram-worker resolves the destination chat, public app URL and forwarding switch from the city registry. It skips non-production delivery, disabled cities, missing destinations and Telegram-originated reports. The existing city settings enable Leipzig forwarding and disable Berlin/Hamburg. No city-specific delivery logic is added to the API or gate.

The formatter is adapted from the old forwarding module. Names come from existing API transit reads; outgoing notifications cache those responses locally for one hour. There are no new dependencies, queues, Durable Objects, schedules or database migrations. Future city summaries can be implemented here without changing the intake path.

`sendTelegramMessage` owns token-authenticated calls, HTML parse mode and existing link-preview settings. It checks both HTTP status and Telegram's `ok` result, applies a five-second timeout, and strips the token from reported errors. The HTTP and RPC entrypoints share Sentry configuration/redaction. Delivery remains best-effort with no automatic retries or deduplication: a timed-out request may already have posted. An enabled notification without a token fails visibly rather than silently succeeding.
