### PR TITLE
refactor: remove Telegram delivery fields from gate requests

### DIFF
--- a/packages/api-worker/src/modules/report-gate/report-gate-client.ts
+++ b/packages/api-worker/src/modules/report-gate/report-gate-client.ts
@@ -43,10 +43,8 @@ const cityDescriptor = (c: Context<Env>) => {
     const city = c.get('city')
     return {
         slug: city.slug,
-        publicAppUrl: city.publicAppUrl,
         dbBinding: city.dbBinding,
-        telegramChatId: city.community.telegramChatId ?? null,
-        reporting: city.reporting,
+        reporting: { publicSubmissionsEnabled: city.reporting.publicSubmissionsEnabled },
     }
 }
 

--- a/packages/api-worker/src/modules/report-gate/report-gate-contract.ts
+++ b/packages/api-worker/src/modules/report-gate/report-gate-contract.ts
@@ -1,11 +1,8 @@
 export type CityDescriptor = {
     slug: string
-    publicAppUrl: string
     dbBinding: string
-    telegramChatId: string | null
     reporting: {
         publicSubmissionsEnabled: boolean
-        telegramForwardingEnabled: boolean
     }
 }
 

--- a/packages/api-worker/src/modules/reports/report-submission-service.ts
+++ b/packages/api-worker/src/modules/reports/report-submission-service.ts
@@ -31,10 +31,8 @@ export class ReportSubmissionService {
             submitTrustedReportToGate(gate, {
                 city: {
                     slug: city.slug,
-                    publicAppUrl: city.publicAppUrl,
                     dbBinding: city.dbBinding,
-                    telegramChatId: city.community.telegramChatId ?? null,
-                    reporting: city.reporting,
+                    reporting: { publicSubmissionsEnabled: city.reporting.publicSubmissionsEnabled },
                 },
                 report: { ...report, source: 'telegram' },
             })

--- a/packages/api-worker/tests/postReport.test.ts
+++ b/packages/api-worker/tests/postReport.test.ts
@@ -59,12 +59,9 @@ describe('Report API contract', () => {
         expect(fakeReportGate.lastIntake).toMatchObject({
             city: {
                 slug: 'berlin',
-                publicAppUrl: 'https://app.freifahren.org',
                 dbBinding: 'DB',
-                telegramChatId: '-1001370021231',
                 reporting: {
                     publicSubmissionsEnabled: true,
-                    telegramForwardingEnabled: false,
                 },
             },
             report: {
@@ -72,6 +69,11 @@ describe('Report API contract', () => {
                 directionId: null,
                 source: 'web_app',
             },
+        })
+        expect(fakeReportGate.lastIntake?.city).toEqual({
+            slug: 'berlin',
+            dbBinding: 'DB',
+            reporting: { publicSubmissionsEnabled: true },
         })
         expect(fakeReportGate.lastIntake).toHaveProperty('report.lineId')
         expect(fakeReportGate.lastIntake).not.toHaveProperty('relayPassword')


### PR DESCRIPTION
Remove Telegram delivery details from API-to-report-gate requests now that delivery belongs to Telegram-worker. Both public HTTP submissions and trusted Telegram RPC submissions send only the city slug, D1 binding and public-submission switch to the gate.

Delete `publicAppUrl`, `telegramChatId` and `telegramForwardingEnabled` from the gate contract and request construction. The API no longer supplies Telegram destination or policy information. Its normalization pipeline, trusted intake, public validation, city fallback and cache invalidation are unchanged. The API can still use its public app URL for its own cache behavior; it is no longer part of the gate delivery contract.

Update the integration assertion to check the exact reduced city descriptor, preventing accidental reintroduction of delivery fields.
