### PR TITLE
fix: evaluate predicted report thresholds in city timezone

### DIFF
--- a/packages/api-worker/src/modules/reports/reports-routes.ts
+++ b/packages/api-worker/src/modules/reports/reports-routes.ts
@@ -51,7 +51,7 @@ export const getReports = defineRoute<Env>()({
     handler: async (c) => {
         const reportsService = c.get('reportsService')
         const query = c.req.valid('query')
-        const now = DateTime.now()
+        const now = DateTime.now().setZone(c.get('city').timezone)
 
         c.header('Cache-Control', 'no-store')
 
@@ -63,7 +63,7 @@ export const getReports = defineRoute<Env>()({
                 currentTime: now,
                 viewer: await resolveViewer(c),
             })
-        ) // Intentionally pass in local time
+        )
     },
 })
 
@@ -87,10 +87,10 @@ export const getReportsByStation = defineRoute<Env>()({
                 from: query.from,
                 to: query.to,
                 stationId,
-                currentTime: DateTime.now(),
+                currentTime: DateTime.now().setZone(c.get('city').timezone),
                 viewer: await resolveViewer(c),
             })
-        ) // Intentionally pass in local time
+        )
     },
 })
 

--- a/packages/api-worker/tests/getReports.test.ts
+++ b/packages/api-worker/tests/getReports.test.ts
@@ -8,6 +8,7 @@ import {
     getDefaultReportsRange,
     MAX_REPORTS_TIMEFRAME,
 } from '../src/modules/reports/constants'
+import { calculatePredictedReportsThreshold, ReportsService } from '../src/modules/reports/reports-service'
 import { db, lineStations, lines, reports } from './test-db'
 import { appRequestWithRedirect, sendReportRequest, setSystemTime } from './test-utils'
 
@@ -389,6 +390,7 @@ describe('Predicted reports', () => {
 })
 
 describe('Predicted reports threshold', () => {
+    const originalZone = Settings.defaultZone
     let testStations: string[]
 
     const seedHistoricalData = async () => {
@@ -427,12 +429,55 @@ describe('Predicted reports threshold', () => {
 
     afterEach(() => {
         vi.restoreAllMocks()
+        Settings.defaultZone = originalZone
+        Settings.now = () => Date.now()
+        setSystemTime()
     })
 
     afterAll(async () => {
         await db.delete(reports)
         Settings.now = () => Date.now()
         setSystemTime()
+    })
+
+    it.each([
+        ['2024-01-15T07:00:00Z', 8, 1, 4],
+        ['2024-07-15T06:00:00Z', 8, 1, 4],
+        ['2024-07-15T18:00:00Z', 20, 1, 3],
+        ['2024-07-15T19:00:00Z', 21, 1, 1],
+        ['2024-07-13T22:30:00Z', 0, 7, 1],
+        ['2024-03-31T00:30:00Z', 1, 7, 1],
+        ['2024-03-31T01:30:00Z', 3, 7, 1],
+        ['2024-10-27T00:30:00Z', 2, 7, 1],
+        ['2024-10-27T01:30:00Z', 2, 7, 1],
+    ])('uses city service hours at %s in both reports endpoints', async (instant, hour, weekday, threshold) => {
+        const now = DateTime.fromISO(instant, { zone: 'utc' })
+        setSystemTime(now.toJSDate())
+        const getReports = vi.spyOn(ReportsService.prototype, 'getReports')
+
+        // Force an unrelated ambient zone even when workerd ignores the host's TZ.
+        for (const processZone of ['UTC', 'Europe/Berlin', 'America/Los_Angeles']) {
+            Settings.defaultZone = processZone
+            for (const city of ['berlin', 'hamburg', 'leipzig']) {
+                for (const path of ['/reports', `/reports/${testStations[0]}`]) {
+                    const response = await appRequestWithRedirect(`${path}?city=${city}`)
+                    expect(response.status).toBe(200)
+                    const currentTime = getReports.mock.lastCall![0].currentTime
+                    expect(currentTime.zoneName).toBe('Europe/Berlin')
+                    expect(currentTime.toMillis()).toBe(now.toMillis())
+                    expect(currentTime.hour).toBe(hour)
+                    expect(currentTime.weekday).toBe(weekday)
+                    expect(calculatePredictedReportsThreshold(currentTime)).toBe(threshold)
+                    const body = (await response.json()) as Array<{ isPredicted: boolean; stationId: string }>
+                    expect(body.length).toBeGreaterThan(0)
+                    expect(body.length).toBeLessThanOrEqual(threshold)
+                    expect(body.every((report) => report.isPredicted)).toBe(true)
+                    if (path !== '/reports') {
+                        expect(body.every((report) => report.stationId === testStations[0])).toBe(true)
+                    }
+                }
+            }
+        }
     })
 
     it('returns more predicted reports during peak hours than night hours', async () => {


### PR DESCRIPTION
Fixes #901. Resolves FRE-779.

Both reports endpoints now evaluate the predicted-report threshold in the request city's configured timezone. Commute ramps and the weekend adjustment therefore follow city time, including daylight-saving changes, instead of the host process timezone.

Adds nine API integration cases covering winter/summer commute hours, the evening cutoff, the local weekday rollover, and both DST transitions. Each exercises both endpoints for Berlin, Hamburg, and Leipzig under three Luxon default zones. Requests run through routing and real D1, with history created through POST requests; the service spy calls through to the real implementation. All nine cases failed before the fix and pass after it.

Reviewed nearby hour/weekday consumers: insights already uses city time; station guessing compares both historical and requested times in UTC. That separate historical matching behavior remains unchanged.

Validation:
- Full API suite: 277 tests passed under TZ=UTC and 277 under TZ=Europe/Berlin.
- Final regression run after test cleanup: 30 getReports tests passed under TZ=Europe/Berlin.
- API typecheck, formatting, and git diff --check passed. Lint: no errors, 14 existing warnings; changed files lint cleanly.
- Production frontend build and both existing Playwright browser tests passed against local Worker/D1.
- Additional temporary Playwright smoke check passed with REPORT_GATE_MODE=preview-open: POST a report, read real reports through both endpoints, request a future range to exercise historical predictions, and render the report list and station page with no browser JavaScript errors. Screenshot visually inspected.

The existing browser harness omits the report-gate service, so its report reads log 503s; the additional smoke check uses the supported local preview mode to exercise successful report flows. Production report-gate integration and deployment are not part of this validation. No schema, dependency, or frontend changes.



Preview verification (2026-09-06, deployed head `050ee2b5`):
- Preview deployment and all CI checks passed. GitHub deployment 6297515463 points to this exact head.
- Live API checks passed for Berlin, Hamburg, and Leipzig: transit/config, current reports, predicted reports for a future range, and station-scoped predictions. Each prediction response returned the expected nighttime minimum of one report with `isPredicted: true` and `expiresAt: null`.
- Submitted an isolated test report through the deployed browser UI (U8, Alexanderplatz). The success screen appeared and the API returned the persisted real report; report list, current-report summary, and station detail loaded the submission.
- All three cities' report forms loaded their respective transit data. Browser error log was empty.
- First-visit confirmation remained present on map/list/detail pages; backing page content was inspected without accepting that confirmation. Server-clock winter/summer and DST transitions are covered by the local/API regression matrix, not by changing the deployed clock.

Preview: https://frontend-pr-985.freifahren.workers.dev
