### PR TITLE
fix: eliminate station line-insights request and database waterfalls

### DIFF
--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -180,7 +180,7 @@ export const createCityServices = (db: DbConnection, city: CityConfig, cacheCtx:
     return {
         transitNetworkDataService,
         reportsService,
-        insightsService: new InsightsService(db, transitNetworkDataService, city.timezone),
+        insightsService: new InsightsService(db, transitNetworkDataService, city.timezone, city.slug, cacheCtx),
         riskService: new RiskService(reportsService, transitNetworkDataService),
     }
 }

--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -1,4 +1,4 @@
-import type { D1Database } from '@cloudflare/workers-types'
+import type { D1Database, WorkerVersionMetadata } from '@cloudflare/workers-types'
 import { CITY_SLUGS, type CityConfig, DEFAULT_CITY_SLUG, getCity } from '@freifahren/cities'
 import { Context, Hono } from 'hono'
 
@@ -15,6 +15,7 @@ import type { CacheCtx } from './modules/transit/reference-cache'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
 
 export type Bindings = {
+    CF_VERSION_METADATA?: WorkerVersionMetadata
     // Cloudflare D1 binding. Present on Workers and, in tests, provided by the Miniflare pool.
     DB?: D1Database
     DB_HAMBURG?: D1Database
@@ -174,7 +175,9 @@ export const createCityDatabase = (env: Bindings, city: CityConfig): DbConnectio
     return createD1Db(binding)
 }
 
-export const createCityServices = (db: DbConnection, city: CityConfig, cacheCtx: CacheCtx): Services => {
+export const createCityServices = (db: DbConnection, city: CityConfig, ctx: CacheCtx, version?: string): Services => {
+    // Cache API entries outlive deploys, while preview deploys can replace the underlying transit seed.
+    const cacheCtx: CacheCtx = ctx ? { version, waitUntil: (promise) => ctx.waitUntil(promise) } : undefined
     const transitNetworkDataService = new TransitNetworkDataService(db, city.slug, cacheCtx)
     const reportsService = new ReportsService(db, transitNetworkDataService)
     return {
@@ -195,7 +198,7 @@ const applyServices = (c: Context<Env>, db: DbConnection, config: AppConfig) => 
         cacheCtx = undefined
     }
 
-    const services = createCityServices(db, c.get('city'), cacheCtx)
+    const services = createCityServices(db, c.get('city'), cacheCtx, c.env.CF_VERSION_METADATA?.id)
     c.set('config', config)
     c.set('reportsService', services.reportsService)
     c.set(

--- a/packages/api-worker/src/db/preview-databases.ts
+++ b/packages/api-worker/src/db/preview-databases.ts
@@ -113,6 +113,7 @@ const provision = (pr: string, out: string) => {
         compatibility_date: COMPATIBILITY_DATE,
         compatibility_flags: COMPATIBILITY_FLAGS,
         cache: { enabled: true },
+        version_metadata: { binding: 'CF_VERSION_METADATA' },
         // No `routes`, so a preview can never take traffic on the production hostname.
         workers_dev: true,
         d1_databases: d1Databases,

--- a/packages/api-worker/src/index.ts
+++ b/packages/api-worker/src/index.ts
@@ -7,7 +7,7 @@ import { corsAllowOrigin, Env, registerContext } from './app-env'
 import { handleError } from './common/error-handler'
 import { registerVersionedRoutes } from './common/router'
 import { getConfig } from './modules/config'
-import { getLineInsights, getStationInsights } from './modules/insights'
+import { getLineInsights, getLinesInsights, getStationInsights } from './modules/insights'
 import {
     insightsCacheMiddleware,
     VERSIONED_INSIGHTS_CACHEABLE_PATHS,
@@ -111,7 +111,7 @@ export const createApp = () => {
         v0: [getRisk],
     })
     registerVersionedRoutes(app, 'insights', 'v0', {
-        v0: [getStationInsights, getLineInsights],
+        v0: [getStationInsights, getLinesInsights, getLineInsights],
     })
     // Deliberately absent from the Workers Cache middlewares above — see config-routes.
     registerVersionedRoutes(app, 'config', 'v0', {

--- a/packages/api-worker/src/modules/insights/insights-cache-middleware.ts
+++ b/packages/api-worker/src/modules/insights/insights-cache-middleware.ts
@@ -6,6 +6,7 @@ import type { Env } from '../../app-env'
 export const VERSIONED_INSIGHTS_CACHEABLE_PATHS = [
     '/:version{v\\d+}/insights/station/:stationId',
     '/:version{v\\d+}/insights/lines/:lineName',
+    '/:version{v\\d+}/insights/lines',
 ] as const
 
 export const INSIGHTS_CACHE_CONTROL = 'public, max-age=0, must-revalidate'
@@ -24,11 +25,9 @@ export const insightsCacheMiddleware: MiddlewareHandler<Env> = async (c, next) =
     if (c.req.method !== 'GET' || c.res.status >= 400) return
 
     c.header('Cache-Control', INSIGHTS_CACHE_CONTROL)
-    const lineName = c.req.param('lineName')
+    const isLineInsights = c.req.path.includes('/insights/lines')
     c.header(
         'Cloudflare-CDN-Cache-Control',
-        lineName !== undefined
-            ? lineInsightsWorkersCacheControl(c.get('city').timezone)
-            : INSIGHTS_WORKERS_CACHE_CONTROL
+        isLineInsights ? lineInsightsWorkersCacheControl(c.get('city').timezone) : INSIGHTS_WORKERS_CACHE_CONTROL
     )
 }

--- a/packages/api-worker/src/modules/insights/insights-routes.ts
+++ b/packages/api-worker/src/modules/insights/insights-routes.ts
@@ -26,3 +26,20 @@ export const getLineInsights = defineRoute<Env>()({
         return c.json(await c.get('insightsService').getLineInsights(lineName))
     },
 })
+
+export const getLinesInsights = defineRoute<Env>()({
+    method: 'get',
+    path: '/lines',
+    schemas: {
+        query: z.object({
+            names: z
+                .string()
+                .transform((value) => value.split(','))
+                .pipe(z.array(z.string().min(1).max(100)).min(1).max(50)),
+        }),
+    },
+    handler: async (c) => {
+        const { names } = c.req.valid('query')
+        return c.json(await c.get('insightsService').getLinesInsights(names))
+    },
+})

--- a/packages/api-worker/src/modules/insights/insights-service.ts
+++ b/packages/api-worker/src/modules/insights/insights-service.ts
@@ -75,8 +75,8 @@ export class InsightsService {
     constructor(
         private db: DbConnection,
         private transitNetworkDataService: TransitNetworkDataService,
-        private timezone: string = 'UTC',
-        private citySlug: string = 'unknown',
+        private timezone: string,
+        private citySlug: string,
         private cacheCtx: CacheCtx = undefined
     ) {}
 

--- a/packages/api-worker/src/modules/insights/insights-service.ts
+++ b/packages/api-worker/src/modules/insights/insights-service.ts
@@ -1,11 +1,12 @@
-import { asc, count, desc, eq, gte, inArray } from 'drizzle-orm'
+import { asc, count, gte, inArray, sql } from 'drizzle-orm'
 import { DateTime } from 'luxon'
 import { z } from 'zod'
 
 import { AppError } from '../../common/errors'
-import { DbConnection, lines, reports, stations } from '../../db'
+import { DbConnection, reports } from '../../db'
 import type { TransitNetworkDataService } from '../transit/transit-network-data-service'
-import type { StationId } from '../transit/types'
+import { cachedReference, type CacheCtx } from '../transit/reference-cache'
+import type { StationId, Stations } from '../transit/types'
 
 const THIRTY_DAYS_IN_MS = 30 * 24 * 60 * 60 * 1000
 const MIN_PROFILE_REPORTS = 80
@@ -66,13 +67,17 @@ export const lineInsightsSchema = z.object({
 
 export type LineInsights = z.infer<typeof lineInsightsSchema>
 
+type CityProfile = { start: string | null; hours: Array<{ hour: number; value: number }> }
+
 const toIso = (date: Date) => date.toISOString()
 
 export class InsightsService {
     constructor(
         private db: DbConnection,
         private transitNetworkDataService: TransitNetworkDataService,
-        private timezone: string = 'UTC'
+        private timezone: string = 'UTC',
+        private citySlug: string = 'unknown',
+        private cacheCtx: CacheCtx = undefined
     ) {}
 
     async getStationInsights(stationId: StationId, now: Date = new Date()): Promise<StationInsights> {
@@ -108,25 +113,99 @@ export class InsightsService {
     }
 
     async getLineInsights(lineName: string, now: Date = new Date()): Promise<LineInsights> {
-        const matchingLines = await this.db.select({ id: lines.id }).from(lines).where(eq(lines.name, lineName))
-        if (matchingLines.length === 0) {
-            throw new AppError({
-                message: 'Line not found',
-                statusCode: 404,
-                internalCode: 'LINE_NOT_FOUND',
-                description: `lineName=${lineName}`,
-            })
+        const [insights] = await this.getLinesInsights([lineName], now)
+        return insights!
+    }
+
+    async getLinesInsights(lineNames: string[], now: Date = new Date()): Promise<LineInsights[]> {
+        const allLines = await this.transitNetworkDataService.getLines()
+        const names = [...new Set(lineNames)]
+        const variantsByName = new Map(names.map((name) => [name, allLines.filter((line) => line.name === name)]))
+        for (const [name, variants] of variantsByName) {
+            if (variants.length === 0) {
+                throw new AppError({
+                    message: 'Line not found',
+                    statusCode: 404,
+                    internalCode: 'LINE_NOT_FOUND',
+                    description: `lineName=${name}`,
+                })
+            }
         }
-        const variantIds = matchingLines.map((line) => line.id)
+        const selectedLines = [...variantsByName.values()].flat()
+        // Read history once for the entire preload; live predictions never enter these insights.
+        const [historicalReports, stationNames] = await Promise.all([
+            this.db
+                .select({ lineId: reports.lineId, timestamp: reports.timestamp, stationId: reports.stationId })
+                .from(reports)
+                .where(
+                    inArray(
+                        reports.lineId,
+                        selectedLines.map((line) => line.id)
+                    )
+                )
+                .orderBy(asc(reports.timestamp)),
+            this.transitNetworkDataService.getStations(),
+        ])
+        const nameById = new Map(selectedLines.map((line) => [line.id, line.name]))
+        const historyByName = new Map(names.map((name) => [name, [] as typeof historicalReports]))
+        for (const report of historicalReports) {
+            const name = report.lineId === null ? undefined : nameById.get(report.lineId)
+            if (name !== undefined) historyByName.get(name)!.push(report)
+        }
+        let cityProfile: Promise<CityProfile> | undefined
+        return Promise.all(
+            names.map((name) =>
+                this.buildLineInsights(
+                    name,
+                    variantsByName.get(name)!.length,
+                    historyByName.get(name)!,
+                    stationNames,
+                    now,
+                    () => (cityProfile ??= this.getCityProfile(now))
+                )
+            )
+        )
+    }
 
-        // Historical insights read the reports table directly. Predictions belong only to the live
-        // Reports service and must never enter this cacheable response.
-        const historicalReports = await this.db
-            .select({ timestamp: reports.timestamp, stationId: reports.stationId })
-            .from(reports)
-            .where(inArray(reports.lineId, variantIds))
-            .orderBy(asc(reports.timestamp))
+    private async getCityProfile(now: Date): Promise<CityProfile> {
+        const localNow = DateTime.fromJSDate(now, { zone: this.timezone })
+        const ttl = Math.max(1, Math.ceil(localNow.plus({ days: 1 }).startOf('day').diff(localNow, 'seconds').seconds))
+        return cachedReference(
+            this.citySlug,
+            `city-profile-v1/${this.timezone}/${localNow.toISODate()}`,
+            async () => {
+                // UTC quarter-hours preserve local hour/weekday boundaries, including DST and fractional offsets.
+                const bucket = sql<number>`cast(${reports.timestamp} / 900000 as integer)`
+                const rows = await this.db
+                    .select({
+                        bucket,
+                        first: sql<number>`min(${reports.timestamp})`,
+                        value: count(),
+                    })
+                    .from(reports)
+                    .groupBy(bucket)
+                const hours = Array.from({ length: 24 }, (_, hour) => ({ hour, value: 0 }))
+                let first: number | undefined
+                for (const row of rows) {
+                    first = first === undefined ? row.first : Math.min(first, row.first)
+                    const time = DateTime.fromMillis(row.bucket * 900000, { zone: this.timezone })
+                    if (time.weekday === localNow.weekday) hours[time.hour]!.value += row.value
+                }
+                return { start: first === undefined ? null : new Date(first).toISOString(), hours }
+            },
+            this.cacheCtx,
+            `public, max-age=${ttl}`
+        )
+    }
 
+    private async buildLineInsights(
+        lineName: string,
+        variantCount: number,
+        historicalReports: Array<{ timestamp: Date; stationId: string }>,
+        stationNames: Stations,
+        now: Date,
+        loadCityProfile: () => Promise<CityProfile>
+    ): Promise<LineInsights> {
         const weekday = DateTime.fromJSDate(now, { zone: this.timezone }).weekday
         const lineProfileReports = historicalReports.filter(
             (report) => DateTime.fromJSDate(report.timestamp, { zone: this.timezone }).weekday === weekday
@@ -139,32 +218,36 @@ export class InsightsService {
         )
         const profileUsesCityFallback =
             lineProfileReports.length < MIN_PROFILE_REPORTS || profileWeeks.size < MIN_PROFILE_WEEKS
-        const profileReports = profileUsesCityFallback
-            ? await this.db.select({ timestamp: reports.timestamp }).from(reports).orderBy(asc(reports.timestamp))
-            : lineProfileReports
-        const profileRange = { start: toIso(profileReports[0]?.timestamp ?? now), end: toIso(now) }
+        const cityProfile = profileUsesCityFallback ? await loadCityProfile() : undefined
+        const profileRange = {
+            start: cityProfile ? (cityProfile.start ?? toIso(now)) : toIso(lineProfileReports[0]?.timestamp ?? now),
+            end: toIso(now),
+        }
         const observedRange = { start: toIso(historicalReports[0]?.timestamp ?? now), end: toIso(now) }
-        const hours = Array.from({ length: 24 }, (_, hour) => ({ hour, value: 0 }))
+        const hours = cityProfile?.hours ?? Array.from({ length: 24 }, (_, hour) => ({ hour, value: 0 }))
         const totalsByStation = new Map<string, number>()
-        for (const report of profileReports) {
-            const time = DateTime.fromJSDate(report.timestamp, { zone: this.timezone })
-            if (time.weekday === weekday) hours[time.hour]!.value += 1
+        if (!cityProfile) {
+            for (const report of lineProfileReports) {
+                const time = DateTime.fromJSDate(report.timestamp, { zone: this.timezone })
+                hours[time.hour]!.value += 1
+            }
         }
         for (const report of historicalReports) {
             totalsByStation.set(report.stationId, (totalsByStation.get(report.stationId) ?? 0) + 1)
         }
 
-        const hotspotRows = await this.db
-            .select({ stationId: stations.id, name: stations.name, value: count() })
-            .from(reports)
-            .innerJoin(stations, eq(stations.id, reports.stationId))
-            .where(inArray(reports.lineId, variantIds))
-            .groupBy(stations.id, stations.name)
-            .orderBy(desc(count()))
+        const hotspotRows = [...totalsByStation]
+            .filter(([stationId]) => Object.hasOwn(stationNames, stationId))
+            .map(([stationId, value]) => ({ stationId, name: stationNames[stationId]!.name, value }))
+            .sort((a, b) => {
+                if (a.value !== b.value) return b.value - a.value
+                if (a.stationId === b.stationId) return 0
+                return a.stationId < b.stationId ? -1 : 1
+            })
 
         const total = historicalReports.length
         return lineInsightsSchema.parse({
-            line: { name: lineName, variantCount: variantIds.length },
+            line: { name: lineName, variantCount },
             profile: {
                 source: profileUsesCityFallback ? 'city_reports' : 'line_reports',
                 metric: { name: 'report_count', range: profileRange },

--- a/packages/api-worker/src/modules/reports/telegram-reports-entrypoint.ts
+++ b/packages/api-worker/src/modules/reports/telegram-reports-entrypoint.ts
@@ -38,7 +38,7 @@ export class TelegramReportsEntrypoint extends WorkerEntrypoint<Bindings> {
             }
             const city = resolveCityBySlug(parsed.data.city)
             const db = createCityDatabase(this.env, city)
-            const { reportsService } = createCityServices(db, city, this.ctx)
+            const { reportsService } = createCityServices(db, city, this.ctx, this.env.CF_VERSION_METADATA?.id)
             const service = new ReportSubmissionService({
                 city,
                 reportsService,

--- a/packages/api-worker/src/modules/transit/reference-cache.ts
+++ b/packages/api-worker/src/modules/transit/reference-cache.ts
@@ -31,7 +31,8 @@ export const cachedReference = async <T>(
     citySlug: string,
     key: string,
     loader: () => Promise<T>,
-    ctx: CacheCtx
+    ctx: CacheCtx,
+    cacheControl: string = REFERENCE_CACHE_CONTROL
 ): Promise<T> => {
     const cache = typeof caches !== 'undefined' ? (caches as unknown as { default: EdgeCache }).default : undefined
     if (cache === undefined) {
@@ -48,7 +49,7 @@ export const cachedReference = async <T>(
     const entry = new Response(JSON.stringify(value), {
         headers: {
             'Content-Type': 'application/json',
-            'Cache-Control': REFERENCE_CACHE_CONTROL,
+            'Cache-Control': cacheControl,
             'Cache-Tag': transitCacheTag(citySlug),
         },
     })

--- a/packages/api-worker/src/modules/transit/reference-cache.ts
+++ b/packages/api-worker/src/modules/transit/reference-cache.ts
@@ -14,9 +14,10 @@ interface EdgeCache {
 const INTERNAL_ORIGIN = 'https://transit-reference.internal'
 
 // City-scoped internal cache key, so one city's reference data never serves another's.
-export const referenceCacheKey = (citySlug: string, key: string): string => `${INTERNAL_ORIGIN}/${citySlug}/${key}`
+export const referenceCacheKey = (citySlug: string, key: string, version?: string): string =>
+    `${INTERNAL_ORIGIN}/${version !== undefined ? `${encodeURIComponent(version)}/` : ''}${citySlug}/${key}`
 
-export type CacheCtx = { waitUntil(promise: Promise<unknown>): void } | undefined
+export type CacheCtx = { version?: string; waitUntil(promise: Promise<unknown>): void } | undefined
 
 /*
  * Read-through cache for static transit reference data (stations, lines, segments,
@@ -39,7 +40,7 @@ export const cachedReference = async <T>(
         return loader()
     }
 
-    const cacheKey = new Request(referenceCacheKey(citySlug, key))
+    const cacheKey = new Request(referenceCacheKey(citySlug, key, ctx?.version))
     const cached = await cache.match(cacheKey)
     if (cached !== undefined) {
         return (await cached.json()) as T

--- a/packages/api-worker/tests/getInsights.test.ts
+++ b/packages/api-worker/tests/getInsights.test.ts
@@ -195,6 +195,86 @@ describe('GET /insights/lines/:lineName', () => {
         )
     })
 
+    it('batches distinct line names with the same payloads as individual requests', async () => {
+        setSystemTime(new Date('2026-07-13T09:00:00.000Z'))
+        for (const [index, variantLineId] of variantLineIds.entries()) {
+            expect(
+                (
+                    await sendReportRequest({
+                        stationId: variantStationIds[index]!,
+                        lineId: variantLineId,
+                        source: 'web_app',
+                    })
+                ).status
+            ).toBe(200)
+        }
+        const names = [...new Set([lineName, multiVariantLineName])]
+        const response = await appRequestWithRedirect(
+            `/insights/lines?names=${encodeURIComponent([...names, names[0]].join(','))}`
+        )
+        expect(response.status).toBe(200)
+        expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBe('public, max-age=46800')
+        const batch = await response.json()
+        const individual = await Promise.all(
+            names.map(async (name) => {
+                const response = await appRequestWithRedirect(`/insights/lines/${encodeURIComponent(name)}`)
+                return response.json()
+            })
+        )
+        expect(batch).toEqual(individual)
+    })
+
+    it.each(['', '?names=', '?names=UNKNOWN_LINE', '?names=' + Array(51).fill('U8').join(',')])(
+        'rejects invalid batches: %s',
+        async (query) => {
+            const response = await appRequestWithRedirect(`/insights/lines${query}`)
+            expect(response.status).toBe(query.includes('UNKNOWN_LINE') ? 404 : 400)
+            expect(response.headers.get('Cloudflare-CDN-Cache-Control')).toBeNull()
+        }
+    )
+
+    it('preserves city-local weekdays, repeated DST hours, and the exact oldest timestamp', async () => {
+        const timestamps = [
+            '2026-10-24T21:59:59.000Z',
+            '2026-10-24T22:00:01.000Z',
+            '2026-10-25T00:05:00.000Z',
+            '2026-10-25T00:06:00.000Z',
+            '2026-10-25T01:05:00.000Z',
+        ]
+        for (const timestamp of timestamps) await sendReportAt(new Date(timestamp))
+        setSystemTime(new Date('2026-10-25T12:00:00.000Z'))
+        const response = await appRequestWithRedirect(`/insights/lines?names=${encodeURIComponent(lineName)}`)
+        const [insight] = lineInsightsSchema.array().parse(await response.json())
+        expect(insight.profile.source).toBe('city_reports')
+        expect(insight.profile.metric.range.start).toBe(timestamps[0])
+        expect(insight.profile.weekday).toBe(7)
+        expect(insight.profile.hours.filter((hour: { value: number }) => hour.value > 0)).toEqual([
+            { hour: 0, value: 1 },
+            { hour: 2, value: 3 },
+        ])
+        expect(insight.hotspots.stations).toEqual([])
+    })
+
+    it('retains the line-specific threshold and excludes other weekdays and city reports', async () => {
+        const first = new Date('2026-01-05T12:00:00.000Z')
+        for (let week = 0; week < 24; week++) {
+            setSystemTime(new Date(first.getTime() + week * 7 * 86400000))
+            for (let report = 0; report < 4; report++) {
+                expect((await sendReportRequest({ stationId, lineId, source: 'web_app' })).status).toBe(200)
+            }
+        }
+        await sendReportAt(new Date('2026-06-22T08:00:00.000Z'))
+        setSystemTime(new Date('2026-06-23T08:00:00.000Z'))
+        expect((await sendReportRequest({ stationId, lineId, source: 'web_app' })).status).toBe(200)
+        setSystemTime(new Date('2026-06-29T12:00:00.000Z'))
+        const response = await appRequestWithRedirect(`/insights/lines?names=${encodeURIComponent(lineName)}`)
+        const [insight] = lineInsightsSchema.array().parse(await response.json())
+        expect(insight.profile.source).toBe('line_reports')
+        expect(insight.profile.metric.range.start).toBe(first.toISOString())
+        expect(insight.profile.hours.reduce((sum: number, hour: { value: number }) => sum + hour.value, 0)).toBe(96)
+        expect(insight.hotspots.stations).toEqual([{ stationId, name: expect.any(String), value: 97, share: 1 }])
+    })
+
     it('returns the standard line-not-found error', async () => {
         const response = await appRequestWithRedirect('/insights/lines/UNKNOWN_LINE')
 

--- a/packages/api-worker/tests/getInsights.test.ts
+++ b/packages/api-worker/tests/getInsights.test.ts
@@ -1,3 +1,4 @@
+import { createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { eq } from 'drizzle-orm'
 
@@ -5,6 +6,7 @@ import { lines, lineStations, reports } from '../src/db'
 import { lineInsightsSchema, stationInsightsSchema } from '../src/modules/insights'
 import { appRequestWithRedirect, sendReportRequest, setSystemTime } from './test-utils'
 import { db } from './test-db'
+import { referenceCacheKey } from '../src/modules/transit/reference-cache'
 
 let stationId: string
 let lineId: string
@@ -273,6 +275,45 @@ describe('GET /insights/lines/:lineName', () => {
         expect(insight.profile.metric.range.start).toBe(first.toISOString())
         expect(insight.profile.hours.reduce((sum: number, hour: { value: number }) => sum + hour.value, 0)).toBe(96)
         expect(insight.hotspots.stations).toEqual([{ stationId, name: expect.any(String), value: 97, share: 1 }])
+    })
+
+    it('shares the cached city fallback across lines and refreshes on a new local date', async () => {
+        const cache = (caches as unknown as { default: Cache }).default
+        const keys = [
+            'lines',
+            'stations',
+            'city-profile-v1/Europe/Berlin/2027-01-04',
+            'city-profile-v1/Europe/Berlin/2027-01-05',
+        ].map((key) => new Request(referenceCacheKey('berlin', key)))
+        const getCached = async (name: string) => {
+            const ctx = createExecutionContext()
+            const response = await appRequestWithRedirect(
+                `/insights/lines/${encodeURIComponent(name)}`,
+                undefined,
+                undefined,
+                ctx
+            )
+            await waitOnExecutionContext(ctx)
+            expect(response.status).toBe(200)
+            return lineInsightsSchema.parse(await response.json())
+        }
+        try {
+            await sendReportAt(new Date('2027-01-04T09:00:00.000Z'))
+            const first = await getCached(lineName)
+            expect(first.profile.hours[10]!.value).toBe(1)
+            await sendReportAt(new Date('2027-01-04T10:00:00.000Z'))
+            const otherLine = await getCached(multiVariantLineName)
+            expect(otherLine.profile.hours).toEqual(first.profile.hours)
+            const entry = await cache.match(keys[2]!)
+            expect(entry?.headers.get('Cache-Control')).toBe('public, max-age=50400')
+            await sendReportAt(new Date('2027-01-05T11:00:00.000Z'))
+            const nextDay = await getCached(lineName)
+            expect(nextDay.profile.weekday).toBe(2)
+            expect(nextDay.profile.hours.filter((hour) => hour.value > 0)).toEqual([{ hour: 12, value: 1 }])
+            expect(nextDay.profile.metric.range.start).toBe(first.profile.metric.range.start)
+        } finally {
+            await Promise.all(keys.map((key) => cache.delete(key)))
+        }
     })
 
     it('returns the standard line-not-found error', async () => {

--- a/packages/api-worker/tests/reference-cache.test.ts
+++ b/packages/api-worker/tests/reference-cache.test.ts
@@ -61,6 +61,16 @@ describe('cachedReference (real Cache API)', () => {
         expect(entry!.headers.get('Cache-Control')).toBe(REFERENCE_CACHE_CONTROL)
     })
 
+    it('honors a shorter lifetime for date-scoped insights', async () => {
+        const key = internalKey('berlin', 'spec-city-profile')
+        await withCtx((ctx) =>
+            cachedReference('berlin', 'spec-city-profile', async () => ({ hours: [] }), ctx, 'public, max-age=30')
+        )
+        const entry = await cache.match(key)
+        expect(entry?.headers.get('Cache-Control')).toBe('public, max-age=30')
+        expect(entry?.headers.get('Cache-Tag')).toBe(transitCacheTag('berlin'))
+    })
+
     it('namespaces cached values by resource key', async () => {
         internalKey('berlin', 'stations')
         internalKey('berlin', 'lines')

--- a/packages/api-worker/tests/reference-cache.test.ts
+++ b/packages/api-worker/tests/reference-cache.test.ts
@@ -19,8 +19,8 @@ const cache = (
 // deleted again so no other suite reads this file's fabricated reference data.
 const usedKeys: Request[] = []
 
-const internalKey = (citySlug: string, key: string): Request => {
-    const request = new Request(referenceCacheKey(citySlug, key))
+const internalKey = (citySlug: string, key: string, version?: string): Request => {
+    const request = new Request(referenceCacheKey(citySlug, key, version))
     usedKeys.push(request)
     return request
 }
@@ -39,6 +39,24 @@ const withCtx = async <T>(run: (ctx: ExecutionContext) => Promise<T>): Promise<T
 }
 
 describe('cachedReference (real Cache API)', () => {
+    it('reuses data within a deployment without reading another deployment or city', async () => {
+        const key = 'spec-versioned'
+        const load = (city: string, version: string, value: number) => {
+            internalKey(city, key, version)
+            return withCtx((ctx) =>
+                cachedReference(city, key, async () => value, {
+                    version,
+                    waitUntil: (promise) => ctx.waitUntil(promise),
+                })
+            )
+        }
+
+        expect(await load('berlin', 'old-version', 1)).toBe(1)
+        expect(await load('berlin', 'new-version', 2)).toBe(2)
+        expect(await load('berlin', 'new-version', 3)).toBe(2)
+        expect(await load('hamburg', 'new-version', 4)).toBe(4)
+    })
+
     it('invokes the loader once on a miss and serves the second call from the cache', async () => {
         internalKey('berlin', 'spec-read-through')
         const loader = vi.fn(async () => ({ answer: 42 }))

--- a/packages/api-worker/tests/test-utils.ts
+++ b/packages/api-worker/tests/test-utils.ts
@@ -153,13 +153,18 @@ export const setSystemTime = (date?: Date) => {
     vi.setSystemTime(date)
 }
 
-export const appRequestWithRedirect = async (path: string, init?: RequestInit, targetApp = app) => {
-    const response = await targetApp.request(path, init, testEnv())
+export const appRequestWithRedirect = async (
+    path: string,
+    init?: RequestInit,
+    targetApp = app,
+    executionCtx?: ExecutionContext
+) => {
+    const response = await targetApp.request(path, init, testEnv(), executionCtx)
     if (response.status === 307) {
         const location = response.headers.get('Location')
         if (location) {
             const url = new URL(location, 'http://localhost')
-            return targetApp.request(url.pathname + url.search, init, testEnv())
+            return targetApp.request(url.pathname + url.search, init, testEnv(), executionCtx)
         }
     }
     return response

--- a/packages/api-worker/wrangler.jsonc
+++ b/packages/api-worker/wrangler.jsonc
@@ -7,6 +7,9 @@
     "cache": {
         "enabled": true,
     },
+    "version_metadata": {
+        "binding": "CF_VERSION_METADATA",
+    },
     "observability": {
         "traces": {
             "enabled": true,

--- a/packages/frontend-next/e2e/insights-preview.spec.ts
+++ b/packages/frontend-next/e2e/insights-preview.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+
+test.skip(!process.env.PREVIEW_URL || !process.env.PREVIEW_API_URL, 'Requires an isolated preview');
+const api = process.env.PREVIEW_API_URL!;
+const isBatch = (url: string) => new URL(url).pathname === '/v0/insights/lines';
+const isSingle = (url: string) => new URL(url).pathname.startsWith('/v0/insights/lines/');
+
+async function stationFixture(request: APIRequestContext, city: string) {
+  const [stationsResponse, linesResponse] = await Promise.all([
+    request.get(`${api}/v0/transit/stations?city=${city}`),
+    request.get(`${api}/v0/transit/lines?city=${city}`),
+  ]);
+  expect(stationsResponse.ok()).toBe(true);
+  expect(linesResponse.ok()).toBe(true);
+  const stations = (await stationsResponse.json()) as Record<
+    string,
+    { name: string; lines: string[] }
+  >;
+  const lines = (await linesResponse.json()) as Array<{ id: string; name: string }>;
+  const nameById = new Map(lines.map((line) => [line.id, line.name]));
+  const candidates = Object.entries(stations).map(([id, station]) => ({
+    id,
+    name: station.name,
+    names: [
+      ...new Set(
+        station.lines.map((id) => nameById.get(id)).filter((name): name is string => !!name),
+      ),
+    ],
+  }));
+  candidates.sort((a, b) => b.names.length - a.names.length);
+  expect(candidates[0].names.length).toBeGreaterThan(1);
+  return candidates[0];
+}
+
+// Response timestamps can differ between separately cached requests; their historical data must agree.
+function historicalData(insight: Record<string, unknown>) {
+  const data = structuredClone(insight) as {
+    profile: { metric: { range: { end?: string } } };
+    hotspots: { metric: { range: { end?: string } } };
+  };
+  delete data.profile.metric.range.end;
+  delete data.hotspots.metric.range.end;
+  return data;
+}
+
+for (const city of ['berlin', 'hamburg', 'leipzig']) {
+  test(`${city}: batch agrees with individual line responses`, async ({ request }) => {
+    const station = await stationFixture(request, city);
+    const batch = await request.get(
+      `${api}/v0/insights/lines?names=${encodeURIComponent(station.names.sort().join(','))}&city=${city}`,
+    );
+    expect(batch.ok()).toBe(true);
+    expect(batch.headers()['cloudflare-cdn-cache-control']).toMatch(/max-age=\d+/);
+    const insights = await batch.json();
+    expect(insights).toHaveLength(station.names.length);
+    for (const insight of insights) {
+      const single = await request.get(
+        `${api}/v0/insights/lines/${encodeURIComponent(insight.line.name)}?city=${city}`,
+      );
+      expect(single.ok()).toBe(true);
+      expect(historicalData(insight)).toEqual(historicalData(await single.json()));
+    }
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() =>
+    localStorage.setItem('legalDisclaimerAcceptedAt', new Date().toISOString()),
+  );
+});
+
+test('one preload serves every line, warm navigation and returning to the station', async ({
+  page,
+  request,
+}) => {
+  const station = await stationFixture(request, 'berlin');
+  const batches: string[] = [];
+  const singles: string[] = [];
+  page.on('request', (request) => {
+    if (isBatch(request.url())) batches.push(request.url());
+    if (isSingle(request.url())) singles.push(request.url());
+  });
+  const batch = page.waitForResponse((response) => isBatch(response.url()));
+  await page.goto(`/station/${station.id}?city=berlin`);
+  expect((await batch).ok()).toBe(true);
+  await expect(page.getByRole('heading', { name: station.name, exact: true })).toBeVisible();
+  for (const name of station.names.slice(0, 3)) {
+    await page.locator(`a[href^="/line/${encodeURIComponent(name)}?"]`).click();
+    await expect(page.locator('#line-typical-activity-heading')).toBeVisible();
+    await expect(page.locator('[aria-busy="true"]')).toHaveCount(0);
+    await page.goBack();
+    await expect(page.getByRole('heading', { name: station.name, exact: true })).toBeVisible();
+  }
+  expect(batches).toHaveLength(1);
+  expect(singles).toHaveLength(0);
+  await page.screenshot({ path: test.info().outputPath('station.png') });
+});
+
+test('navigation during an unfinished preload reuses the in-flight request', async ({
+  page,
+  request,
+}) => {
+  const station = await stationFixture(request, 'berlin');
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const singles: string[] = [];
+  page.on('request', (request) => {
+    if (isSingle(request.url())) singles.push(request.url());
+  });
+  await page.route('**/v0/insights/lines?**', async (route) => {
+    const response = await route.fetch();
+    await held;
+    await route.fulfill({ response });
+  });
+  await page.goto(`/station/${station.id}?city=berlin`);
+  const name = station.names[0];
+  await page.locator(`a[href^="/line/${encodeURIComponent(name)}?"]`).click();
+  await expect(page.locator('[aria-busy="true"]')).toBeVisible();
+  release();
+  await expect(page.locator('#line-typical-activity-heading')).toBeVisible();
+  expect(singles).toHaveLength(0);
+  await page.screenshot({ path: test.info().outputPath('line.png') });
+});
+
+test('a failed batch retries and leaves line navigation usable', async ({ page, request }) => {
+  const station = await stationFixture(request, 'berlin');
+  await page.route('**/v0/insights/lines?**', (route) =>
+    route.fulfill({ status: 503, body: '{}' }),
+  );
+  const recovered = page.waitForResponse((response) => isSingle(response.url()) && response.ok());
+  await page.goto(`/station/${station.id}?city=berlin`);
+  await recovered;
+  await page.locator(`a[href^="/line/${encodeURIComponent(station.names[0])}?"]`).click();
+  await expect(page.locator('#line-typical-activity-heading')).toBeVisible();
+});

--- a/packages/frontend-next/e2e/insights-preview.spec.ts
+++ b/packages/frontend-next/e2e/insights-preview.spec.ts
@@ -32,14 +32,17 @@ async function stationFixture(request: APIRequestContext, city: string) {
   return candidates[0];
 }
 
-// Response timestamps can differ between separately cached requests; their historical data must agree.
+// Empty ranges use request time for both bounds; only historical timestamps must agree.
 function historicalData(insight: Record<string, unknown>) {
   const data = structuredClone(insight) as {
-    profile: { metric: { range: { end?: string } } };
-    hotspots: { metric: { range: { end?: string } } };
+    profile: { metric: { range: { start?: string; end?: string } } };
+    hotspots: { metric: { range: { start?: string; end?: string } } };
   };
-  delete data.profile.metric.range.end;
-  delete data.hotspots.metric.range.end;
+  for (const section of [data.profile, data.hotspots]) {
+    const { range } = section.metric;
+    if (range.start === range.end) delete range.start;
+    delete range.end;
+  }
   return data;
 }
 
@@ -50,7 +53,7 @@ for (const city of ['berlin', 'hamburg', 'leipzig']) {
       `${api}/v0/insights/lines?names=${encodeURIComponent(station.names.sort().join(','))}&city=${city}`,
     );
     expect(batch.ok()).toBe(true);
-    expect(batch.headers()['cloudflare-cdn-cache-control']).toMatch(/max-age=\d+/);
+    expect(batch.headers()['cache-control']).toBe('public, max-age=0, must-revalidate');
     const insights = await batch.json();
     expect(insights).toHaveLength(station.names.length);
     for (const insight of insights) {

--- a/packages/frontend-next/playwright.preview.config.ts
+++ b/packages/frontend-next/playwright.preview.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: 'insights-preview.spec.ts',
+  timeout: 60_000,
+  workers: 1,
+  use: {
+    baseURL: process.env.PREVIEW_URL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'desktop', use: { ...devices['Desktop Chrome'] } },
+    { name: 'mobile-safari', use: { ...devices['iPhone 13'] } },
+  ],
+});

--- a/packages/frontend-next/src/api/insights.ts
+++ b/packages/frontend-next/src/api/insights.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { type QueryClient, useQuery } from '@tanstack/react-query';
 
 import { DAY_MS } from './reports';
 import { fetchJson } from './transit';
@@ -47,3 +47,28 @@ export const lineInsightsQueryOptions = (lineName: string) => ({
 });
 
 export const useLineInsights = (lineName: string) => useQuery(lineInsightsQueryOptions(lineName));
+
+export function prefetchLineInsights(queryClient: QueryClient, lineNames: string[]) {
+  const pending: string[] = [];
+  let batch: Promise<LineInsights[]> | undefined;
+  for (const lineName of new Set(lineNames)) {
+    void queryClient.prefetchQuery({
+      ...lineInsightsQueryOptions(lineName),
+      queryFn: () => {
+        if (pending.includes(lineName)) return lineInsightsQueryOptions(lineName).queryFn();
+        pending.push(lineName);
+        // Keep the individual cache keys (including in-flight deduplication) while sharing one request.
+        batch ??= Promise.resolve().then(() =>
+          fetchJson<LineInsights[]>(
+            `/v0/insights/lines?names=${encodeURIComponent(pending.sort().join(','))}`,
+          ),
+        );
+        return batch.then((insights) => {
+          const insight = insights.find((entry) => entry.line.name === lineName);
+          if (!insight) throw new Error('Missing line insights');
+          return insight;
+        });
+      },
+    });
+  }
+}

--- a/packages/frontend-next/src/components/map/StationDetail.tsx
+++ b/packages/frontend-next/src/components/map/StationDetail.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { lineInsightsQueryOptions } from '@/api/insights';
+import { prefetchLineInsights } from '@/api/insights';
 import { DAY_MS, useReports } from '@/api/reports';
 import { resolveStationLineNames, type Station, useLines } from '@/api/transit';
 import { Button } from '@/components/ui/button';
@@ -32,9 +32,7 @@ export function StationDetail({ station, onClose }: StationDetailProps) {
 
   useEffect(() => {
     if (!lines) return;
-    for (const lineName of resolveStationLineNames(station.lines, lines)) {
-      void queryClient.prefetchQuery(lineInsightsQueryOptions(lineName));
-    }
+    prefetchLineInsights(queryClient, resolveStationLineNames(station.lines, lines));
   }, [lines, queryClient, station.lines]);
 
   return (


### PR DESCRIPTION
Opening a station previously preloaded one line-insights request per served line, and each cold request repeated line lookup, hotspot aggregation, and an entire-city history read; this batches the preload and shares the history work while preserving individual React Query cache entries and navigation behavior.

- Batch uncached served lines into one GET request, retaining in-flight reuse and single-line retry recovery.
- Load requested line histories together, resolve variants and station names from cached transit data, and calculate hotspots from the loaded history.
- Share a compact city fallback profile, preserving weekday/hour calculations, DST, thresholds, and exact historical range starts.
- Scope internal transit and profile caches by Worker version: otherwise a deployment that reseeds preview D1 can reuse an older network snapshot and return inconsistent line variants.
- Correct preview assertions for Cloudflare's public cache headers and request-time bounds on empty ranges.

Validation at commit 37a460a1: all 278 D1 integration tests, API typecheck/lint, generated binding types, and Worker dry-run build passed; all 12 deployed-preview checks passed across desktop Chromium and mobile WebKit, covering all-city batch/single parity, warm navigation, in-flight reuse, and failed-preload recovery, and repeated fresh Leipzig requests now return consistent variant counts.

Closes #871
Closes #872
