### PR TITLE
feat: add journey routing with inspection risk per leg

### DIFF
--- a/packages/api-worker/README.md
+++ b/packages/api-worker/README.md
@@ -74,6 +74,15 @@ development, run all three Worker configs together; only this API is exposed:
 bun run dev:with-report-gate
 ```
 
+The `report-gate` Worker lives outside this repository, so that command only works with access to
+it. Without it, every route that resolves a viewer — `/reports`, `/risk`, `/transit/route` — answers
+`503 REPORT_GATE_UNAVAILABLE`. To work on those paths locally, put the switch that PR previews use
+into `.dev.vars` and run the plain `bun run dev`:
+
+```sh
+echo 'REPORT_GATE_MODE=preview-open' >> .dev.vars
+```
+
 The Stripe webhook signing secret remains an API Worker secret:
 
 ```sh

--- a/packages/api-worker/src/app-env.ts
+++ b/packages/api-worker/src/app-env.ts
@@ -12,6 +12,7 @@ import { ReportSubmissionService } from './modules/reports/report-submission-ser
 import { invalidateStationReportsCache } from './modules/reports/reports-cache-middleware'
 import { RiskService } from './modules/risk'
 import type { CacheCtx } from './modules/transit/reference-cache'
+import { RouteService } from './modules/transit/route-service'
 import { TransitNetworkDataService } from './modules/transit/transit-network-data-service'
 
 export type Bindings = {
@@ -82,6 +83,7 @@ export type Services = {
     insightsService: InsightsService
     riskService: RiskService
     transitNetworkDataService: TransitNetworkDataService
+    routeService: RouteService
 }
 
 export type Env = {
@@ -182,6 +184,7 @@ export const createCityServices = (db: DbConnection, city: CityConfig, cacheCtx:
         reportsService,
         insightsService: new InsightsService(db, transitNetworkDataService, city.timezone),
         riskService: new RiskService(reportsService, transitNetworkDataService),
+        routeService: new RouteService(transitNetworkDataService, reportsService, city.routing),
     }
 }
 
@@ -211,6 +214,7 @@ const applyServices = (c: Context<Env>, db: DbConnection, config: AppConfig) => 
     c.set('insightsService', services.insightsService)
     c.set('riskService', services.riskService)
     c.set('transitNetworkDataService', services.transitNetworkDataService)
+    c.set('routeService', services.routeService)
 }
 
 export const registerContext = (app: Hono<Env>) => {

--- a/packages/api-worker/src/index.ts
+++ b/packages/api-worker/src/index.ts
@@ -22,7 +22,7 @@ import {
     VERSIONED_TRANSIT_CACHEABLE_PATHS,
     VERSIONED_TRANSIT_PATH,
 } from './modules/transit/transit-cache-middleware'
-import { getDistance, getLines, getSegments, getStations } from './modules/transit/transit-routes'
+import { getDistance, getLines, getRoute, getSegments, getStations } from './modules/transit/transit-routes'
 
 export const createApp = () => {
     const app = new Hono<Env>()
@@ -105,7 +105,7 @@ export const createApp = () => {
         v0: [getReports, postReport, getReportsByStation],
     })
     registerVersionedRoutes(app, 'transit', 'v0', {
-        v0: [getStations, getLines, getSegments, getDistance],
+        v0: [getStations, getLines, getSegments, getDistance, getRoute],
     })
     registerVersionedRoutes(app, 'risk', 'v0', {
         v0: [getRisk],

--- a/packages/api-worker/src/modules/risk/risk-model.ts
+++ b/packages/api-worker/src/modules/risk/risk-model.ts
@@ -302,3 +302,105 @@ export const predictSegmentRisk = (
 
     return Object.fromEntries(segmentColors)
 }
+
+export type RouteRiskTarget = { sid: string; at: Date }
+
+/**
+ * Risk for the segments of one journey, each evaluated at the moment the rider
+ * enters it rather than at a single `now`.
+ *
+ * Same components, decay tables and overlap behaviour as predictSegmentRisk; the
+ * differences are deliberate and both follow from what a journey needs:
+ *  - a per-segment clock, because the temporal decay runs on the same timescale as
+ *    a trip (direct risk halves in ~17 minutes) and the last leg is not reached now;
+ *  - every requested segment is returned, zeros included, because a journey must be
+ *    able to tell "no inspections expected" apart from "could not be determined".
+ *
+ * Only the requested segments are scored, so this costs O(targets x reports)
+ * instead of a pass over the whole network.
+ */
+export const predictRouteRisk = (
+    segments: RiskModelSegment[],
+    reports: RiskModelReport[],
+    targets: RouteRiskTarget[],
+    circularLineIds: ReadonlySet<string> = new Set()
+): Record<string, SegmentRisk> => {
+    const lineIndexes = buildLineIndexes(segments)
+    const sidToSegment = new Map(segments.map((segment) => [segment.sid, segment]))
+    const rankBySid = new Map<string, number>()
+    for (const lineIndex of lineIndexes.values()) {
+        for (const segment of lineIndex.segments) {
+            rankBySid.set(segment.sid, segment.rank)
+        }
+    }
+
+    const segmentsByStationPair = new Map<string, RiskModelSegment[]>()
+    for (const segment of segments) {
+        const pairKey = sortedPairKey(segment.fromStationId, segment.toStationId)
+        const overlapping = segmentsByStationPair.get(pairKey)
+        if (overlapping) {
+            overlapping.push(segment)
+        } else {
+            segmentsByStationPair.set(pairKey, [segment])
+        }
+    }
+
+    const result: Record<string, SegmentRisk> = {}
+
+    for (const target of targets) {
+        const targetSegment = sidToSegment.get(target.sid)
+        if (targetSegment === undefined) continue
+
+        /*
+         * A report on a line that shares this station pair counts too: the map
+         * propagates risk across overlapping segments, and taking the strongest of
+         * them keeps a journey from reading safer than the map it is drawn on.
+         */
+        const overlapping =
+            segmentsByStationPair.get(sortedPairKey(targetSegment.fromStationId, targetSegment.toStationId)) ?? []
+
+        let highestRisk = 0
+        for (const segment of overlapping) {
+            const lineIndex = lineIndexes.get(segment.lineId)
+            const rank = rankBySid.get(segment.sid)
+            if (lineIndex === undefined || rank === undefined) continue
+
+            const lineRingSize = ringSize(lineIndex, circularLineIds.has(segment.lineId))
+
+            let direct = 0
+            let bidirect = 0
+            let line = 0
+
+            for (const report of reports) {
+                if (!report.lines.includes(segment.lineId)) continue
+
+                const timeDiffSeconds = (target.at.getTime() - report.timestamp.getTime()) / 1000
+
+                if (!report.stationId) {
+                    line = Math.min(1, line + lineRisk(report, timeDiffSeconds))
+                    continue
+                }
+
+                const stationRank = lineIndex.stationRank.get(report.stationId)
+                if (stationRank === undefined) continue
+
+                const linearDistance = Math.abs(rank - stationRank)
+                const distance =
+                    lineRingSize === null ? linearDistance : Math.min(linearDistance, lineRingSize - linearDistance)
+
+                direct = Math.min(1, direct + directRisk(report, timeDiffSeconds) * spatialDecay(distance, 'direct'))
+                bidirect = Math.min(
+                    1,
+                    bidirect + bidirectRisk(report, timeDiffSeconds) * spatialDecay(distance, 'bidirect')
+                )
+                line = Math.min(1, line + lineRisk(report, timeDiffSeconds) * spatialDecay(distance, 'line'))
+            }
+
+            highestRisk = Math.max(highestRisk, Math.min(1, direct + bidirect + line))
+        }
+
+        result[target.sid] = { color: riskToColor(highestRisk), risk: Math.round(highestRisk * 1000) / 1000 }
+    }
+
+    return result
+}

--- a/packages/api-worker/src/modules/transit/pathfinding.ts
+++ b/packages/api-worker/src/modules/transit/pathfinding.ts
@@ -1,3 +1,5 @@
+import type { RouteType } from '@freifahren/cities'
+
 import { NoPathFoundError, StationNotFoundError } from '../../common/errors'
 
 export type StationId = string
@@ -18,7 +20,7 @@ export type Neighbor = {
 export type Graph = {
     stations: Map<StationId, StationWithCoords>
     neighbors: Map<StationId, Neighbor[]>
-    lineInfo: Map<LineId, { isCircular: boolean }>
+    lineInfo: Map<LineId, { isCircular: boolean; type: RouteType }>
 }
 
 type AStarState = {
@@ -30,6 +32,7 @@ type AStarState = {
 type LineRow = {
     id: LineId
     isCircular: boolean
+    type: RouteType
 }
 
 type LineStationRow = {
@@ -114,9 +117,9 @@ export const buildGraph = (stations: StationWithCoords[], lines: LineRow[], line
         stationMap.set(station.id, station)
     }
 
-    const lineInfoMap = new Map<LineId, { isCircular: boolean }>()
+    const lineInfoMap = new Map<LineId, { isCircular: boolean; type: RouteType }>()
     for (const line of lines) {
-        lineInfoMap.set(line.id, { isCircular: line.isCircular })
+        lineInfoMap.set(line.id, { isCircular: line.isCircular, type: line.type })
     }
 
     const neighborsMap = new Map<StationId, Neighbor[]>()

--- a/packages/api-worker/src/modules/transit/pathfinding.ts
+++ b/packages/api-worker/src/modules/transit/pathfinding.ts
@@ -1,4 +1,4 @@
-import type { RouteType } from '@freifahren/cities'
+import type { CityRoutingConfig, RouteType } from '@freifahren/cities'
 
 import { NoPathFoundError, StationNotFoundError } from '../../common/errors'
 
@@ -41,8 +41,12 @@ type LineStationRow = {
     order: number
 }
 
-class MinHeap {
-    private heap: AStarState[] = []
+/*
+ * Generic over the state type so both the hop-count search and the journey search
+ * can use it; ordering only ever looks at fCost.
+ */
+class MinHeap<T extends { fCost: number }> {
+    private heap: T[] = []
 
     private getParentIndex(index: number): number {
         return Math.floor((index - 1) / 2)
@@ -91,12 +95,12 @@ class MinHeap {
         }
     }
 
-    insert(item: AStarState): void {
+    insert(item: T): void {
         this.heap.push(item)
         this.heapifyUp(this.heap.length - 1)
     }
 
-    extractMin(): AStarState | undefined {
+    extractMin(): T | undefined {
         if (this.heap.length === 0) return undefined
         if (this.heap.length === 1) return this.heap.pop()!
 
@@ -202,7 +206,7 @@ export const findPathWithAStar = (graph: Graph, from: StationId, to: StationId):
         throw new StationNotFoundError(to)
     }
 
-    const openSet = new MinHeap()
+    const openSet = new MinHeap<AStarState>()
     openSet.insert({
         stationId: from,
         gCost: 0,
@@ -250,4 +254,138 @@ export const findPathWithAStar = (graph: Graph, from: StationId, to: StationId):
     }
 
     return goalState.gCost
+}
+
+export type RouteEdge = {
+    fromStationId: StationId
+    toStationId: StationId
+    lineId: LineId
+    /** Seconds from journey start until entering this edge. */
+    offsetSeconds: number
+    rideSeconds: number
+}
+
+type RouteState = {
+    stationId: StationId
+    /** Line currently ridden; null only at the origin, so boarding costs no transfer. */
+    lineId: LineId | null
+    gCost: number
+    fCost: number
+}
+
+const stateKey = (stationId: StationId, lineId: LineId | null): string => `${stationId}|${lineId ?? ''}`
+
+const EARTH_RADIUS_METERS = 6_371_000
+
+/*
+ * Local rather than imported from the seed pipeline's helper: that module belongs to
+ * the Node-only seed path and must not be pulled into the Worker bundle.
+ */
+const metersBetween = (a: StationWithCoords, b: StationWithCoords): number => {
+    const toRadians = (degrees: number) => (degrees * Math.PI) / 180
+    const deltaLat = toRadians(b.lat - a.lat)
+    const deltaLng = toRadians(b.lng - a.lng)
+    const chord =
+        Math.sin(deltaLat / 2) ** 2 +
+        Math.sin(deltaLng / 2) ** 2 * Math.cos(toRadians(a.lat)) * Math.cos(toRadians(b.lat))
+    return 2 * EARTH_RADIUS_METERS * Math.asin(Math.min(1, Math.sqrt(chord)))
+}
+
+/**
+ * Shortest journey by estimated travel time, as the edges actually ridden.
+ *
+ * Unlike findPathWithAStar, which counts hops, the search state carries the line
+ * being ridden. That makes a line change an ordinary edge with a cost instead of a
+ * special case, and it is why a slower direct line can beat a faster one that needs
+ * a transfer. Costs are seconds, so the heuristic is expressed in seconds too and
+ * stays admissible.
+ */
+export const findRoute = (graph: Graph, from: StationId, to: StationId, routing: CityRoutingConfig): RouteEdge[] => {
+    const fromStation = graph.stations.get(from)
+    const toStation = graph.stations.get(to)
+
+    if (!fromStation) {
+        throw new StationNotFoundError(from)
+    }
+    if (!toStation) {
+        throw new StationNotFoundError(to)
+    }
+    if (from === to) {
+        return []
+    }
+
+    const heuristic = (station: StationWithCoords): number =>
+        metersBetween(station, toStation) / routing.maxSpeedMetersPerSecond
+
+    const openSet = new MinHeap<RouteState>()
+    openSet.insert({ stationId: from, lineId: null, gCost: 0, fCost: heuristic(fromStation) })
+
+    const bestCost = new Map<string, number>()
+    const cameFrom = new Map<string, { state: RouteState; edge: RouteEdge }>()
+    let goalState: RouteState | null = null
+
+    while (!openSet.isEmpty()) {
+        const current = openSet.extractMin()!
+        const currentKey = stateKey(current.stationId, current.lineId)
+
+        const settled = bestCost.get(currentKey)
+        if (settled !== undefined && settled < current.gCost) {
+            continue
+        }
+        bestCost.set(currentKey, current.gCost)
+
+        if (current.stationId === to) {
+            goalState = current
+            break
+        }
+
+        for (const neighbor of graph.neighbors.get(current.stationId) ?? []) {
+            const lineType = graph.lineInfo.get(neighbor.lineId)?.type
+            if (lineType === undefined) {
+                continue
+            }
+
+            const rideSeconds = routing.secondsPerHop[lineType]
+            const transferSeconds =
+                current.lineId !== null && current.lineId !== neighbor.lineId ? routing.transferSeconds : 0
+            const gCost = current.gCost + transferSeconds + rideSeconds
+
+            const neighborKey = stateKey(neighbor.stationId, neighbor.lineId)
+            const known = bestCost.get(neighborKey)
+            if (known !== undefined && known <= gCost) {
+                continue
+            }
+            bestCost.set(neighborKey, gCost)
+
+            cameFrom.set(neighborKey, {
+                state: current,
+                edge: {
+                    fromStationId: current.stationId,
+                    toStationId: neighbor.stationId,
+                    lineId: neighbor.lineId,
+                    offsetSeconds: current.gCost + transferSeconds,
+                    rideSeconds,
+                },
+            })
+
+            openSet.insert({
+                stationId: neighbor.stationId,
+                lineId: neighbor.lineId,
+                gCost,
+                fCost: gCost + heuristic(graph.stations.get(neighbor.stationId)!),
+            })
+        }
+    }
+
+    if (!goalState) {
+        throw new NoPathFoundError(from, to)
+    }
+
+    const edges: RouteEdge[] = []
+    let step = cameFrom.get(stateKey(goalState.stationId, goalState.lineId))
+    while (step !== undefined) {
+        edges.push(step.edge)
+        step = cameFrom.get(stateKey(step.state.stationId, step.state.lineId))
+    }
+    return edges.reverse()
 }

--- a/packages/api-worker/src/modules/transit/route-service.ts
+++ b/packages/api-worker/src/modules/transit/route-service.ts
@@ -1,0 +1,251 @@
+import type { CityRoutingConfig, RouteType } from '@freifahren/cities'
+import { DateTime } from 'luxon'
+
+import { AppError, NoPathFoundError, StationNotFoundError } from '../../common/errors'
+import type { ReportsService, ViewerContext } from '../reports/reports-service'
+import { predictRouteRisk, type RiskModelReport, type RiskModelSegment } from '../risk/risk-model'
+
+import { findRoute, type RouteEdge } from './pathfinding'
+import type { TransitNetworkDataService } from './transit-network-data-service'
+import type { Line, StationId } from './types'
+
+export type RouteLegSegment = {
+    /** Null when no seeded segment backs this hop. */
+    segmentId: number | null
+    fromStationId: StationId
+    toStationId: StationId
+    offsetSeconds: number
+    /** Null when no segment backs this hop, which is not the same as no risk. */
+    risk: number | null
+}
+
+export type RouteLeg = {
+    lineId: string
+    lineName: string
+    lineColor: string
+    lineType: RouteType
+    fromStationId: StationId
+    toStationId: StationId
+    stationIds: StationId[]
+    departureOffsetSeconds: number
+    arrivalOffsetSeconds: number
+    segments: RouteLegSegment[]
+}
+
+export type RoutePlan = {
+    legs: RouteLeg[]
+    totalSeconds: number
+    stationCount: number
+    transfers: number
+    risk: {
+        overall: number
+        worstSegmentId: number | null
+        /** Hops with no segment to score. Above zero, `overall` is an incomplete answer. */
+        unratedSegments: number
+    }
+}
+
+type ResolvedEdge = { edge: RouteEdge; segmentId: number | null }
+
+const segmentKey = (lineId: string, from: StationId, to: StationId): string => `${lineId}|${from}|${to}`
+
+const groupIntoLegs = (
+    resolved: ResolvedEdge[],
+    // Indexed access is optimistic in TypeScript; a missing score has to stay expressible.
+    risks: Record<string, { risk: number } | undefined>,
+    linesById: Map<string, Line>
+): RouteLeg[] => {
+    const legs: RouteLeg[] = []
+
+    for (const { edge, segmentId } of resolved) {
+        const segment: RouteLegSegment = {
+            segmentId,
+            fromStationId: edge.fromStationId,
+            toStationId: edge.toStationId,
+            offsetSeconds: edge.offsetSeconds,
+            risk: segmentId === null ? null : (risks[String(segmentId)]?.risk ?? 0),
+        }
+
+        const current = legs.at(-1)
+        if (current !== undefined && current.lineId === edge.lineId) {
+            current.toStationId = edge.toStationId
+            current.stationIds.push(edge.toStationId)
+            current.arrivalOffsetSeconds = edge.offsetSeconds + edge.rideSeconds
+            current.segments.push(segment)
+            continue
+        }
+
+        const line = linesById.get(edge.lineId)
+        legs.push({
+            lineId: edge.lineId,
+            lineName: line?.name ?? edge.lineId,
+            lineColor: line?.color ?? '#000000',
+            lineType: line?.type ?? 'subway',
+            fromStationId: edge.fromStationId,
+            toStationId: edge.toStationId,
+            stationIds: [edge.fromStationId, edge.toStationId],
+            departureOffsetSeconds: edge.offsetSeconds,
+            arrivalOffsetSeconds: edge.offsetSeconds + edge.rideSeconds,
+            segments: [segment],
+        })
+    }
+
+    return legs
+}
+
+const summarize = (legs: RouteLeg[], resolved: ResolvedEdge[]): RoutePlan => {
+    const segments = legs.flatMap((leg) => leg.segments)
+    const rated = segments.filter((segment) => segment.risk !== null)
+
+    /*
+     * The overall level is the worst leg, not a combined probability. The model spreads
+     * one report across several neighbouring segments by design, so their values are
+     * strongly correlated; treating them as independent (1 - product of complements)
+     * would turn ten legs at 0.3 into 0.97 for what is a single inspector.
+     */
+    const overall = rated.reduce((worst, segment) => Math.max(worst, segment.risk ?? 0), 0)
+    const worst = overall > 0 ? rated.find((segment) => segment.risk === overall) : undefined
+    const lastEdge = resolved.at(-1)?.edge
+
+    return {
+        legs,
+        totalSeconds: lastEdge === undefined ? 0 : lastEdge.offsetSeconds + lastEdge.rideSeconds,
+        stationCount: resolved.length,
+        transfers: Math.max(0, legs.length - 1),
+        risk: {
+            overall,
+            worstSegmentId: worst?.segmentId ?? null,
+            unratedSegments: segments.length - rated.length,
+        },
+    }
+}
+
+export class RouteService {
+    constructor(
+        private transitNetworkDataService: TransitNetworkDataService,
+        private reportsService: ReportsService,
+        private routing: CityRoutingConfig
+    ) {}
+
+    /*
+     * Viewer-dependent and time-dependent, so this is computed per request rather than
+     * cached — the same reasoning as RiskService.getRisk.
+     */
+    async getRoute({
+        from,
+        to,
+        viewer,
+        now = DateTime.utc(),
+    }: {
+        from: StationId
+        to: StationId
+        viewer?: ViewerContext
+        now?: DateTime
+    }): Promise<RoutePlan> {
+        const graph = await this.transitNetworkDataService.getGraph()
+
+        let edges: RouteEdge[]
+        try {
+            edges = findRoute(graph, from, to, this.routing)
+        } catch (error) {
+            if (error instanceof StationNotFoundError) {
+                throw new AppError({
+                    message: 'Station not found',
+                    statusCode: 404,
+                    internalCode: 'STATION_NOT_FOUND',
+                    description: error.stationId,
+                })
+            }
+            if (error instanceof NoPathFoundError) {
+                throw new AppError({
+                    message: 'No path found between stations',
+                    statusCode: 422,
+                    internalCode: 'NO_PATH_FOUND',
+                    description: `${from}->${to}`,
+                })
+            }
+            throw error
+        }
+
+        const [segmentCollection, lines, stations] = await Promise.all([
+            this.transitNetworkDataService.getSegments(),
+            this.transitNetworkDataService.getLines(),
+            this.transitNetworkDataService.getStations(),
+        ])
+
+        /*
+         * Segments are seeded once per line variant, in the station order of that variant,
+         * so a hop ridden the other way round has no row of its own — both orientations
+         * have to resolve to the same segment.
+         */
+        const segmentByEdge = new Map<string, number>()
+        for (const feature of segmentCollection.features) {
+            const { id, line, from: segmentFrom, to: segmentTo } = feature.properties
+            segmentByEdge.set(segmentKey(line, segmentFrom, segmentTo), id)
+            segmentByEdge.set(segmentKey(line, segmentTo, segmentFrom), id)
+        }
+
+        const resolved: ResolvedEdge[] = edges.map((edge) => ({
+            edge,
+            segmentId: segmentByEdge.get(segmentKey(edge.lineId, edge.fromStationId, edge.toStationId)) ?? null,
+        }))
+
+        /*
+         * The same one-hour window the map draws markers for. Only the weighting looks
+         * ahead: a report that would be 80 minutes old on arrival is damped by the model
+         * rather than dropped, which avoids a cliff at the window edge.
+         */
+        const liveReports = await this.reportsService.getLiveReports({
+            from: now.minus({ hours: 1 }),
+            to: now,
+            currentTime: now,
+            viewer,
+        })
+
+        const reports: RiskModelReport[] = liveReports.flatMap((report) => {
+            const reportLines = report.lineId !== null ? [report.lineId] : stations[report.stationId].lines
+            if (reportLines.length === 0) return []
+            return [
+                {
+                    stationId: report.stationId,
+                    lines: reportLines,
+                    directionId: report.directionId,
+                    timestamp: report.timestamp,
+                },
+            ]
+        })
+
+        const modelSegments: RiskModelSegment[] = segmentCollection.features.map((feature) => ({
+            sid: String(feature.properties.id),
+            lineId: feature.properties.line,
+            fromStationId: feature.properties.from,
+            toStationId: feature.properties.to,
+        }))
+
+        const circularLineIds = new Set(lines.filter((line) => line.isCircular).map((line) => line.id))
+
+        try {
+            const risks = predictRouteRisk(
+                modelSegments,
+                reports,
+                resolved
+                    .filter((entry): entry is ResolvedEdge & { segmentId: number } => entry.segmentId !== null)
+                    .map((entry) => ({
+                        sid: String(entry.segmentId),
+                        at: now.plus({ seconds: entry.edge.offsetSeconds }).toJSDate(),
+                    })),
+                circularLineIds
+            )
+
+            const linesById = new Map(lines.map((line) => [line.id, line]))
+            return summarize(groupIntoLegs(resolved, risks, linesById), resolved)
+        } catch (error) {
+            throw new AppError({
+                message: 'Risk model failed',
+                statusCode: 500,
+                internalCode: 'RISK_MODEL_FAILED',
+                description: error instanceof Error ? error.message : String(error),
+            })
+        }
+    }
+}

--- a/packages/api-worker/src/modules/transit/transit-network-data-service.ts
+++ b/packages/api-worker/src/modules/transit/transit-network-data-service.ts
@@ -134,7 +134,7 @@ export class TransitNetworkDataService {
     }
 
     async getDistance(from: StationId, to: StationId): Promise<number> {
-        const graph = await this.loadGraph()
+        const graph = await this.getGraph()
 
         this.assertStationExists(graph, from, 'from')
         this.assertStationExists(graph, to, 'to')
@@ -169,7 +169,7 @@ export class TransitNetworkDataService {
         }
     }
 
-    private async loadGraph(): Promise<Graph> {
+    async getGraph(): Promise<Graph> {
         // Cache the raw rows rather than the built Graph — Graph holds Maps, which
         // Don't survive the JSON round-trip; rebuilding from rows is cheap in-process.
         const inputs = await cachedReference(this.citySlug, 'graph-inputs', () => this.loadGraphInputs(), this.cacheCtx)

--- a/packages/api-worker/src/modules/transit/transit-routes.ts
+++ b/packages/api-worker/src/modules/transit/transit-routes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 import { Env } from '../../app-env'
 import { defineRoute } from '../../common/router'
+import { resolveViewer } from '../reports/viewer'
 
 export const getStations = defineRoute<Env>()({
     method: 'get' as const,
@@ -60,5 +61,29 @@ export const getDistance = defineRoute<Env>()({
         const distance = await transitNetworkDataService.getDistance(query.from, query.to)
         c.header('Cache-Control', 'no-store')
         return c.json({ distance })
+    },
+})
+
+export const getRoute = defineRoute<Env>()({
+    method: 'get' as const,
+    path: '/route',
+    schemas: {
+        query: z
+            .object({
+                from: z.string().min(1),
+                to: z.string().min(1),
+            })
+            .refine((query) => query.from !== query.to, {
+                message: 'from and to must be different stations',
+                path: ['to'],
+            }),
+    },
+    handler: async (c) => {
+        const routeService = c.get('routeService')
+        const { from, to } = c.req.valid('query')
+        const plan = await routeService.getRoute({ from, to, viewer: await resolveViewer(c) })
+        // Depends on the viewer and on the current time, so it must not be stored at the edge.
+        c.header('Cache-Control', 'no-store')
+        return c.json(plan)
     },
 })

--- a/packages/api-worker/tests/getRoute.test.ts
+++ b/packages/api-worker/tests/getRoute.test.ts
@@ -1,4 +1,4 @@
-import { asc, eq, inArray } from 'drizzle-orm'
+import { and, asc, eq, inArray } from 'drizzle-orm'
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { createApp } from '../src'
@@ -211,6 +211,21 @@ describe('GET /v0/transit/route — risk over time', () => {
         expect(response.status).toBe(200)
         return (await response.json()) as RouteResponse
     }
+
+    it('reports a hop with no segment as unrated rather than risk-free', async () => {
+        // line_stations and segments are separate tables, so a hop can exist with no
+        // segment behind it. Reporting that as 0 would present an unscored stretch as
+        // safe, which is the one failure this feature must not have.
+        await db.delete(segments).where(and(eq(segments.lineId, LINE_ID), eq(segments.fromStationId, 'TEST_T1')))
+        isolatedApp = createApp()
+
+        const body = await isolatedRoute('TEST_T0', 'TEST_T3')
+        const gap = allSegments(body).find((segment) => segment.fromStationId === 'TEST_T1')
+
+        expect(gap?.segmentId).toBeNull()
+        expect(gap?.risk).toBeNull()
+        expect(body.risk.unratedSegments).toBe(1)
+    })
 
     it('scores the same segment lower when it is reached later in the journey', async () => {
         // Reported at the far end of the line, so the shared segments sit far enough away

--- a/packages/api-worker/tests/getRoute.test.ts
+++ b/packages/api-worker/tests/getRoute.test.ts
@@ -1,0 +1,240 @@
+import { asc, eq, inArray } from 'drizzle-orm'
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { createApp } from '../src'
+import { db, lines, lineStations, reports, segments, stations } from './test-db'
+import { appRequestWithRedirect, resetTestEnv, sendReportRequest } from './test-utils'
+
+type RouteSegment = {
+    segmentId: number | null
+    fromStationId: string
+    toStationId: string
+    offsetSeconds: number
+    risk: number | null
+}
+
+type RouteResponse = {
+    legs: {
+        lineId: string
+        lineName: string
+        stationIds: string[]
+        departureOffsetSeconds: number
+        arrivalOffsetSeconds: number
+        segments: RouteSegment[]
+    }[]
+    totalSeconds: number
+    stationCount: number
+    transfers: number
+    risk: { overall: number; worstSegmentId: number | null; unratedSegments: number }
+}
+
+type ErrorResponse = { details: { internal_code: string } }
+
+let lineId: string
+let stationIds: string[]
+let routeApp = createApp()
+
+const getRoute = (from: string, to: string) =>
+    appRequestWithRedirect(`/transit/route?${new URLSearchParams({ from, to }).toString()}`, undefined, routeApp)
+
+const routeBody = async (from: string, to: string): Promise<RouteResponse> => {
+    const response = await getRoute(from, to)
+    expect(response.status).toBe(200)
+    return (await response.json()) as RouteResponse
+}
+
+const allSegments = (body: RouteResponse): RouteSegment[] => body.legs.flatMap((leg) => leg.segments)
+
+describe('GET /v0/transit/route', () => {
+    beforeAll(async () => {
+        // Find six consecutive stations on one line in the seeded data rather than naming
+        // stations, so the test does not depend on a particular city's network.
+        const rows = await db
+            .select({ lineId: lineStations.lineId, stationId: lineStations.stationId })
+            .from(lineStations)
+            .orderBy(asc(lineStations.lineId), asc(lineStations.order))
+
+        for (let index = 0; index + 5 < rows.length; index++) {
+            const window = rows.slice(index, index + 6)
+            if (window.every((row) => row.lineId === window[0].lineId)) {
+                lineId = window[0].lineId
+                stationIds = window.map((row) => row.stationId)
+                return
+            }
+        }
+
+        throw new Error('Expected seeded transit data to contain six consecutive stations on one line')
+    })
+
+    beforeEach(async () => {
+        routeApp = createApp()
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        resetTestEnv()
+        await db.delete(reports)
+    })
+
+    it('returns a single leg for a ride along one line', async () => {
+        const body = await routeBody(stationIds[0], stationIds[3])
+
+        expect(body.legs).toHaveLength(1)
+        expect(body.legs[0].lineId).toBe(lineId)
+        expect(body.legs[0].stationIds).toEqual(stationIds.slice(0, 4))
+        expect(body.transfers).toBe(0)
+        expect(body.stationCount).toBe(3)
+        expect(body.totalSeconds).toBeGreaterThan(0)
+    })
+
+    it('increases the offset of every following segment', async () => {
+        const offsets = allSegments(await routeBody(stationIds[0], stationIds[3])).map(
+            (segment) => segment.offsetSeconds
+        )
+
+        expect(offsets[0]).toBe(0)
+        expect(offsets).toEqual([...offsets].sort((a, b) => a - b))
+        expect(new Set(offsets).size).toBe(offsets.length)
+    })
+
+    it('resolves segments when travelling against the seeded direction', async () => {
+        const body = await routeBody(stationIds[3], stationIds[0])
+
+        expect(body.risk.unratedSegments).toBe(0)
+        expect(allSegments(body).every((segment) => segment.segmentId !== null)).toBe(true)
+    })
+
+    it('reports no risk while there are no reports', async () => {
+        const body = await routeBody(stationIds[0], stationIds[3])
+
+        expect(body.risk.overall).toBe(0)
+        expect(body.risk.worstSegmentId).toBeNull()
+        // A risk-free leg is scored, not omitted: null would mean "could not determine".
+        expect(allSegments(body).every((segment) => segment.risk === 0)).toBe(true)
+    })
+
+    it('raises the risk of a segment a report was filed on', async () => {
+        await sendReportRequest({ stationId: stationIds[1], lineId, source: 'web_app' }, routeApp)
+
+        const body = await routeBody(stationIds[0], stationIds[3])
+
+        expect(body.risk.overall).toBeGreaterThan(0)
+        expect(body.risk.worstSegmentId).not.toBeNull()
+    })
+
+    it('rejects a request without parameters', async () => {
+        const response = await appRequestWithRedirect('/transit/route', undefined, routeApp)
+
+        expect(response.status).toBe(400)
+    })
+
+    it('rejects identical origin and destination', async () => {
+        const response = await getRoute(stationIds[0], stationIds[0])
+
+        expect(response.status).toBe(400)
+    })
+
+    it('returns 404 when a station id does not exist', async () => {
+        const response = await getRoute('UNKNOWN_STATION', stationIds[0])
+
+        expect(response.status).toBe(404)
+        expect(((await response.json()) as ErrorResponse).details.internal_code).toBe('STATION_NOT_FOUND')
+    })
+
+    it('is not stored at the edge', async () => {
+        // Guards against the route being added to the cacheable transit paths: the answer
+        // depends on the viewer and on the current time.
+        const response = await getRoute(stationIds[0], stationIds[2])
+
+        expect(response.headers.get('Cache-Control')).toBe('no-store')
+    })
+})
+
+/*
+ * The seeded network offers alternative lines between most station pairs, so two
+ * journeys over "the same" stretch can legitimately come back on different lines and
+ * share no segments at all. This isolated line has no alternatives, which is what makes
+ * arrival time the only difference between the two journeys below.
+ */
+describe('GET /v0/transit/route — risk over time', () => {
+    const LINE_ID = 'TEST_TL'
+    const STATION_IDS = Array.from({ length: 8 }, (_, index) => `TEST_T${index}`)
+
+    let isolatedApp = createApp()
+
+    beforeEach(async () => {
+        await db.insert(stations).values(
+            STATION_IDS.map((id, index) => ({
+                id,
+                name: `Timing Test ${index}`,
+                lat: 52.9 + index * 0.01,
+                lng: 13.9,
+            }))
+        )
+        await db.insert(lines).values({ id: LINE_ID, name: 'Timing Test Line', type: 'subway', isCircular: false })
+        await db
+            .insert(lineStations)
+            .values(STATION_IDS.map((stationId, order) => ({ lineId: LINE_ID, stationId, order })))
+        await db.insert(segments).values(
+            STATION_IDS.slice(0, -1).map((fromStationId, position) => ({
+                lineId: LINE_ID,
+                fromStationId,
+                toStationId: STATION_IDS[position + 1],
+                position,
+                color: '#123456',
+                coordinates: [
+                    [13.9, 52.9 + position * 0.01],
+                    [13.9, 52.9 + (position + 1) * 0.01],
+                ] as [number, number][],
+            }))
+        )
+        // Built after the fixture so its reference reads see the isolated line.
+        isolatedApp = createApp()
+        await db.delete(reports)
+    })
+
+    afterEach(async () => {
+        resetTestEnv()
+        await db.delete(reports)
+        await db.delete(segments).where(eq(segments.lineId, LINE_ID))
+        await db.delete(lineStations).where(eq(lineStations.lineId, LINE_ID))
+        await db.delete(lines).where(eq(lines.id, LINE_ID))
+        await db.delete(stations).where(inArray(stations.id, STATION_IDS))
+    })
+
+    const isolatedRoute = async (from: string, to: string): Promise<RouteResponse> => {
+        const response = await appRequestWithRedirect(
+            `/transit/route?${new URLSearchParams({ from, to }).toString()}`,
+            undefined,
+            isolatedApp
+        )
+        expect(response.status).toBe(200)
+        return (await response.json()) as RouteResponse
+    }
+
+    it('scores the same segment lower when it is reached later in the journey', async () => {
+        // Reported at the far end of the line, so the shared segments sit far enough away
+        // spatially that their risk stays below the model's cap — a saturated 1.0 cannot
+        // show a difference no matter how much later it is reached.
+        await sendReportRequest({ stationId: 'TEST_T7', lineId: LINE_ID, source: 'web_app' }, isolatedApp)
+
+        // Same destination, same line, same report: only the time to reach the shared
+        // segments differs, so temporal decay is the sole cause of any difference.
+        const nearby = await isolatedRoute('TEST_T4', 'TEST_T6')
+        const distant = await isolatedRoute('TEST_T0', 'TEST_T6')
+
+        const nearbyById = new Map(allSegments(nearby).map((segment) => [segment.segmentId, segment]))
+        const comparable = allSegments(distant).filter((segment) => {
+            const sooner = nearbyById.get(segment.segmentId)
+            return sooner !== undefined && sooner.risk !== null && sooner.risk > 0 && sooner.risk < 1
+        })
+
+        expect(comparable).not.toHaveLength(0)
+
+        for (const segment of comparable) {
+            const sooner = nearbyById.get(segment.segmentId)!
+            expect(segment.offsetSeconds).toBeGreaterThan(sooner.offsetSeconds)
+            expect(segment.risk!).toBeLessThan(sooner.risk!)
+        }
+    })
+})

--- a/packages/api-worker/tests/route-planning.test.ts
+++ b/packages/api-worker/tests/route-planning.test.ts
@@ -1,4 +1,4 @@
-import type { CityRoutingConfig } from '@freifahren/cities'
+import type { CityRoutingConfig, RouteType } from '@freifahren/cities'
 import { describe, expect, it } from 'vitest'
 
 import { NoPathFoundError, StationNotFoundError } from '../src/common/errors'
@@ -21,7 +21,7 @@ const routing: CityRoutingConfig = {
     maxSpeedMetersPerSecond: 22,
 }
 
-const line = (id: string, type: 'subway' | 'tram') => ({ id, isCircular: false, type })
+const line = (id: string, type: RouteType) => ({ id, isCircular: false, type })
 
 describe('buildGraph', () => {
     it('carries the route type of each line', () => {
@@ -79,10 +79,15 @@ describe('findRoute', () => {
     })
 
     it('prefers the slower-per-hop line when it avoids a transfer', () => {
-        // Direct tram A->B->C costs 180; the subway pair costs 100 + 240 + 100.
+        /*
+         * The direct train costs 2 x 150 = 300; the subway pair costs 100 + 240 + 100.
+         * The per-hop rates are deliberately the wrong way round: without the transfer
+         * cost the subway pair would win at 200, so only the transfer can produce this
+         * result. A cheaper-per-hop direct line would pass even with free transfers.
+         */
         const graph = buildGraph(
             threeStations,
-            [line('T1', 'tram'), line('L1', 'subway'), line('L2', 'subway')],
+            [line('T1', 'train'), line('L1', 'subway'), line('L2', 'subway')],
             [
                 { lineId: 'T1', stationId: 'A', order: 0 },
                 { lineId: 'T1', stationId: 'B', order: 1 },

--- a/packages/api-worker/tests/route-planning.test.ts
+++ b/packages/api-worker/tests/route-planning.test.ts
@@ -1,11 +1,27 @@
+import type { CityRoutingConfig } from '@freifahren/cities'
 import { describe, expect, it } from 'vitest'
 
-import { buildGraph } from '../src/modules/transit/pathfinding'
+import { NoPathFoundError, StationNotFoundError } from '../src/common/errors'
+import { buildGraph, findRoute } from '../src/modules/transit/pathfinding'
 
 const stations = [
     { id: 'A', name: 'A', lat: 52.5, lng: 13.4 },
     { id: 'B', name: 'B', lat: 52.51, lng: 13.41 },
 ]
+
+const threeStations = [
+    { id: 'A', name: 'A', lat: 52.5, lng: 13.4 },
+    { id: 'B', name: 'B', lat: 52.51, lng: 13.41 },
+    { id: 'C', name: 'C', lat: 52.52, lng: 13.42 },
+]
+
+const routing: CityRoutingConfig = {
+    secondsPerHop: { subway: 100, light_rail: 120, tram: 90, bus: 95, train: 150 },
+    transferSeconds: 240,
+    maxSpeedMetersPerSecond: 22,
+}
+
+const line = (id: string, type: 'subway' | 'tram') => ({ id, isCircular: false, type })
 
 describe('buildGraph', () => {
     it('carries the route type of each line', () => {
@@ -19,5 +35,117 @@ describe('buildGraph', () => {
         )
 
         expect(graph.lineInfo.get('L1')?.type).toBe('tram')
+    })
+})
+
+describe('findRoute', () => {
+    it('returns one edge per hop along a single line', () => {
+        const graph = buildGraph(
+            threeStations,
+            [line('L1', 'subway')],
+            [
+                { lineId: 'L1', stationId: 'A', order: 0 },
+                { lineId: 'L1', stationId: 'B', order: 1 },
+                { lineId: 'L1', stationId: 'C', order: 2 },
+            ]
+        )
+
+        const edges = findRoute(graph, 'A', 'C', routing)
+
+        expect(edges.map((edge) => [edge.fromStationId, edge.toStationId])).toEqual([
+            ['A', 'B'],
+            ['B', 'C'],
+        ])
+        expect(edges.map((edge) => edge.offsetSeconds)).toEqual([0, 100])
+    })
+
+    it('charges the transfer cost once when changing lines', () => {
+        const graph = buildGraph(
+            threeStations,
+            [line('L1', 'subway'), line('L2', 'subway')],
+            [
+                { lineId: 'L1', stationId: 'A', order: 0 },
+                { lineId: 'L1', stationId: 'B', order: 1 },
+                { lineId: 'L2', stationId: 'B', order: 0 },
+                { lineId: 'L2', stationId: 'C', order: 1 },
+            ]
+        )
+
+        const edges = findRoute(graph, 'A', 'C', routing)
+
+        expect(edges.map((edge) => edge.lineId)).toEqual(['L1', 'L2'])
+        // Second edge starts after the first ride (100) plus one transfer (240).
+        expect(edges[1].offsetSeconds).toBe(340)
+    })
+
+    it('prefers the slower-per-hop line when it avoids a transfer', () => {
+        // Direct tram A->B->C costs 180; the subway pair costs 100 + 240 + 100.
+        const graph = buildGraph(
+            threeStations,
+            [line('T1', 'tram'), line('L1', 'subway'), line('L2', 'subway')],
+            [
+                { lineId: 'T1', stationId: 'A', order: 0 },
+                { lineId: 'T1', stationId: 'B', order: 1 },
+                { lineId: 'T1', stationId: 'C', order: 2 },
+                { lineId: 'L1', stationId: 'A', order: 0 },
+                { lineId: 'L1', stationId: 'B', order: 1 },
+                { lineId: 'L2', stationId: 'B', order: 0 },
+                { lineId: 'L2', stationId: 'C', order: 1 },
+            ]
+        )
+
+        expect(findRoute(graph, 'A', 'C', routing).map((edge) => edge.lineId)).toEqual(['T1', 'T1'])
+    })
+
+    it('boarding at the origin costs no transfer', () => {
+        const graph = buildGraph(
+            stations,
+            [line('L1', 'subway')],
+            [
+                { lineId: 'L1', stationId: 'A', order: 0 },
+                { lineId: 'L1', stationId: 'B', order: 1 },
+            ]
+        )
+
+        expect(findRoute(graph, 'A', 'B', routing)[0].offsetSeconds).toBe(0)
+    })
+
+    it('returns no edges when origin and destination are the same', () => {
+        const graph = buildGraph(
+            stations,
+            [line('L1', 'subway')],
+            [
+                { lineId: 'L1', stationId: 'A', order: 0 },
+                { lineId: 'L1', stationId: 'B', order: 1 },
+            ]
+        )
+
+        expect(findRoute(graph, 'A', 'A', routing)).toEqual([])
+    })
+
+    it('throws when the target is unreachable', () => {
+        const graph = buildGraph(
+            [...stations, { id: 'X', name: 'X', lat: 52.6, lng: 13.5 }],
+            [line('L1', 'subway')],
+            [
+                { lineId: 'L1', stationId: 'A', order: 0 },
+                { lineId: 'L1', stationId: 'B', order: 1 },
+            ]
+        )
+
+        expect(() => findRoute(graph, 'A', 'X', routing)).toThrow(NoPathFoundError)
+    })
+
+    it('throws when a station id is unknown', () => {
+        const graph = buildGraph(
+            stations,
+            [line('L1', 'subway')],
+            [
+                { lineId: 'L1', stationId: 'A', order: 0 },
+                { lineId: 'L1', stationId: 'B', order: 1 },
+            ]
+        )
+
+        expect(() => findRoute(graph, 'A', 'NOPE', routing)).toThrow(StationNotFoundError)
     })
 })

--- a/packages/api-worker/tests/route-planning.test.ts
+++ b/packages/api-worker/tests/route-planning.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildGraph } from '../src/modules/transit/pathfinding'
+
+const stations = [
+    { id: 'A', name: 'A', lat: 52.5, lng: 13.4 },
+    { id: 'B', name: 'B', lat: 52.51, lng: 13.41 },
+]
+
+describe('buildGraph', () => {
+    it('carries the route type of each line', () => {
+        const graph = buildGraph(
+            stations,
+            [{ id: 'L1', isCircular: false, type: 'tram' as const }],
+            [
+                { lineId: 'L1', stationId: 'A', order: 0 },
+                { lineId: 'L1', stationId: 'B', order: 1 },
+            ]
+        )
+
+        expect(graph.lineInfo.get('L1')?.type).toBe('tram')
+    })
+})

--- a/packages/api-worker/tests/route-planning.test.ts
+++ b/packages/api-worker/tests/route-planning.test.ts
@@ -2,6 +2,7 @@ import type { CityRoutingConfig, RouteType } from '@freifahren/cities'
 import { describe, expect, it } from 'vitest'
 
 import { NoPathFoundError, StationNotFoundError } from '../src/common/errors'
+import { predictRouteRisk, predictSegmentRisk } from '../src/modules/risk/risk-model'
 import { buildGraph, findRoute } from '../src/modules/transit/pathfinding'
 
 const stations = [
@@ -152,5 +153,66 @@ describe('findRoute', () => {
         )
 
         expect(() => findRoute(graph, 'A', 'NOPE', routing)).toThrow(StationNotFoundError)
+    })
+})
+
+describe('predictRouteRisk', () => {
+    const segments = [
+        { sid: '1', lineId: 'L1', fromStationId: 'A', toStationId: 'B' },
+        { sid: '2', lineId: 'L1', fromStationId: 'B', toStationId: 'C' },
+    ]
+    const now = new Date('2026-09-08T12:00:00Z')
+    const reports = [{ stationId: 'A', lines: ['L1'], directionId: null, timestamp: now }]
+
+    it('scores a segment the rider enters right away', () => {
+        const result = predictRouteRisk(segments, reports, [{ sid: '1', at: now }])
+
+        expect(result['1'].risk).toBeGreaterThan(0)
+    })
+
+    it('scores the same segment lower the later it is entered', () => {
+        const immediately = predictRouteRisk(segments, reports, [{ sid: '1', at: now }])
+        const inHalfAnHour = predictRouteRisk(segments, reports, [
+            { sid: '1', at: new Date(now.getTime() + 30 * 60_000) },
+        ])
+
+        expect(inHalfAnHour['1'].risk).toBeLessThan(immediately['1'].risk)
+    })
+
+    it('returns an entry for every target, including risk-free ones', () => {
+        /*
+         * predictSegmentRisk drops green segments because the map only paints the rest.
+         * A journey must report every leg it was asked about: a missing entry would be
+         * indistinguishable from a leg whose risk could not be determined.
+         */
+        const result = predictRouteRisk(
+            segments,
+            [],
+            [
+                { sid: '1', at: now },
+                { sid: '2', at: now },
+            ]
+        )
+
+        expect(Object.keys(result).sort()).toEqual(['1', '2'])
+        expect(result['1'].risk).toBe(0)
+    })
+
+    it('matches predictSegmentRisk when the target is evaluated at now', () => {
+        const viaMap = predictSegmentRisk(segments, reports, now)
+        const viaRoute = predictRouteRisk(segments, reports, [{ sid: '1', at: now }])
+
+        expect(viaRoute['1'].risk).toBeCloseTo(viaMap['1'].risk, 10)
+    })
+
+    it('inherits risk from a parallel line over the same station pair', () => {
+        // The map propagates risk across segments sharing a station pair; a journey has
+        // to agree with what the user sees on it.
+        const overlapping = [...segments, { sid: '3', lineId: 'L2', fromStationId: 'A', toStationId: 'B' }]
+        const onOtherLine = [{ stationId: 'A', lines: ['L2'], directionId: null, timestamp: now }]
+
+        const result = predictRouteRisk(overlapping, onOtherLine, [{ sid: '1', at: now }])
+
+        expect(result['1'].risk).toBeGreaterThan(0)
     })
 })

--- a/packages/cities/src/berlin.ts
+++ b/packages/cities/src/berlin.ts
@@ -70,6 +70,14 @@ export const BERLIN: CityConfig = {
         bounds: [13.088, 52.338, 13.761, 52.675],
         styleUrl: 'https://tiles.freifahren.org/styles/berlin.json',
     },
+    // Order-of-magnitude values derived from typical stop spacing and travel speeds,
+    // not measurements. Precision matters less than the relative ageing they produce:
+    // they decide how stale a report is by the time the rider reaches a leg.
+    routing: {
+        secondsPerHop: { subway: 100, light_rail: 120, tram: 90, bus: 95, train: 150 },
+        transferSeconds: 240,
+        maxSpeedMetersPerSecond: 22,
+    },
     tiles: {
         osmUrl: 'https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf',
     },

--- a/packages/cities/src/hamburg.ts
+++ b/packages/cities/src/hamburg.ts
@@ -64,6 +64,11 @@ export const HAMBURG: CityConfig = {
         bounds: [9.727, 53.369, 10.348, 53.733],
         styleUrl: 'https://tiles.freifahren.org/styles/hamburg.json',
     },
+    routing: {
+        secondsPerHop: { subway: 100, light_rail: 120, tram: 90, bus: 95, train: 150 },
+        transferSeconds: 240,
+        maxSpeedMetersPerSecond: 22,
+    },
     tiles: {
         osmUrl: 'https://download.geofabrik.de/europe/germany/hamburg-latest.osm.pbf',
     },

--- a/packages/cities/src/leipzig.ts
+++ b/packages/cities/src/leipzig.ts
@@ -60,6 +60,11 @@ export const LEIPZIG: CityConfig = {
         bounds: [12.18, 51.24, 12.56, 51.45],
         styleUrl: 'https://tiles.freifahren.org/styles/leipzig.json',
     },
+    routing: {
+        secondsPerHop: { subway: 100, light_rail: 120, tram: 90, bus: 95, train: 150 },
+        transferSeconds: 240,
+        maxSpeedMetersPerSecond: 22,
+    },
     tiles: {
         // No Leipzig-only Geofabrik extract exists, so the whole Saxony extract is used
         // and cropped to the city bounds (clipToMapBounds).

--- a/packages/cities/src/types.ts
+++ b/packages/cities/src/types.ts
@@ -143,6 +143,21 @@ export interface CityMap {
 }
 
 /**
+ * Travel-time estimates for journey planning. The network data carries no
+ * timetable — no departures, headways or service hours — so these constants are
+ * the only source of duration. They drive two things: which route the planner
+ * prefers, and how far a report has aged by the time the rider reaches a leg.
+ */
+export interface CityRoutingConfig {
+    /** Seconds for one stop-to-stop hop, by route type. Includes dwell time. */
+    secondsPerHop: Record<RouteType, number>
+    /** Seconds added when changing lines: walking plus expected wait. */
+    transferSeconds: number
+    /** Upper bound on travel speed in m/s. Only used to keep the A* heuristic admissible. */
+    maxSpeedMetersPerSecond: number
+}
+
+/**
  * A single city's complete configuration. City is a runtime dimension resolved
  * from the hostname (or an explicit `?city=` param on the API); this registry is
  * the single source of truth for everything that differs between cities.
@@ -163,6 +178,7 @@ export interface CityConfig extends CityDatabaseConfig {
     timezone: string
     reporting: CityReportingConfig
     map: CityMap
+    routing: CityRoutingConfig
     /** Basemap tile-build inputs. Every city ships with a basemap. */
     tiles: CityTiles
     seed: CitySeedConfig


### PR DESCRIPTION
## Describe the issue:

Answering "should I expect an inspection on the way to X?" currently means reading it off the map: find your line, follow it with your eyes, judge the colours along the way. The data to answer it directly is already here — `predictSegmentRisk` scores every segment, and the graph in `transit/pathfinding.ts` already knows how stations connect. What is missing is the path between two stations and a way to score it.

This is an outside proposal with no prior issue, so the honest first question is whether the direction is wanted at all. A journey view moves the app closer to something people could mistake for a trip planner, which is a product call rather than a technical one. I have tried to make the boundary explicit below, and I am happy to drop this if it does not fit.

## Explain how you solved the issue:

`GET /v0/transit/route?from=&to=` returns the legs of a journey with a risk score per segment.

**No second risk model.** `predictSegmentRisk` is unchanged, line for line; its tests pass untouched. Alongside it, `predictRouteRisk` shares the same components, decay tables and overlap propagation, and differs in two ways that follow from what a journey needs:

- **A clock per segment.** The temporal decay runs on the same timescale as a trip — direct risk halves in roughly 17 minutes — so scoring a whole journey at `now` overstates every leg the rider has not reached yet. Each segment is evaluated at its estimated arrival instead.
- **Every requested segment is returned, zeros included.** The map drops green segments because it only paints the rest; a journey has to distinguish "nothing expected" from "could not be determined".

It scores only the requested segments, so it costs O(targets × reports) instead of a pass over the whole network — cheaper than the `/v0/risk` call that already runs per request.

**Routing.** `findPathWithAStar` answers "how many hops apart", which is all `/transit/distance` needs, and stays untouched. `findRoute` sits beside it with a search state of `(station, line)`, which turns a transfer into an ordinary edge with a cost rather than a special case — that is what lets a slower direct line beat a faster one that needs a change. Costs are seconds, so the heuristic is in seconds too (great-circle distance over an upper speed bound) and stays admissible. `MinHeap` is now generic so both searches share it.

**Travel times** are estimates from per-city constants in `@freifahren/cities` (`secondsPerHop` by route type, `transferSeconds`). There is no timetable data in the schema, so this is the only available source of duration, and it is city-specific.

Two decisions worth stating, both commented at the point they apply because they are not visible from the code:

- **Segments are seeded once per line variant in that variant's station order**, so a hop ridden the other way round has no row of its own; both orientations resolve to the same segment. A hop with no segment behind it is reported as *unrated*, never as zero — showing an unscored stretch as safe is the one failure this feature must not have.
- **The overall level is the worst leg, not a combined probability.** One report is spread across neighbouring segments by design, so those values are correlated; assuming independence would read ten legs at 0.3 as 0.97 for a single inspector.

Not cached at the edge: the answer depends on the viewer's trust threshold and on the current time, like `/v0/risk`. A test pins the `no-store` header so it cannot be added to the cacheable transit paths by accident.

Identical origin and destination is rejected in the query schema rather than through a new internal error code — `INTERNAL_CODES` is a shared closed list and this edge case does not warrant a permanent entry in it.

## Additional notes or considerations:

**Deliberately out of scope:** no alternative-route comparison (the response shape does not preclude adding it), no address or POI search, no walking transfers between nearby stations with different names, and explicitly not a journey planner — durations are estimates and the UI says so.

**Testing.** 23 new tests, 301 total, all green; nothing existing was modified. Unit tests cover the two pure functions (there is precedent in `risk-model.test.ts` and `build-variants.test.ts`, and transfer-cost edge cases are not reachable over HTTP); the behaviour lives in `getRoute.test.ts`, driven through the API with fixtures found in the seeded data rather than named, so it works for any city.

Two things the tests learned from running against real data rather than mocks:

- The timing test builds its own isolated line. On the seeded network, two journeys over "the same" stretch legitimately come back on **different lines** — a tram alternative won between two stations of the intended line — sharing no segments and making the comparison vacuous.
- The report in that test sits at the far end of the line so the shared segments stay below the model's cap. At a saturated 1.0, no amount of elapsed time can show a difference.

**An honest measurement about the per-segment clock.** It works, but it matters less than it sounds. Measured against real Berlin data with a report at the destination, comparing the same final segment reached from different starting points:

| travel time to that segment | risk | vs. shortest |
|---:|---:|---:|
| 2 min | 0.438 | — |
| 10 min | 0.433 | −0.005 |
| 22 min | 0.414 | −0.024 |
| 43 min | 0.301 | −0.137 (−31%) |

On a typical city journey the difference is far below the resolution of the risk bands and invisible to users; it only becomes substantial on the longest trips. That is the correct shape — the decay curve is deliberately flat in the first minutes, and on a short journey almost nothing *should* change — but it is worth saying plainly rather than selling the feature on it.

**Verified live** against a local D1 with the full Berlin seed: a report mid-route produces a clean curve peaking at the reported station (0.438 → 0.731 → 0.581), and unrelated routes stay at exactly 0.000 — including one that ends at the same station as the reported line but uses different segments.

The frontend for this lives on a separate branch and will follow as its own PR once this one is settled, so this can be reviewed on its own.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6ymvG1kij8CSg49oQyNwp
