### PR TITLE
Fix timeline scale for the rhythm chart.

### DIFF
--- a/packages/frontend-next/src/components/map/RhythmChart.tsx
+++ b/packages/frontend-next/src/components/map/RhythmChart.tsx
@@ -27,10 +27,11 @@ export function RhythmChart({ hours, currentHour, label }: RhythmChartProps) {
         />
       </div>
       <div className="text-text-4 mt-1 flex justify-between px-1 text-[10px]">
-        <span>0h</span>
-        <span>6h</span>
+        <span>00h</span>
+        <span>06h</span>
         <span>12h</span>
         <span>18h</span>
+        <span>23h</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Describe the issue:
On the line detail component, the Rhythm chart had a missing time element (23h), affecting the alignment of the time labels with the time bars.

## Explain how you solved the issue:
I just added one more span element with the 23h information. I also added leading 0 to the single characters time element, to help on the alignment as well.

## Additional notes or considerations:
